### PR TITLE
Add argument maxNumEvalLocal to example usages in run scripts

### DIFF
--- a/bin/run.sh
+++ b/bin/run.sh
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 # EXAMPLE USAGE 
-# ./run.sh -local true -split 4 -input ../src/test/resources/data/sample -output output_simple
+# ./run.sh -local true -split 4 -input ../src/test/resources/data/sample -output output_simple -maxNumEvalLocal 5
 
 # RUNTIME
 SELF_JAR=../target/dolphin-0.1-SNAPSHOT-shaded.jar

--- a/bin/run_em.sh
+++ b/bin/run_em.sh
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 # EXAMPLE USAGE 
-# ./run_em.sh -numCls 4 -convThr 0.01 -maxIter 20 -local true -split 4 -input ../src/test/resources/data/clustering -output output_em
+# ./run_em.sh -numCls 4 -convThr 0.01 -maxIter 20 -local true -split 4 -input ../src/test/resources/data/clustering -output output_em -maxNumEvalLocal 5
 
 # RUNTIME
 SELF_JAR=../target/dolphin-0.1-SNAPSHOT-shaded.jar

--- a/bin/run_kmeans.sh
+++ b/bin/run_kmeans.sh
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 # EXAMPLE USAGE 
-# ./run_kmeans.sh -numCls 4 -convThr 0.01 -maxIter 20 -local true -split 4 -input ../src/test/resources/data/clustering -output output_kmeans
+# ./run_kmeans.sh -numCls 4 -convThr 0.01 -maxIter 20 -local true -split 4 -input ../src/test/resources/data/clustering -output output_kmeans -maxNumEvalLocal 5
 
 # RUNTIME
 SELF_JAR=../target/dolphin-0.1-SNAPSHOT-shaded.jar

--- a/bin/run_logistic.sh
+++ b/bin/run_logistic.sh
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 # EXAMPLE USAGE 
-# ./run_logistic.sh -dim 3 -maxIter 20 -stepSize 0.00001 -lambda 0.1 -local true -split 4 -input ../src/test/resources/data/classification -output output_logistic
+# ./run_logistic.sh -dim 3 -maxIter 20 -stepSize 0.00001 -lambda 0.1 -local true -split 4 -input ../src/test/resources/data/classification -output output_logistic -maxNumEvalLocal 5
 
 # RUNTIME
 SELF_JAR=../target/dolphin-0.1-SNAPSHOT-shaded.jar

--- a/bin/run_pagerank.sh
+++ b/bin/run_pagerank.sh
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 # EXAMPLE USAGE
-# ./run_pagerank.sh -convThr 0.01 -maxIter 10 -dampingFactor 0.85 -local true -split 1 -input ../src/test/resources/data/pagerank -output output_pagerank
+# ./run_pagerank.sh -convThr 0.01 -maxIter 10 -dampingFactor 0.85 -local true -split 1 -input ../src/test/resources/data/pagerank -output output_pagerank -maxNumEvalLocal 2
 
 # RUNTIME
 SELF_JAR=../target/dolphin-0.1-SNAPSHOT-shaded.jar

--- a/bin/run_regression.sh
+++ b/bin/run_regression.sh
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 # EXAMPLE USAGE 
-# ./run_regression.sh -dim 3 -maxIter 20 -stepSize 0.001 -lambda 0.1 -local true -split 4 -input ../src/test/resources/data/regression -output output_regression
+# ./run_regression.sh -dim 3 -maxIter 20 -stepSize 0.001 -lambda 0.1 -local true -split 4 -input ../src/test/resources/data/regression -output output_regression -maxNumEvalLocal 5
 
 # RUNTIME
 SELF_JAR=../target/dolphin-0.1-SNAPSHOT-shaded.jar


### PR DESCRIPTION
The current example usages in run scripts may fail because of the lack of providing the argument `maxNumEvalLocal`. This pull request adds the argument to each example usage.

Closes #86.
