### PR TITLE
[MINOR] Implement 1D and 3D print/equals cases

### DIFF
--- a/src/main/java/edu/snu/reef/dolphin/neuralnet/util/Nd4jUtils.java
+++ b/src/main/java/edu/snu/reef/dolphin/neuralnet/util/Nd4jUtils.java
@@ -103,7 +103,7 @@ public final class Nd4jUtils {
   /**
    * Prints out the given 1D, 2D or 3D matrix.
    * 
-   * For 4D or higher dimension matrix, return without printing.
+   * For 4D or higher dimension matrices, returns without printing.
    *
    * @param matrix the matrix to be printed.
    */


### PR DESCRIPTION
Convolutional neural network layers handle 3D input/output. We should extend the existing 2D-only print features. In this PR, the 3D printing format style comes from Matlab/Octave.
