### PR TITLE
Add READMEs for dolphin-bsp, dolphin-ps, and the root

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,11 @@
 Dolphin
 =======
 
-### How to build Dolphin
-1. Build REEF: check https://cwiki.apache.org/confluence/display/REEF/Compiling+REEF
+Dolphin is a machine learning platform built top on [Apache REEF](http://reef.incubator.apache.org/). Dolphin contains a BSP-style framework (`dolphin-bsp`), a deep learning framework (`dolphin-dnn`), and a parameter server module (`dolphin-ps`).
+
+### How to build and run Dolphin
+1. Build REEF: check https://cwiki.apache.org/confluence/display/REEF/Compiling+REEF  
+  Currently, Dolphin depends on REEF `0.13.0-incubating-SNAPSHOT`, which means you must build the current snapshot of REEF before building Dolphin. We will move to the release version `0.13.0-incubating` once it's out, around Oct 2015.
 
 2. Build Dolphin:
     ```
@@ -11,11 +14,10 @@ Dolphin
     mvn clean install
     ```
     
-### How to run Dolphin
-In order to run a application with Dolphin, you must at least write a class that implements `UserComputeTask`, a class that implements `UserControllerTask`, and a Launcher class that uses `DolphinLauncher`.
 
-In case you just want to test out Dolphin without writing any code, samples are provided for you: `SimpleCmpTask`, `SimpleCtrlTask`, and `SimpleREEF` implement the classes mentioned above, respectively. There is also a run script provided, `bin/run.sh`. Simply execute it without any additional arguments, and Dolphin will run `SimpleREEF`.
-Currently `SimpleCmpTask` does not perform any special actions. Instead for demonstration, it spends a few milliseconds and then returns. The time spent during this meaningless computation is sent to the Driver. You can check that the Driver has received message like `Task Message CmpTask-1: 47 milliseconds` in its `driver.stderr` log. Although the Driver does not perform further actions, we can use the collected info to later build a optimization plan.
+3. Run Dolphin: check the READMEs in the submodules for more details.
 
-### Why run Dolphin?
-As mentioned above, the only code you need to write to run your applcation Dolphin is, `UserComputeTask`, `UserControllerTask`, and a Launcher. This greatly reduces your work to write long, hard code!
+### Dolphin Mailing List
+We appreciate bug reports, feature requests, or even simple questions!  
+Subscribe to dolphin-discussion@googlegroups.com and we will reply ASAP.
+

--- a/dolphin-bsp/README.md
+++ b/dolphin-bsp/README.md
@@ -1,0 +1,84 @@
+Dolphin - Bulk Synchronous Parallel (BSP) Framework
+===================================================
+
+Many large-scale machine learning applications and frameworks run algorithms under distributed environments by dividing the whole computation into several independent partitions and aggregating the results of each partition every `n` iterations. This aggregating process can be viewed as a synchronization step, where workers synchronize with each other to get ready for the next iteration. The [Bulk Synchronous Parallel (BSP)](https://en.wikipedia.org/wiki/Bulk_synchronous_parallel) model is one of the most well-known programming models to suggest such synchronous behavior, and although recent researches argue asynchronous models to be more fast and accurate, synchronous models are still being widely used to solve modern machine learning problems.
+
+### Architecture
+![Dolphin BSP Architecture](http://cmslab.snu.ac.kr/home/wp-content/uploads/2015/09/Dolphin-BSP.png)
+The BSP module of Dolphin is a machine learning framework for running ML algorithms, BSP style. Dolphin-BSP creates several Compute Tasks for distributed computation, and a single Controller Task for aggregating the computation results sent from the Compute Tasks. The Controller Task starts a job by sending Compute Tasks the initial model to work on. Compute Tasks perform local computation using the given model, and then transmits their calculations back to the Controller Task. After aggregation is done, the Controller Task starts another iteration by sending an updated model to Compute Tasks, and the same process repeats over and over until the model converges. Communication between Tasks is done using [Apache REEF](http://reef.incubator.apache.org)’s Group Communication Service, which provides MPI Broadcast, Reduce, Scatter, and Gather operations.
+
+An algorithm may need more than one Controller-Compute **stage** to completely run; for example, a typical application loads data from a backing distributed file system and pre-processes it before actually running the core computation. Each stage can be regarded as its own BSP stage having its own set of Tasks. Dolphin supports such multiple BSP stages by running a separate set of Controller Task and Compute Tasks per stage. The overhead of spawning a different set of Tasks for each stage is minimal thanks to the retainability of REEF Evaluators throughout the whole job. An Evaluator that was used as a container for a Compute Task of a certain stage is re-used for a Compute Task of the next stage (same for the Controller Task).
+
+
+### How to write a new algorithm
+Here, we describe how you can write your own algorithm on Dolphin. Examples are provided in the [`edu.snu.dolphin.bsp.examples.ml.algorithms`](https://github.com/cmssnu/dolphin/tree/master/dolphin-bsp/src/main/java/edu/snu/dolphin/bsp/examples/ml/algorithms) package. There are roughly four steps:
+
+First, create classes specifying what kind of local computation the Controller Task and Compute Tasks should do. You must also pick what kind of MPI operations you will use by making your class implement the corresponding interface. If your algorithm requires more than one stage, then you should write a Controller/Compute Task for each stage.
+```Java
+public class MyFirstCtrlTask extends UserControllerTask implements DataBroadcastSender<Integer>, DataReduceReceiver<Integer> {
+  @Override
+  public void run(final int iteration) { ... }
+  
+  @Override
+  public void receiveReduceData(final int iteration, final Integer data) { ... }
+  
+  @Override
+  public Integer sendBroadcastData(final int iteration) { ... }
+}
+```
+
+Next, define your algorithm's stages as a `UserJobInfo`. Codec classes that indicate how your data will be serialized into bytes must be input in this step too, as well as a Reduce function class in case you use MPI Reduce, and your data parser class.
+```Java
+public class MyJobInfo implement UserJobInfo {
+
+  @Inject
+  private MyJobInfo() { }
+
+  @Override
+  public List<StageInfo> getStageInfoList() {
+    final List<StageInfo> stageInfoList = new ArrayList<>(1);
+
+    stageInfoList.add(
+        StageInfo.newBuilder(MyFirstCmpTask.class, MyFirstCtrlTask.class, CommunicationGroup.class)
+            .setBroadcast(MyBroadcastCodec.class)
+            .setReduce(MyReduceCodec.class, MyReduceFunction.class)
+            .build());
+
+    return stageInfoList;
+  }
+  
+  @Override
+  public Class<? extends DataParser> getDataParser() { return MyDataParser.class; }
+}
+```
+
+Third, create a `UserParameters` class that contains the algorithm parameters and configurations you will use.
+```Java
+public class MyParameters implements UserParameters {
+  ...
+  @Override
+  public Configuration getUserCmpTaskConf() {
+    return Tang.Factory.getTang().newConfigurationBuilder()
+        .bindNamedParameter(StepSize.class, "10")
+        .bindNamedParameter(Lambda.class, "0.9")
+        .bindImplementation(Loss.class, LogisticLoss.class)
+        .build();
+  }
+  ...
+}
+```
+
+
+Last, use `DolphinLauncher` to run your algorithm, using the classes you created up until now.
+```Java
+DolphinLauncher.run(
+    Configurations.merge(
+        DolphinConfiguration.getConfiguration(args, MyParameters.getCommandLine()),
+        Tang.Factory.getTang().newConfigurationBuilder()
+            .bindNamedParameter(JobIdentifier.class, "My Algorithm")
+            .bindImplementation(UserJobInfo.class, MyJobInfo.class)
+            .bindImplementation(UserParameters.class, MyParameters.class)
+            .build()
+      )
+```
+

--- a/dolphin-ps/README.md
+++ b/dolphin-ps/README.md
@@ -1,0 +1,74 @@
+Parameter Server
+================
+
+The idea of using a separate server for aggregating and storing parameters for asynchronous machine learning algorithms has been proved to be very effective, in terms of learning speed as well as the accuracy of the output model ([DistBelief](http://papers.nips.cc/paper/4687-large-scale-distributed-deep-networks.pdf), [Petuum](http://www.cs.cmu.edu/~./seunghak/petuum-13-weidai.pdf), [Adam](https://www.usenix.org/system/files/conference/osdi14/osdi14-paper-chilimbi.pdf)). One of the main assumptions of a parameter server application is that the given algorithm should be robust to inconsistencies between model replicas. Indeed, this is true for popular algorithms used nowadays. For example, several variants of [stochastic gradient descent](https://en.wikipedia.org/wiki/Stochastic_gradient_descent) go through training sets without analyzing each and every training data sequentially. The fact that typical data sets consist of millions or billions of instances also contribute to such robustness of modern machine learning applications; in fact, inconsistency can be viewed as a method to avoid overfitting over training data.
+
+### Architecture
+![Parameter Server Architechture](http://cmslab.snu.ac.kr/home/wp-content/uploads/2015/09/Parameter-Server.png)
+Dolphin's parameter server module is made up of two components: the server and the worker. Both sides have a message sender and a message handler (receiver) to communicate with each other using [Apache REEF](http://reef.incubator.apache.org/)'s Network Connection Service. The worker provides methods for applications to push and pull parameter values to servers, while the server receives such values and stores them in the form of a key-value store. Before storing values, the server transforms them into a different format using a parameter updater, in case the application requires a pre-processing step. [Adam](https://www.usenix.org/system/files/conference/osdi14/osdi14-paper-chilimbi.pdf), for instance, makes servers compute weight updates from activation and error gradient vectors rather than directly sending the updates from workers.
+
+The code, as of Sep 2015, contains an implementation of a single-node parameter server (`SingleNodeParameterServer` and `SingleNodeParameterWorker`). However, the server does not necessarily need to be a single node; it can consist of more than one node, given the fact that workers send their parameters to the correct server node. We are currently working on a parameter server implementation that uses several nodes to process worker requests. One possible approach is to place a router node between workers and servers that directs worker requests to the corresponding server, similar to a Hadoop NameNode. Another approach is to configure workers to know which server owns which key, a problem that has been explored deeply in [distributed hash tables](https://en.wikipedia.org/wiki/Distributed_hash_table).
+
+The worker provides the following APIs for applications:
+* `push(key, preValue)`: send a value, associated with a key, to the server to be processed and stored
+* `pull(key)`: fetch a value, which is associated with the given key, from the server
+
+### How to use
+First, create [codec classes](https://github.com/apache/incubator-reef/blob/master/lang/java/reef-common/src/main/java/org/apache/reef/io/serialization/Codec.java) that specifies how Dolphin will encode and decode your keys, preValues, and values. In case you use classes that are Java Serializables, you can simply use [`SerializableCodec`](https://github.com/apache/incubator-reef/blob/master/lang/java/reef-common/src/main/java/org/apache/reef/io/serialization/SerializableCodec.java) although this is not recommended due to slow performance. You should also create a parameter updater class that shows how to process preValues and generate value updates.
+
+Second, use `ParameterServerConfigurationBuilder` to build a Tang configuration of the parameter server module and submit it to REEF together with the REEF Driver configuration.
+```Java
+final Configuration psConf = ParameterServerConfigurationBuilder.newBuilder()
+    .setManagerClass(SingleNodeParameterServer.class)
+    .setUpdaterClass(MyCustomParameterUpdater.class)
+    .setKeyCodecClass(MyKeyCodec.class)
+    .setPreValueCodecClass(MyPreValueCodec.class)
+    .setValueCodecClass(MyValueCodec.class)
+    .build();
+    
+final Configuration finalDriverConf = Configurations.merge(driverConf, psConf);
+driverLauncher.run(finalDriverConf);
+```
+
+Later at the driver, receive a Tang injection of `ParameterServerDriver` and call the `get*Configuration` methods for REEF contexts and services, both worker-side and server-side.
+```Java
+@Inject
+private MyDriver(final ParameterServerDriver psDriver) {
+  this.psDriver = psDriver;
+}
+
+final class ActiveContextHandler implements EventHandler<ActiveContext> {
+  @Override
+  public void onNext(final ActiveContext activeContext) {
+  ...
+  // when submitting a worker-side context and service
+  final Configuration finalWorkerContextConf = Configurations.merge(
+      workerContextConf, psDriver.getWorkerContextConfiguration());
+  final Configuration finalWorkerServerConf = Configurations.merge(
+      workerServiceConf, psDriver.getWorkerServiceConfiguration());
+  activeContext.submitContextAndService(finalWorkerContextConf, finalWorkerServiceConf);
+
+  // do the same for the server-side
+  ...
+  }
+}
+```
+
+Finally, receive a Tang injection of a `ParameterWorker` instance at your application, and call its `push` and `pull` methods to communicate with the server.
+
+```Java
+@Inject
+private MyTask(final ParameterWorker<MyKey, MyPreValue, MyValue> worker) {
+  this.worker = worker;
+}
+
+@Override
+public byte[] call(final byte[] bytes) throws Exception {
+  ...
+  worker.push(MY_KEY, MY_PREVALUE)
+  final MyValue MY_VALUE = worker.pull(MY_KEY);
+  ...
+}
+
+```
+


### PR DESCRIPTION
This PR adds READMEs for the `dolphin-bsp` and `dolphin-ps` modules. This also corrects the top-level README to match the current state of Dolphin.
