### PR TITLE
fix README typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Dolphin
     ```
     git clone https://github.com/cmssnu/dolphin
     cd dolphin
-    mvn build install
+    mvn clean install
     ```
     
 ### How to run Dolphin


### PR DESCRIPTION
To introduce Dolphin simple example easily, 
- fix typo in mvn build command guideline
- add default parameters in `run.sh` according to README description (_Simply execute it without any additional arguments_)
