### PR TITLE
Add rat check for checking license headers

### DIFF
--- a/bin/sample
+++ b/bin/sample
@@ -1,3 +1,17 @@
+# Copyright (C) 2015 Seoul National University
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 9.725720805017028 8.836225670904302 8.783642664161844
 10.469045621231 9.697968403776377 -9.514122258282002
 11.876154194561966 -8.077599554197107 9.84774913960382

--- a/bin/sample_classification
+++ b/bin/sample_classification
@@ -1,3 +1,17 @@
+# Copyright (C) 2015 Seoul National University
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # name: sample_classification
 # description: syntactic data for classification (e.g., Logistic regression)
 # original model: 0.5 - 3x1 + 2x2 -1.5x3

--- a/bin/sample_cluster
+++ b/bin/sample_cluster
@@ -1,3 +1,17 @@
+# Copyright (C) 2015 Seoul National University
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # name: sample_cluster
 # description: syntactic data for clustering (e.g., K-means and EM)
 # means: {1,3,5}, {6,4,2}, {3,5,7}

--- a/bin/sample_pagerank
+++ b/bin/sample_pagerank
@@ -1,3 +1,17 @@
+# Copyright (C) 2015 Seoul National University
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # name: sample_pagerank
 # description: an example in https://en.wikipedia.org/wiki/PageRank
 1

--- a/bin/sample_regression
+++ b/bin/sample_regression
@@ -1,3 +1,17 @@
+# Copyright (C) 2015 Seoul National University
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # name: sample_regression
 # description: syntactic data for regression (e.g., Linear regression)
 # original model: 0.5 - 3x1 + 2x2 -1.5x3

--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright (C) 2015 Seoul National University
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -16,6 +31,7 @@
     <shimoga.version>0.1-SNAPSHOT</shimoga.version>
     <hadoop.version>2.4.0</hadoop.version>
     <mahout.version>0.9</mahout.version>
+    <rat.version>0.11</rat.version>
     <maven-checkstyle-plugin.version>2.15</maven-checkstyle-plugin.version>
     <checkstyle.version>6.6</checkstyle.version>
   </properties>
@@ -105,6 +121,41 @@
     <pluginManagement>
       <plugins>
         <plugin>
+          <groupId>org.apache.rat</groupId>
+          <artifactId>apache-rat-plugin</artifactId>
+          <version>${rat.version}</version>
+          <configuration>
+            <excludes>
+              <!-- Markdown files such as README.md -->
+              <exclude>**/*.md</exclude>
+              <!-- Git files -->
+              <exclude>.gitattributes</exclude>
+              <exclude>.gitignore</exclude>
+              <exclude>.git/**</exclude>
+              <!-- Intellij idea project files -->
+              <exclude>**/.idea/**</exclude>
+              <exclude>**/*.iml</exclude>
+              <!-- Maven build files -->
+              <exclude>**/target/**</exclude>
+              <!-- REEF run files -->
+              <exclude>**/REEF_LOCAL_RUNTIME/**</exclude>
+            </excludes>
+          </configuration>
+          <dependencies>
+            <dependency>
+              <groupId>org.apache.maven.doxia</groupId>
+              <artifactId>doxia-core</artifactId>
+              <version>1.6</version>
+              <exclusions>
+                <exclusion>
+                  <groupId>xerces</groupId>
+                  <artifactId>xercesImpl</artifactId>
+                </exclusion>
+              </exclusions>
+            </dependency>
+          </dependencies>
+        </plugin>
+        <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-checkstyle-plugin</artifactId>
           <version>${maven-checkstyle-plugin.version}</version>
@@ -134,6 +185,19 @@
           <showDeprecation>true</showDeprecation>
           <encoding>${project.build.sourceEncoding}</encoding>
         </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.rat</groupId>
+        <artifactId>apache-rat-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>validate</id>
+            <phase>validate</phase>
+            <goals>
+              <goal>check</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/src/main/java/edu/snu/reef/dolphin/core/metric/MetricCodec.java
+++ b/src/main/java/edu/snu/reef/dolphin/core/metric/MetricCodec.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2015 Seoul National University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package edu.snu.reef.dolphin.core.metric;
 
 import org.apache.reef.tang.annotations.DefaultImplementation;


### PR DESCRIPTION
This pull request adds rat check for license headers. It also includes fixes for the source files that didn't include licenses.
This part:

``` xml
<groupId>org.apache.rat</groupId>
<artifactId>apache-rat-plugin</artifactId>
...
<dependencies>
    <dependency>
        <groupId>org.apache.maven.doxia</groupId>
        <artifactId>doxia-core</artifactId>
        <version>1.6</version>
        <exclusions>
            <exclusion>
                <groupId>xerces</groupId>
                <artifactId>xercesImpl</artifactId>
            </exclusion>
        </exclusions>
    </dependency>
</dependencies>
```

is to get rid of a dependency warning related to the `doxia` module that pops up during checks.

Closes #71.
