### PR TITLE
Introduce a new Matrix interface and implementation based on JBLAS

### DIFF
--- a/dolphin-dnn/pom.xml
+++ b/dolphin-dnn/pom.xml
@@ -84,6 +84,10 @@
       <artifactId>mockito-core</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.jblas</groupId>
+      <artifactId>jblas</artifactId>
+    </dependency>
+    <dependency>
       <groupId>${project.parent.groupId}</groupId>
       <artifactId>dolphin-bsp</artifactId>
       <version>${project.parent.version}</version>

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/blas/Matrix.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/blas/Matrix.java
@@ -33,47 +33,47 @@ public interface Matrix {
   /**
    * Returns a element specified by the given index (linear indexing).
    */
-  float get(final int i);
+  float get(int i);
 
   /**
    * Returns elements specified by the linear indices.
    */
-  Matrix get(final int[] indices);
+  Matrix get(int[] indices);
 
   /**
    * Returns a element specified by the row and column indices.
    */
-  float get(final int rowIndex, final int columnIndex);
+  float get(int rowIndex, int columnIndex);
 
   /**
    * Sets a matrix element (linear indexing).
    */
-  Matrix put(final int i, final float v);
+  Matrix put(int i, float v);
 
   /**
    * Sets a matrix element.
    */
-  Matrix put(final int rowIndex, final int columnIndex, final float v);
+  Matrix put(int rowIndex, int columnIndex, float v);
 
   /**
    * Sets a column with the given column vector.
    */
-  void putColumn(final int i, Matrix v);
+  void putColumn(int i, Matrix v);
 
   /**
    * Sets a row with the given row vector.
    */
-  void putRow(final int i, Matrix v);
+  void putRow(int i, Matrix v);
 
   /**
    * Returns a copy of a column.
    */
-  Matrix getColumn(final int i);
+  Matrix getColumn(int i);
 
   /**
    * Returns a copy of a row.
    */
-  Matrix getRow(final int i);
+  Matrix getRow(int i);
 
   /**
    * Returns total number of elements.
@@ -93,13 +93,13 @@ public interface Matrix {
   /**
    * Sets all elements to the specified value.
    */
-  Matrix fill(final float v);
+  Matrix fill(float v);
 
   /**
    * Reshapes the matrix.
    * The number of elements must not change.
    */
-  Matrix reshape(final int newRows, final int newColumns);
+  Matrix reshape(int newRows, int newColumns);
 
   /**
    * Returns a string representation of this matrix.
@@ -116,7 +116,7 @@ public interface Matrix {
    * @param m a source matrix
    * @return a source matrix {@code m}
    */
-  Matrix copy(final Matrix m);
+  Matrix copy(Matrix m);
 
   /**
    * @return a duplicate of this matrix.
@@ -134,212 +134,212 @@ public interface Matrix {
   /**
    * Adds a scalar.
    */
-  Matrix add(final float v);
+  Matrix add(float v);
 
   /**
    * Adds a scalar (in place).
    */
-  Matrix addi(final float v);
+  Matrix addi(float v);
 
   /**
    * Adds a matrix.
    */
-  Matrix add(final Matrix m);
+  Matrix add(Matrix m);
 
   /**
    * Adds a matrix (in place).
    */
-  Matrix addi(final Matrix m);
+  Matrix addi(Matrix m);
 
   /**
    * Adds a vector to all columns of the matrix.
    */
-  Matrix addColumnVector(final Matrix v);
+  Matrix addColumnVector(Matrix v);
 
   /**
    * Adds a vector to all columns of the matrix (in place).
    */
-  Matrix addiColumnVector(final Matrix v);
+  Matrix addiColumnVector(Matrix v);
 
   /**
    * Adds a vector to all rows of the matrix.
    */
-  Matrix addRowVector(final Matrix v);
+  Matrix addRowVector(Matrix v);
 
   /**
    * Adds a vector to all rows of the matrix (in place).
    */
-  Matrix addiRowVector(final Matrix v);
+  Matrix addiRowVector(Matrix v);
 
   /**
    * Subtracts a scalar.
    */
-  Matrix sub(final float v);
+  Matrix sub(float v);
 
   /**
    * Subtracts a scalar (in place).
    */
-  Matrix subi(final float v);
+  Matrix subi(float v);
 
   /**
    * Subtracts a matrix.
    */
-  Matrix sub(final Matrix m);
+  Matrix sub(Matrix m);
 
   /**
    * Subtracts a matrix (in place).
    */
-  Matrix subi(final Matrix m);
+  Matrix subi(Matrix m);
 
   /**
    * Subtracts a vector to all columns of the matrix.
    */
-  Matrix subColumnVector(final Matrix v);
+  Matrix subColumnVector(Matrix v);
 
   /**
    * Subtracts a vector to all columns of the matrix (in place).
    */
-  Matrix subiColumnVector(final Matrix v);
+  Matrix subiColumnVector(Matrix v);
 
   /**
    * Subtracts a vector to all rows of the matrix.
    */
-  Matrix subRowVector(final Matrix v);
+  Matrix subRowVector(Matrix v);
 
   /**
    * Subtracts a vector to all rows of the matrix (in place).
    */
-  Matrix subiRowVector(final Matrix v);
+  Matrix subiRowVector(Matrix v);
 
   /**
    * (right-)subtracts a scalar.
    */
-  Matrix rsub(final float v);
+  Matrix rsub(float v);
 
   /**
    * (right-)subtracts a scalar (in place).
    */
-  Matrix rsubi(final float v);
+  Matrix rsubi(float v);
 
   /**
    * (right-)subtracts a matrix.
    */
-  Matrix rsub(final Matrix m);
+  Matrix rsub(Matrix m);
 
   /**
    * (right-)subtracts a matrix (in place).
    */
-  Matrix rsubi(final Matrix m);
+  Matrix rsubi(Matrix m);
 
   /**
    * Multiplies a scalar.
    */
-  Matrix mul(final float v);
+  Matrix mul(float v);
 
   /**
    * Multiplies a scalar (in place).
    */
-  Matrix muli(final float v);
+  Matrix muli(float v);
 
   /**
    * Multiplies a matrix.
    */
-  Matrix mul(final Matrix m);
+  Matrix mul(Matrix m);
 
   /**
    * Multiplies a matrix (in place).
    */
-  Matrix muli(final Matrix m);
+  Matrix muli(Matrix m);
 
   /**
    * Multiplies a vector to all columns of the matrix.
    */
-  Matrix mulColumnVector(final Matrix v);
+  Matrix mulColumnVector(Matrix v);
 
   /**
    * Multiplies a vector to all columns of the matrix (in place).
    */
-  Matrix muliColumnVector(final Matrix v);
+  Matrix muliColumnVector(Matrix v);
 
   /**
    * Multiplies a vector to all rows of the matrix.
    */
-  Matrix mulRowVector(final Matrix v);
+  Matrix mulRowVector(Matrix v);
 
   /**
    * Multiplies a vector to all rows of the matrix (in place).
    */
-  Matrix muliRowVector(final Matrix v);
+  Matrix muliRowVector(Matrix v);
 
   /**
    * Divides by a scalar.
    */
-  Matrix div(final float v);
+  Matrix div(float v);
 
   /**
    * Divides by a scalar (in place).
    */
-  Matrix divi(final float v);
+  Matrix divi(float v);
 
   /**
    * Divides by a matrix.
    */
-  Matrix div(final Matrix m);
+  Matrix div(Matrix m);
 
   /**
    * Divides by a matrix (in place).
    */
-  Matrix divi(final Matrix m);
+  Matrix divi(Matrix m);
 
   /**
    * Divides a vector to all columns of the matrix.
    */
-  Matrix divColumnVector(final Matrix v);
+  Matrix divColumnVector(Matrix v);
 
   /**
    * Divides a vector to all columns of the matrix (in place).
    */
-  Matrix diviColumnVector(final Matrix v);
+  Matrix diviColumnVector(Matrix v);
 
   /**
    * Divides a vector to all rows of the matrix.
    */
-  Matrix divRowVector(final Matrix v);
+  Matrix divRowVector(Matrix v);
 
   /**
    * Divides a vector to all rows of the matrix (in place).
    */
-  Matrix diviRowVector(final Matrix v);
+  Matrix diviRowVector(Matrix v);
 
   /**
    * (right-)divides by a scalar.
    */
-  Matrix rdiv(final float v);
+  Matrix rdiv(float v);
 
   /**
    * (right-)divides by a scalar (in place).
    */
-  Matrix rdivi(final float v);
+  Matrix rdivi(float v);
 
   /**
    * (right-)divides by a matrix.
    */
-  Matrix rdiv(final Matrix m);
+  Matrix rdiv(Matrix m);
 
   /**
    * (right-)divides by a matrix (in place).
    */
-  Matrix rdivi(final Matrix m);
+  Matrix rdivi(Matrix m);
 
   /**
    * Matrix-Matrix multiplication.
    */
-  Matrix mmul(final Matrix m);
+  Matrix mmul(Matrix m);
 
   /**
    * Matrix-Matrix multiplication (in place).
    */
-  Matrix mmuli(final Matrix m);
+  Matrix mmuli(Matrix m);
 
   /**
    * Returns the maximum element of the matrix.
@@ -392,5 +392,5 @@ public interface Matrix {
    * Returns true if and only if the given matrix has the same size
    * and the maximal absolute difference in all elements is smaller than the specified tolerance.
    */
-  boolean compare(final Matrix m, float tolerance);
+  boolean compare(Matrix m, float tolerance);
 }

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/blas/Matrix.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/blas/Matrix.java
@@ -342,6 +342,51 @@ public interface Matrix {
   Matrix mmuli(final Matrix m);
 
   /**
+   * Returns the maximum element of the matrix.
+   */
+  float max();
+
+  /**
+   * Returns column-wise maximums.
+   */
+  Matrix columnMaxs();
+
+  /**
+   * Returns row-wise maximums.
+   */
+  Matrix rowMaxs();
+
+  /**
+   * Returns the minimum element of the matrix.
+   */
+  float min();
+
+  /**
+   * Returns column-wise minimums.
+   */
+  Matrix columnMins();
+
+  /**
+   * Returns row-wise minimums.
+   */
+  Matrix rowMins();
+
+  /**
+   * Returns a row vector containing the sum of elements in each column.
+   */
+  Matrix columnSums();
+
+  /**
+   * Returns a column vector containing the sum of elements in each row.
+   */
+  Matrix rowSums();
+
+  /**
+   * Returns the sum of all elements in the matrix.
+   */
+  float sum();
+
+  /**
    * Compares with the given matrix.
    *
    * Returns true if and only if the given matrix has the same size

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/blas/Matrix.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/blas/Matrix.java
@@ -1,0 +1,351 @@
+/*
+ * Copyright (C) 2015 Seoul National University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.snu.dolphin.dnn.blas;
+
+/**
+ * Matrix interface.
+ */
+public interface Matrix {
+
+  /**
+   * Returns the number of rows.
+   */
+  int getRows();
+
+  /**
+   * Returns the number of columns.
+   */
+  int getColumns();
+
+  /**
+   * Returns a element specified by the given index (linear indexing).
+   */
+  float get(final int i);
+
+  /**
+   * Returns elements specified by the linear indices.
+   */
+  Matrix get(final int[] indices);
+
+  /**
+   * Returns a element specified by the row and column indices.
+   */
+  float get(final int rowIndex, final int columnIndex);
+
+  /**
+   * Sets a matrix element (linear indexing).
+   */
+  Matrix put(final int i, final float v);
+
+  /**
+   * Sets a matrix element.
+   */
+  Matrix put(final int rowIndex, final int columnIndex, final float v);
+
+  /**
+   * Sets a column with the given column vector.
+   */
+  void putColumn(final int i, Matrix v);
+
+  /**
+   * Sets a row with the given row vector.
+   */
+  void putRow(final int i, Matrix v);
+
+  /**
+   * Returns a copy of a column.
+   */
+  Matrix getColumn(final int i);
+
+  /**
+   * Returns a copy of a row.
+   */
+  Matrix getRow(final int i);
+
+  /**
+   * Returns total number of elements.
+   */
+  int getLength();
+
+  /**
+   * Checks whether the matrix is a column vector.
+   */
+  boolean isColumnVector();
+
+  /**
+   * Checks whether the matrix is a row vector.
+   */
+  boolean isRowVector();
+
+  /**
+   * Sets all elements to the specified value.
+   */
+  Matrix fill(final float v);
+
+  /**
+   * Reshapes the matrix.
+   * The number of elements must not change.
+   */
+  Matrix reshape(final int newRows, final int newColumns);
+
+  /**
+   * Returns a string representation of this matrix.
+   */
+  String toString();
+
+  /**
+   * Converts the matrix to a one-dimensional array of {@code float}s.
+   */
+  float[] toFloatArray();
+
+  /**
+   * Copies {@code Matrix} {@code m} to this.
+   * @param m a source matrix
+   * @return a source matrix {@code m}
+   */
+  Matrix copy(final Matrix m);
+
+  /**
+   * @return a duplicate of this matrix.
+   */
+  Matrix dup();
+
+  /**
+   * Returns transposed copy of this matrix.
+   */
+  Matrix transpose();
+
+
+  /* Operations */
+
+  /**
+   * Adds a scalar.
+   */
+  Matrix add(final float v);
+
+  /**
+   * Adds a scalar (in place).
+   */
+  Matrix addi(final float v);
+
+  /**
+   * Adds a matrix.
+   */
+  Matrix add(final Matrix m);
+
+  /**
+   * Adds a matrix (in place).
+   */
+  Matrix addi(final Matrix m);
+
+  /**
+   * Adds a vector to all columns of the matrix.
+   */
+  Matrix addColumnVector(final Matrix v);
+
+  /**
+   * Adds a vector to all columns of the matrix (in place).
+   */
+  Matrix addiColumnVector(final Matrix v);
+
+  /**
+   * Adds a vector to all rows of the matrix.
+   */
+  Matrix addRowVector(final Matrix v);
+
+  /**
+   * Adds a vector to all rows of the matrix (in place).
+   */
+  Matrix addiRowVector(final Matrix v);
+
+  /**
+   * Subtracts a scalar.
+   */
+  Matrix sub(final float v);
+
+  /**
+   * Subtracts a scalar (in place).
+   */
+  Matrix subi(final float v);
+
+  /**
+   * Subtracts a matrix.
+   */
+  Matrix sub(final Matrix m);
+
+  /**
+   * Subtracts a matrix (in place).
+   */
+  Matrix subi(final Matrix m);
+
+  /**
+   * Subtracts a vector to all columns of the matrix.
+   */
+  Matrix subColumnVector(final Matrix v);
+
+  /**
+   * Subtracts a vector to all columns of the matrix (in place).
+   */
+  Matrix subiColumnVector(final Matrix v);
+
+  /**
+   * Subtracts a vector to all rows of the matrix.
+   */
+  Matrix subRowVector(final Matrix v);
+
+  /**
+   * Subtracts a vector to all rows of the matrix (in place).
+   */
+  Matrix subiRowVector(final Matrix v);
+
+  /**
+   * (right-)subtracts a scalar.
+   */
+  Matrix rsub(final float v);
+
+  /**
+   * (right-)subtracts a scalar (in place).
+   */
+  Matrix rsubi(final float v);
+
+  /**
+   * (right-)subtracts a matrix.
+   */
+  Matrix rsub(final Matrix m);
+
+  /**
+   * (right-)subtracts a matrix (in place).
+   */
+  Matrix rsubi(final Matrix m);
+
+  /**
+   * Multiplies a scalar.
+   */
+  Matrix mul(final float v);
+
+  /**
+   * Multiplies a scalar (in place).
+   */
+  Matrix muli(final float v);
+
+  /**
+   * Multiplies a matrix.
+   */
+  Matrix mul(final Matrix m);
+
+  /**
+   * Multiplies a matrix (in place).
+   */
+  Matrix muli(final Matrix m);
+
+  /**
+   * Multiplies a vector to all columns of the matrix.
+   */
+  Matrix mulColumnVector(final Matrix v);
+
+  /**
+   * Multiplies a vector to all columns of the matrix (in place).
+   */
+  Matrix muliColumnVector(final Matrix v);
+
+  /**
+   * Multiplies a vector to all rows of the matrix.
+   */
+  Matrix mulRowVector(final Matrix v);
+
+  /**
+   * Multiplies a vector to all rows of the matrix (in place).
+   */
+  Matrix muliRowVector(final Matrix v);
+
+  /**
+   * Divides by a scalar.
+   */
+  Matrix div(final float v);
+
+  /**
+   * Divides by a scalar (in place).
+   */
+  Matrix divi(final float v);
+
+  /**
+   * Divides by a matrix.
+   */
+  Matrix div(final Matrix m);
+
+  /**
+   * Divides by a matrix (in place).
+   */
+  Matrix divi(final Matrix m);
+
+  /**
+   * Divides a vector to all columns of the matrix.
+   */
+  Matrix divColumnVector(final Matrix v);
+
+  /**
+   * Divides a vector to all columns of the matrix (in place).
+   */
+  Matrix diviColumnVector(final Matrix v);
+
+  /**
+   * Divides a vector to all rows of the matrix.
+   */
+  Matrix divRowVector(final Matrix v);
+
+  /**
+   * Divides a vector to all rows of the matrix (in place).
+   */
+  Matrix diviRowVector(final Matrix v);
+
+  /**
+   * (right-)divides by a scalar.
+   */
+  Matrix rdiv(final float v);
+
+  /**
+   * (right-)divides by a scalar (in place).
+   */
+  Matrix rdivi(final float v);
+
+  /**
+   * (right-)divides by a matrix.
+   */
+  Matrix rdiv(final Matrix m);
+
+  /**
+   * (right-)divides by a matrix (in place).
+   */
+  Matrix rdivi(final Matrix m);
+
+  /**
+   * Matrix-Matrix multiplication.
+   */
+  Matrix mmul(final Matrix m);
+
+  /**
+   * Matrix-Matrix multiplication (in place).
+   */
+  Matrix mmuli(final Matrix m);
+
+  /**
+   * Compares with the given matrix.
+   *
+   * Returns true if and only if the given matrix has the same size
+   * and the maximal absolute difference in all elements is smaller than the specified tolerance.
+   */
+  boolean compare(final Matrix m, float tolerance);
+}

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/blas/Matrix.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/blas/Matrix.java
@@ -16,7 +16,9 @@
 package edu.snu.dolphin.dnn.blas;
 
 /**
- * Matrix interface.
+ * Interface for matrix whose elements are {@code float} values.
+ *
+ * Linear indexing is in column-major order.
  */
 public interface Matrix {
 
@@ -33,10 +35,11 @@ public interface Matrix {
   /**
    * Returns a element specified by the given index (linear indexing).
    */
-  float get(int i);
+  float get(int index);
 
   /**
-   * Returns elements specified by the linear indices.
+   * Returns a row vector in which elements are specified by the given linear indices.
+   * The modification on the returned vector does not affect this matrix.
    */
   Matrix get(int[] indices);
 
@@ -48,32 +51,32 @@ public interface Matrix {
   /**
    * Sets a matrix element (linear indexing).
    */
-  Matrix put(int i, float v);
+  Matrix put(int index, float value);
 
   /**
    * Sets a matrix element.
    */
-  Matrix put(int rowIndex, int columnIndex, float v);
+  Matrix put(int rowIndex, int columnIndex, float value);
 
   /**
    * Sets a column with the given column vector.
    */
-  void putColumn(int i, Matrix v);
+  void putColumn(int index, Matrix vector);
 
   /**
    * Sets a row with the given row vector.
    */
-  void putRow(int i, Matrix v);
+  void putRow(int index, Matrix vector);
 
   /**
    * Returns a copy of a column.
    */
-  Matrix getColumn(int i);
+  Matrix getColumn(int index);
 
   /**
    * Returns a copy of a row.
    */
-  Matrix getRow(int i);
+  Matrix getRow(int index);
 
   /**
    * Returns total number of elements.
@@ -93,7 +96,7 @@ public interface Matrix {
   /**
    * Sets all elements to the specified value.
    */
-  Matrix fill(float v);
+  Matrix fill(float value);
 
   /**
    * Reshapes the matrix.
@@ -112,14 +115,14 @@ public interface Matrix {
   float[] toFloatArray();
 
   /**
-   * Copies {@code Matrix} {@code m} to this.
-   * @param m a source matrix
-   * @return a source matrix {@code m}
+   * Copies {@link Matrix} {@code matrix} to this.
+   * @param matrix a source matrix
+   * @return a source matrix {@code matrix}
    */
-  Matrix copy(Matrix m);
+  Matrix copy(Matrix matrix);
 
   /**
-   * @return a duplicate of this matrix.
+   * Returns a duplicate of this matrix.
    */
   Matrix dup();
 
@@ -132,214 +135,214 @@ public interface Matrix {
   /* Operations */
 
   /**
-   * Adds a scalar.
+   * Adds a scalar to all elements.
    */
-  Matrix add(float v);
+  Matrix add(float value);
 
   /**
-   * Adds a scalar (in place).
+   * Adds a scalar to all elements (in place).
    */
-  Matrix addi(float v);
+  Matrix addi(float value);
 
   /**
-   * Adds a matrix.
+   * Element-wise adds a matrix.
    */
-  Matrix add(Matrix m);
+  Matrix add(Matrix matrix);
 
   /**
-   * Adds a matrix (in place).
+   * Element-wise Adds a matrix (in place).
    */
-  Matrix addi(Matrix m);
+  Matrix addi(Matrix matrix);
 
   /**
-   * Adds a vector to all columns of the matrix.
+   * Element-wise adds a vector to all columns of the matrix.
    */
-  Matrix addColumnVector(Matrix v);
+  Matrix addColumnVector(Matrix vector);
 
   /**
-   * Adds a vector to all columns of the matrix (in place).
+   * Element-wise adds a vector to all columns of the matrix (in place).
    */
-  Matrix addiColumnVector(Matrix v);
+  Matrix addiColumnVector(Matrix vector);
 
   /**
-   * Adds a vector to all rows of the matrix.
+   * Element-wise adds a vector to all rows of the matrix.
    */
-  Matrix addRowVector(Matrix v);
+  Matrix addRowVector(Matrix vector);
 
   /**
-   * Adds a vector to all rows of the matrix (in place).
+   * Element-wise adds a vector to all rows of the matrix (in place).
    */
-  Matrix addiRowVector(Matrix v);
+  Matrix addiRowVector(Matrix vector);
 
   /**
-   * Subtracts a scalar.
+   * Subtracts a scalar to all elements.
    */
-  Matrix sub(float v);
+  Matrix sub(float value);
 
   /**
-   * Subtracts a scalar (in place).
+   * Subtracts a scalar to all elements (in place).
    */
-  Matrix subi(float v);
+  Matrix subi(float value);
 
   /**
-   * Subtracts a matrix.
+   * Element-wise subtracts a matrix.
    */
-  Matrix sub(Matrix m);
+  Matrix sub(Matrix matrix);
 
   /**
-   * Subtracts a matrix (in place).
+   * Element-wise subtracts a matrix (in place).
    */
-  Matrix subi(Matrix m);
+  Matrix subi(Matrix matrix);
 
   /**
-   * Subtracts a vector to all columns of the matrix.
+   * Element-wise subtracts a vector to all columns of the matrix.
    */
-  Matrix subColumnVector(Matrix v);
+  Matrix subColumnVector(Matrix vector);
 
   /**
-   * Subtracts a vector to all columns of the matrix (in place).
+   * Element-wise subtracts a vector to all columns of the matrix (in place).
    */
-  Matrix subiColumnVector(Matrix v);
+  Matrix subiColumnVector(Matrix vector);
 
   /**
-   * Subtracts a vector to all rows of the matrix.
+   * Element-wise subtracts a vector to all rows of the matrix.
    */
-  Matrix subRowVector(Matrix v);
+  Matrix subRowVector(Matrix vector);
 
   /**
-   * Subtracts a vector to all rows of the matrix (in place).
+   * Element-wise subtracts a vector to all rows of the matrix (in place).
    */
-  Matrix subiRowVector(Matrix v);
+  Matrix subiRowVector(Matrix vector);
 
   /**
-   * (right-)subtracts a scalar.
+   * Element-wise (right-)subtracts a scalar to all elements.
    */
-  Matrix rsub(float v);
+  Matrix rsub(float value);
 
   /**
-   * (right-)subtracts a scalar (in place).
+   * Element-wise (right-)subtracts a scalar to all elements (in place).
    */
-  Matrix rsubi(float v);
+  Matrix rsubi(float value);
 
   /**
-   * (right-)subtracts a matrix.
+   * Element-wise (right-)subtracts a matrix.
    */
-  Matrix rsub(Matrix m);
+  Matrix rsub(Matrix matrix);
 
   /**
-   * (right-)subtracts a matrix (in place).
+   * Element-wise (right-)subtracts a matrix (in place).
    */
-  Matrix rsubi(Matrix m);
+  Matrix rsubi(Matrix matrix);
 
   /**
-   * Multiplies a scalar.
+   * Multiplies a scalar to all elements.
    */
-  Matrix mul(float v);
+  Matrix mul(float value);
 
   /**
-   * Multiplies a scalar (in place).
+   * Multiplies a scalar to all elements (in place).
    */
-  Matrix muli(float v);
+  Matrix muli(float value);
 
   /**
-   * Multiplies a matrix.
+   * Element-wise multiplies a matrix.
    */
-  Matrix mul(Matrix m);
+  Matrix mul(Matrix matrix);
 
   /**
-   * Multiplies a matrix (in place).
+   * Element-wise multiplies a matrix (in place).
    */
-  Matrix muli(Matrix m);
+  Matrix muli(Matrix matrix);
 
   /**
-   * Multiplies a vector to all columns of the matrix.
+   * Element-wise multiplies a vector to all columns of the matrix.
    */
-  Matrix mulColumnVector(Matrix v);
+  Matrix mulColumnVector(Matrix vector);
 
   /**
-   * Multiplies a vector to all columns of the matrix (in place).
+   * Element-wise multiplies a vector to all columns of the matrix (in place).
    */
-  Matrix muliColumnVector(Matrix v);
+  Matrix muliColumnVector(Matrix vector);
 
   /**
-   * Multiplies a vector to all rows of the matrix.
+   * Element-wise multiplies a vector to all rows of the matrix.
    */
-  Matrix mulRowVector(Matrix v);
+  Matrix mulRowVector(Matrix vector);
 
   /**
-   * Multiplies a vector to all rows of the matrix (in place).
+   * Element-wise multiplies a vector to all rows of the matrix (in place).
    */
-  Matrix muliRowVector(Matrix v);
+  Matrix muliRowVector(Matrix vector);
 
   /**
-   * Divides by a scalar.
+   * Divides by a scalar to all elements.
    */
-  Matrix div(float v);
+  Matrix div(float value);
 
   /**
-   * Divides by a scalar (in place).
+   * Divides by a scalar to all elements (in place).
    */
-  Matrix divi(float v);
+  Matrix divi(float value);
 
   /**
-   * Divides by a matrix.
+   * Element-wise divides by a matrix.
    */
-  Matrix div(Matrix m);
+  Matrix div(Matrix matrix);
 
   /**
-   * Divides by a matrix (in place).
+   * Element-wise divides by a matrix (in place).
    */
-  Matrix divi(Matrix m);
+  Matrix divi(Matrix matrix);
 
   /**
-   * Divides a vector to all columns of the matrix.
+   * Element-wise divides a vector to all columns of the matrix.
    */
-  Matrix divColumnVector(Matrix v);
+  Matrix divColumnVector(Matrix vector);
 
   /**
-   * Divides a vector to all columns of the matrix (in place).
+   * Element-wise divides a vector to all columns of the matrix (in place).
    */
-  Matrix diviColumnVector(Matrix v);
+  Matrix diviColumnVector(Matrix vector);
 
   /**
-   * Divides a vector to all rows of the matrix.
+   * Element-wise divides a vector to all rows of the matrix.
    */
-  Matrix divRowVector(Matrix v);
+  Matrix divRowVector(Matrix vector);
 
   /**
-   * Divides a vector to all rows of the matrix (in place).
+   * Element-wise divides a vector to all rows of the matrix (in place).
    */
-  Matrix diviRowVector(Matrix v);
+  Matrix diviRowVector(Matrix vector);
 
   /**
-   * (right-)divides by a scalar.
+   * Element-wise (right-)divides by a scalar to all elements.
    */
-  Matrix rdiv(float v);
+  Matrix rdiv(float value);
 
   /**
-   * (right-)divides by a scalar (in place).
+   * Element-wise (right-)divides by a scalar to all elements (in place).
    */
-  Matrix rdivi(float v);
+  Matrix rdivi(float value);
 
   /**
-   * (right-)divides by a matrix.
+   * Element-wise (right-)divides by a matrix.
    */
-  Matrix rdiv(Matrix m);
+  Matrix rdiv(Matrix matrix);
 
   /**
-   * (right-)divides by a matrix (in place).
+   * Element-wise (right-)divides by a matrix (in place).
    */
-  Matrix rdivi(Matrix m);
+  Matrix rdivi(Matrix matrix);
 
   /**
    * Matrix-Matrix multiplication.
    */
-  Matrix mmul(Matrix m);
+  Matrix mmul(Matrix matrix);
 
   /**
    * Matrix-Matrix multiplication (in place).
    */
-  Matrix mmuli(Matrix m);
+  Matrix mmuli(Matrix matrix);
 
   /**
    * Returns the maximum element of the matrix.
@@ -392,5 +395,5 @@ public interface Matrix {
    * Returns true if and only if the given matrix has the same size
    * and the maximal absolute difference in all elements is smaller than the specified tolerance.
    */
-  boolean compare(Matrix m, float tolerance);
+  boolean compare(Matrix matrix, float tolerance);
 }

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/blas/Matrix.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/blas/Matrix.java
@@ -117,7 +117,7 @@ public interface Matrix {
   /**
    * Copies {@link Matrix} {@code matrix} to this.
    * @param matrix a source matrix
-   * @return a source matrix {@code matrix}
+   * @return this matrix.
    */
   Matrix copy(Matrix matrix);
 

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/blas/MatrixFactory.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/blas/MatrixFactory.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright (C) 2015 Seoul National University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.snu.dolphin.dnn.blas;
+
+/**
+ * Factory interface for {@link Matrix}.
+ */
+public interface MatrixFactory {
+
+  /**
+   * Creates a row vector.
+   * @param length the length of a row vector
+   * @return a generated row vector
+   */
+  Matrix create(final int length);
+
+  /**
+   * Creates a matrix.
+   * @param rows the number of rows
+   * @param columns the number of columns
+   * @return a generated matrix
+   */
+  Matrix create(final int rows, final int columns);
+
+  /**
+   * Creates a row vector with the given values.
+   * @param data elements of a row vector
+   * @return a generated row vector
+   */
+  Matrix create(final float[] data);
+
+  /**
+   * Creates a matrix with the given values.
+   * @param data elements of a matrix
+   * @return a generated matrix
+   */
+  Matrix create(final float[][] data);
+
+  /**
+   * Creates a matrix with the given values.
+   * @param data elements of a matrix in column-major order
+   * @param rows the number of rows
+   * @param columns the number of columns
+   * @return a generated matrix
+   */
+  Matrix create(final float[] data, final int rows, final int columns);
+
+  /**
+   * Creates a row vector in which all elements are equal to {@code 1}.
+   * @param length the length of a row vector
+   * @return a generated row vector
+   */
+  Matrix ones(final int length);
+
+  /**
+   * Creates a matrix in which all elements are equal to {@code 1}.
+   * @param rows the number of rows
+   * @param columns the number of columns
+   * @return a generated matrix
+   */
+  Matrix ones(final int rows, final int columns);
+
+  /**
+   * Creates a row vector in which all elements are equal to {@code 0}.
+   * @param length the length of a row vector
+   * @return a generated row vector
+   */
+  Matrix zeros(final int length);
+
+  /**
+   * Creates a matrix in which all elements are equal to {@code 0}.
+   * @param rows the number of rows
+   * @param columns the number of columns
+   * @return a generated matrix
+   */
+  Matrix zeros(final int rows, final int columns);
+
+  /**
+   * Creates a row vector with random values uniformly distributed in 0..1.
+   * @param length the length of a row vector
+   * @return a generated row vector
+   */
+  Matrix rand(final int length);
+
+  /**
+   * Creates a matrix with random values uniformly distributed in 0..1.
+   * @param rows the number of rows
+   * @param columns the number of columns
+   * @return a generated matrix
+   */
+  Matrix rand(final int rows, final int columns);
+
+  /**
+   * Creates a matrix with random values uniformly distributed in 0..1.
+   * @param rows the number of rows
+   * @param columns the number of columns
+   * @param seed a random seed
+   * @return a generated matrix
+   */
+  Matrix rand(final int rows, final int columns, long seed);
+
+  /**
+   * Creates a row vector with normally distributed random values.
+   * @param length the length of a row vector
+   * @return a generated row vector
+   */
+  Matrix randn(final int length);
+
+  /**
+   * Creates a matrix with normally distributed random values.
+   * @param rows the number of rows
+   * @param columns the number of columns
+   * @return a generated matrix
+   */
+  Matrix randn(final int rows, final int columns);
+
+  /**
+   * Creates a matrix with normally distributed random values.
+   * @param rows the number of rows
+   * @param columns the number of columns
+   * @param seed a random seed
+   * @return a generated matrix
+   */
+  Matrix randn(final int rows, final int columns, long seed);
+
+  /**
+   * Concatenates two matrices horizontally.
+   */
+  Matrix concatHorizontally(Matrix a, Matrix b);
+
+  /**
+   * Concatenates two matrices vertically.
+   */
+  Matrix concatVertically(Matrix a, Matrix b);
+}

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/blas/MatrixFactory.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/blas/MatrixFactory.java
@@ -44,7 +44,8 @@ public interface MatrixFactory {
 
   /**
    * Creates a matrix with the given values.
-   * @param data elements of a matrix
+   * @param data elements of a matrix.
+   *             rows are numbered by the first index and columns are numbered by the second index.
    * @return a generated matrix
    */
   Matrix create(float[][] data);
@@ -113,14 +114,14 @@ public interface MatrixFactory {
   Matrix rand(int rows, int columns, long seed);
 
   /**
-   * Creates a row vector with normally distributed random values.
+   * Creates a row vector containing normally distributed random values with mean 0.0 and standard deviation 1.0.
    * @param length the length of a row vector
    * @return a generated row vector
    */
   Matrix randn(int length);
 
   /**
-   * Creates a matrix with normally distributed random values.
+   * Creates a matrix containing normally distributed random values with mean 0.0 and standard deviation 1.0.
    * @param rows the number of rows
    * @param columns the number of columns
    * @return a generated matrix

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/blas/MatrixFactory.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/blas/MatrixFactory.java
@@ -25,7 +25,7 @@ public interface MatrixFactory {
    * @param length the length of a row vector
    * @return a generated row vector
    */
-  Matrix create(final int length);
+  Matrix create(int length);
 
   /**
    * Creates a matrix.
@@ -33,21 +33,21 @@ public interface MatrixFactory {
    * @param columns the number of columns
    * @return a generated matrix
    */
-  Matrix create(final int rows, final int columns);
+  Matrix create(int rows, int columns);
 
   /**
    * Creates a row vector with the given values.
    * @param data elements of a row vector
    * @return a generated row vector
    */
-  Matrix create(final float[] data);
+  Matrix create(float[] data);
 
   /**
    * Creates a matrix with the given values.
    * @param data elements of a matrix
    * @return a generated matrix
    */
-  Matrix create(final float[][] data);
+  Matrix create(float[][] data);
 
   /**
    * Creates a matrix with the given values.
@@ -56,14 +56,14 @@ public interface MatrixFactory {
    * @param columns the number of columns
    * @return a generated matrix
    */
-  Matrix create(final float[] data, final int rows, final int columns);
+  Matrix create(float[] data, int rows, int columns);
 
   /**
    * Creates a row vector in which all elements are equal to {@code 1}.
    * @param length the length of a row vector
    * @return a generated row vector
    */
-  Matrix ones(final int length);
+  Matrix ones(int length);
 
   /**
    * Creates a matrix in which all elements are equal to {@code 1}.
@@ -71,14 +71,14 @@ public interface MatrixFactory {
    * @param columns the number of columns
    * @return a generated matrix
    */
-  Matrix ones(final int rows, final int columns);
+  Matrix ones(int rows, int columns);
 
   /**
    * Creates a row vector in which all elements are equal to {@code 0}.
    * @param length the length of a row vector
    * @return a generated row vector
    */
-  Matrix zeros(final int length);
+  Matrix zeros(int length);
 
   /**
    * Creates a matrix in which all elements are equal to {@code 0}.
@@ -86,14 +86,14 @@ public interface MatrixFactory {
    * @param columns the number of columns
    * @return a generated matrix
    */
-  Matrix zeros(final int rows, final int columns);
+  Matrix zeros(int rows, int columns);
 
   /**
    * Creates a row vector with random values uniformly distributed in 0..1.
    * @param length the length of a row vector
    * @return a generated row vector
    */
-  Matrix rand(final int length);
+  Matrix rand(int length);
 
   /**
    * Creates a matrix with random values uniformly distributed in 0..1.
@@ -101,7 +101,7 @@ public interface MatrixFactory {
    * @param columns the number of columns
    * @return a generated matrix
    */
-  Matrix rand(final int rows, final int columns);
+  Matrix rand(int rows, int columns);
 
   /**
    * Creates a matrix with random values uniformly distributed in 0..1.
@@ -110,14 +110,14 @@ public interface MatrixFactory {
    * @param seed a random seed
    * @return a generated matrix
    */
-  Matrix rand(final int rows, final int columns, long seed);
+  Matrix rand(int rows, int columns, long seed);
 
   /**
    * Creates a row vector with normally distributed random values.
    * @param length the length of a row vector
    * @return a generated row vector
    */
-  Matrix randn(final int length);
+  Matrix randn(int length);
 
   /**
    * Creates a matrix with normally distributed random values.
@@ -125,7 +125,7 @@ public interface MatrixFactory {
    * @param columns the number of columns
    * @return a generated matrix
    */
-  Matrix randn(final int rows, final int columns);
+  Matrix randn(int rows, int columns);
 
   /**
    * Creates a matrix with normally distributed random values.
@@ -134,7 +134,7 @@ public interface MatrixFactory {
    * @param seed a random seed
    * @return a generated matrix
    */
-  Matrix randn(final int rows, final int columns, long seed);
+  Matrix randn(int rows, int columns, long seed);
 
   /**
    * Concatenates two matrices horizontally.

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/blas/MatrixFunctions.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/blas/MatrixFunctions.java
@@ -16,7 +16,7 @@
 package edu.snu.dolphin.dnn.blas;
 
 /**
- * Utility class that provides functions for {@link edu.snu.dolphin.dnn.blas.Matrix}.
+ * Utility class that provides functions for {@link Matrix}.
  */
 public final class MatrixFunctions {
 

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/blas/MatrixFunctions.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/blas/MatrixFunctions.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2015 Seoul National University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.snu.dolphin.dnn.blas;
+
+/**
+ * Utility class that provides functions for {@link edu.snu.dolphin.dnn.blas.Matrix}.
+ */
+public final class MatrixFunctions {
+
+  private MatrixFunctions() {
+  }
+
+  public static Matrix neg(final Matrix m) {
+    return negi(m.dup());
+  }
+
+  public static Matrix negi(final Matrix m) {
+    for (int i = 0; i < m.getLength(); ++i) {
+      m.put(i, -m.get(i));
+    }
+    return m;
+  }
+
+  public static Matrix exp(final Matrix m) {
+    return expi(m.dup());
+  }
+
+  public static Matrix expi(final Matrix m) {
+    for (int i = 0; i < m.getLength(); ++i) {
+      m.put(i, (float) Math.exp(m.get(i)));
+    }
+    return m;
+  }
+}

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/blas/MatrixFunctions.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/blas/MatrixFunctions.java
@@ -44,4 +44,48 @@ public final class MatrixFunctions {
     }
     return m;
   }
+
+  public static Matrix pow(final Matrix m, final float c) {
+    return powi(m.dup(), c);
+  }
+
+  public static Matrix powi(final Matrix m, final float c) {
+    for (int i = 0; i < m.getLength(); ++i) {
+      m.put(i, (float) Math.pow(m.get(i), c));
+    }
+    return m;
+  }
+
+  public static Matrix abs(final Matrix m) {
+    return absi(m.dup());
+  }
+
+  public static Matrix absi(final Matrix m) {
+    for (int i = 0; i < m.getLength(); ++i) {
+      m.put(i, Math.abs(m.get(i)));
+    }
+    return m;
+  }
+
+  public static Matrix signum(final Matrix m) {
+    return signumi(m.dup());
+  }
+
+  public static Matrix signumi(final Matrix m) {
+    for (int i = 0; i < m.getLength(); ++i) {
+      m.put(i, Math.signum(m.get(i)));
+    }
+    return m;
+  }
+
+  public static Matrix tanh(final Matrix m) {
+    return tanhi(m.dup());
+  }
+
+  public static Matrix tanhi(final Matrix m) {
+    for (int i = 0; i < m.getLength(); ++i) {
+      m.put(i, (float) Math.tanh(m.get(i)));
+    }
+    return m;
+  }
 }

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/blas/MatrixUtils.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/blas/MatrixUtils.java
@@ -22,7 +22,7 @@ import java.util.Iterator;
 import java.util.List;
 
 /**
- * Utility class for {@link edu.snu.dolphin.dnn.blas.Matrix}.
+ * Utility class for {@link Matrix}.
  */
 public final class MatrixUtils {
 
@@ -66,7 +66,7 @@ public final class MatrixUtils {
 
 
   /**
-   * Loads a matrix from a Numpy-compatible plain text file with the specified delimiter.
+   * Loads a matrix from an input stream of a Numpy-compatible plain text file with the specified delimiter.
    * @param matrixFactory a matrix factory used to create a matrix
    * @param inputStream a Numpy-compatible plain text input stream
    * @param delimiter a delimiter
@@ -78,23 +78,24 @@ public final class MatrixUtils {
                                  final String delimiter) throws IOException {
     final BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream));
     String line;
-    final List<float[]> data2 = new ArrayList<>();
+    final List<float[]> dataList = new ArrayList<>();
     int numColumns = -1;
     final Matrix ret;
     while ((line = reader.readLine()) != null) {
       final String[] data = line.trim().split(delimiter);
       if (numColumns < 0) {
         numColumns = data.length;
-
       } else {
-        assert data.length == numColumns : "Data has inconsistent number of columns";
+        if (data.length != numColumns) {
+          throw new RuntimeException("Data has inconsistent number of columns");
+        }
       }
-      data2.add(readSplit(data));
+      dataList.add(readSplit(data));
     }
 
-    ret = matrixFactory.create(data2.size(), numColumns);
-    for (int i = 0; i < data2.size(); i++) {
-      ret.putRow(i, matrixFactory.create(data2.get(i)));
+    ret = matrixFactory.create(dataList.size(), numColumns);
+    for (int i = 0; i < dataList.size(); i++) {
+      ret.putRow(i, matrixFactory.create(dataList.get(i)));
     }
     return ret;
   }
@@ -128,7 +129,6 @@ public final class MatrixUtils {
    * @param index an index of the element to be set to {@code}
    * @param length the length of a row vector
    * @return a generated row vector
-   * @return
    */
   public static Matrix createOutputVector(final MatrixFactory matrixFactory, final int index, final int length) {
     return matrixFactory.zeros(length).put(index, 1.0f);

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/blas/MatrixUtils.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/blas/MatrixUtils.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright (C) 2015 Seoul National University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.snu.dolphin.dnn.blas;
+
+import java.io.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+
+/**
+ * Utility class for {@link edu.snu.dolphin.dnn.blas.Matrix}.
+ */
+public final class MatrixUtils {
+
+  private MatrixUtils() {
+  }
+
+  /**
+   * Returns true if and only if two lists of Matrix have same size
+   * and Matrix elements are equal to one another within tolerance.
+   *
+   * @param a one list of Matrix for comparison.
+   * @param b another list of Matrix for comparison.
+   * @param tolerance the maximum difference for which both numbers are still considered equal.
+   * @return true if the two specified lists of Matrix are equal to one another.
+   */
+  public static boolean compare(final List<Matrix> a, final List<Matrix> b, final float tolerance) {
+    if (a.size() != b.size()) {
+      return false;
+    }
+    final Iterator<Matrix> bIter = b.iterator();
+    for (final Matrix m : a) {
+      if (!m.compare(bIter.next(), tolerance)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /**
+   * Returns true if and only if two arrays of Matrix have same size
+   * and Matrix elements are equal to one another within tolerance.
+   *
+   * @param a one array of Matrix for comparison.
+   * @param b another array of Matrix for comparison.
+   * @param tolerance the maximum difference for which both numbers are still considered equal.
+   * @return true if the two specified arrays of Matrix are equal to one another.
+   */
+  public static boolean compare(final Matrix[] a, final Matrix[] b, final float tolerance) {
+    return compare(Arrays.asList(a), Arrays.asList(b), tolerance);
+  }
+
+
+  /**
+   * Loads a matrix from a Numpy-compatible plain text file with the specified delimiter.
+   * @param matrixFactory a matrix factory used to create a matrix
+   * @param inputStream a Numpy-compatible plain text input stream
+   * @param delimiter a delimiter
+   * @return a loaded matrix
+   * @throws IOException
+   */
+  public static Matrix readNumpy(final MatrixFactory matrixFactory,
+                                 final InputStream inputStream,
+                                 final String delimiter) throws IOException {
+    final BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream));
+    String line;
+    final List<float[]> data2 = new ArrayList<>();
+    int numColumns = -1;
+    final Matrix ret;
+    while ((line = reader.readLine()) != null) {
+      final String[] data = line.trim().split(delimiter);
+      if (numColumns < 0) {
+        numColumns = data.length;
+
+      } else {
+        assert data.length == numColumns : "Data has inconsistent number of columns";
+      }
+      data2.add(readSplit(data));
+    }
+
+    ret = matrixFactory.create(data2.size(), numColumns);
+    for (int i = 0; i < data2.size(); i++) {
+      ret.putRow(i, matrixFactory.create(data2.get(i)));
+    }
+    return ret;
+  }
+
+  private static float[] readSplit(final String[] split) {
+    final float[] ret = new float[split.length];
+    for (int i = 0; i < split.length; i++) {
+      ret[i] = Float.parseFloat(split[i]);
+    }
+    return ret;
+  }
+
+  /**
+   * Loads a matrix from a Numpy-compatible plain text file with the specified delimiter.
+   * @param matrixFactory a matrix factory used to create a matrix
+   * @param filePath a path for the Numpy-compatible plain text file
+   * @param delimiter a delimiter
+   * @return a loaded matrix
+   * @throws IOException
+   */
+  public static Matrix readNumpy(final MatrixFactory matrixFactory,
+                                 final String filePath,
+                                 final String delimiter) throws IOException {
+    return readNumpy(matrixFactory, new FileInputStream(filePath), delimiter);
+  }
+
+  /**
+   * Creates a row vector in which only element at the specified position is {@code 1} and other elements are {@code 0}.
+   *
+   * @param matrixFactory a matrix factor used to create a matrix
+   * @param index an index of the element to be set to {@code}
+   * @param length the length of a row vector
+   * @return a generated row vector
+   * @return
+   */
+  public static Matrix createOutputVector(final MatrixFactory matrixFactory, final int index, final int length) {
+    return matrixFactory.zeros(length).put(index, 1.0f);
+  }
+}

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/blas/function/Function.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/blas/function/Function.java
@@ -39,6 +39,8 @@ public interface Function {
       switch (name.toLowerCase()) {
       case "sigmoid":
         return new Sigmoid();
+      case "relu":
+        return new ReLU();
       default:
         throw new IllegalArgumentException("Unsupported function: " + name);
       }

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/blas/function/Function.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/blas/function/Function.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2015 Seoul National University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.snu.dolphin.dnn.blas.function;
+
+import edu.snu.dolphin.dnn.blas.Matrix;
+
+/**
+ * Function interface.
+ */
+public interface Function {
+
+  Matrix apply(final Matrix m);
+
+  Matrix applyi(final Matrix m);
+
+  Matrix derivative(final Matrix m);
+
+  Matrix derivativei(final Matrix m);
+
+  final class Factory {
+
+    private Factory() {
+    }
+
+    public static Function getFunction(final String name) {
+      switch (name.toLowerCase()) {
+      case "sigmoid":
+        return new Sigmoid();
+      default:
+        throw new IllegalArgumentException("Unsupported function: " + name);
+      }
+    }
+  }
+}

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/blas/function/Function.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/blas/function/Function.java
@@ -43,6 +43,8 @@ public interface Function {
         return new Sigmoid();
       case "relu":
         return new ReLU();
+      case "tanh":
+        return new Tanh();
       default:
         throw new IllegalArgumentException("Unsupported function: " + name);
       }

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/blas/function/Function.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/blas/function/Function.java
@@ -29,25 +29,4 @@ public interface Function {
   Matrix derivative(Matrix m);
 
   Matrix derivativei(Matrix m);
-
-  final class Factory {
-
-    private Factory() {
-    }
-
-    public static Function getFunction(final String name) {
-      switch (name.toLowerCase()) {
-      case "identity":
-        return new Identity();
-      case "sigmoid":
-        return new Sigmoid();
-      case "relu":
-        return new ReLU();
-      case "tanh":
-        return new Tanh();
-      default:
-        throw new IllegalArgumentException("Unsupported function: " + name);
-      }
-    }
-  }
 }

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/blas/function/Function.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/blas/function/Function.java
@@ -37,6 +37,8 @@ public interface Function {
 
     public static Function getFunction(final String name) {
       switch (name.toLowerCase()) {
+      case "identity":
+        return new Identity();
       case "sigmoid":
         return new Sigmoid();
       case "relu":

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/blas/function/Function.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/blas/function/Function.java
@@ -22,13 +22,13 @@ import edu.snu.dolphin.dnn.blas.Matrix;
  */
 public interface Function {
 
-  Matrix apply(final Matrix m);
+  Matrix apply(Matrix m);
 
-  Matrix applyi(final Matrix m);
+  Matrix applyi(Matrix m);
 
-  Matrix derivative(final Matrix m);
+  Matrix derivative(Matrix m);
 
-  Matrix derivativei(final Matrix m);
+  Matrix derivativei(Matrix m);
 
   final class Factory {
 

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/blas/function/FunctionFactory.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/blas/function/FunctionFactory.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2015 Seoul National University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.snu.dolphin.dnn.blas.function;
+
+/**
+ * Factory class for {@link Function}.
+ */
+public final class FunctionFactory {
+
+  private FunctionFactory() {
+  }
+
+  // Function singletons
+  private static final Function SIGMOID = new Sigmoid();
+  private static final Function IDENTITY = new Identity();
+  private static final Function RELU = new ReLU();
+  private static final Function TANH = new Tanh();
+
+  public static Function getSingleInstance(final String name) {
+    switch (name.toLowerCase()) {
+    case "identity":
+      return IDENTITY;
+    case "sigmoid":
+      return SIGMOID;
+    case "relu":
+      return RELU;
+    case "tanh":
+      return TANH;
+    default:
+      throw new IllegalArgumentException("Unsupported function: " + name);
+    }
+  }
+}

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/blas/function/Identity.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/blas/function/Identity.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2015 Seoul National University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.snu.dolphin.dnn.blas.function;
+
+import edu.snu.dolphin.dnn.blas.Matrix;
+
+/**
+ * Identity function.
+ */
+public final class Identity implements Function {
+
+  /**
+   * Applies an identity function to all elements of the specified matrix.
+   */
+  @Override
+  public Matrix apply(final Matrix m) {
+    return applyi(m.dup());
+  }
+
+  /**
+   * Applies an identity function to all elements of the specified matrix (in place).
+   */
+  @Override
+  public Matrix applyi(final Matrix m) {
+    return m;
+  }
+
+  /**
+   * Calculates the matrix in which all elements are derivatives of an identity function.
+   */
+  @Override
+  public Matrix derivative(final Matrix m) {
+    return derivativei(m.dup());
+  }
+
+  /**
+   * Calculates the matrix in which all elements are derivatives of an identity function (in place).
+   */
+  @Override
+  public Matrix derivativei(final Matrix m) {
+    m.fill(1.0f);
+    return m;
+  }
+}

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/blas/function/Identity.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/blas/function/Identity.java
@@ -20,7 +20,7 @@ import edu.snu.dolphin.dnn.blas.Matrix;
 /**
  * Identity function.
  */
-public final class Identity implements Function {
+final class Identity implements Function {
 
   /**
    * Applies an identity function to all elements of the specified matrix.

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/blas/function/Identity.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/blas/function/Identity.java
@@ -23,7 +23,7 @@ import edu.snu.dolphin.dnn.blas.Matrix;
 final class Identity implements Function {
 
   /**
-   * Applies an identity function to all elements of the specified matrix.
+   * Applies the identity function to all elements of the specified matrix.
    */
   @Override
   public Matrix apply(final Matrix m) {
@@ -31,7 +31,7 @@ final class Identity implements Function {
   }
 
   /**
-   * Applies an identity function to all elements of the specified matrix (in place).
+   * Applies the identity function to all elements of the specified matrix (in place).
    */
   @Override
   public Matrix applyi(final Matrix m) {
@@ -39,7 +39,7 @@ final class Identity implements Function {
   }
 
   /**
-   * Calculates the matrix in which all elements are derivatives of an identity function.
+   * Calculates the matrix in which all elements are derivatives of the identity function.
    */
   @Override
   public Matrix derivative(final Matrix m) {
@@ -47,7 +47,7 @@ final class Identity implements Function {
   }
 
   /**
-   * Calculates the matrix in which all elements are derivatives of an identity function (in place).
+   * Calculates the matrix in which all elements are derivatives of the identity function (in place).
    */
   @Override
   public Matrix derivativei(final Matrix m) {

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/blas/function/ReLU.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/blas/function/ReLU.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2015 Seoul National University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.snu.dolphin.dnn.blas.function;
+
+import edu.snu.dolphin.dnn.blas.Matrix;
+
+/**
+ * Rectified linear unit.
+ */
+public final class ReLU implements Function {
+
+  /**
+   * Applies a rectified linear unit to all elements of the specified matrix.
+   */
+  @Override
+  public Matrix apply(final Matrix m) {
+    return applyi(m.dup());
+  }
+
+  /**
+   * Applies a rectified linear unit to all elements of the specified matrix (in place).
+   */
+  @Override
+  public Matrix applyi(final Matrix m) {
+    for (int i = 0; i < m.getLength(); ++i) {
+      if (m.get(i) < 0) {
+        m.put(i, 0.0f);
+      }
+    }
+    return m;
+  }
+
+  /**
+   * Calculates the matrix in which all elements are derivatives of a rectified linear unit.
+   */
+  @Override
+  public Matrix derivative(final Matrix m) {
+    return derivativei(m.dup());
+  }
+
+  /**
+   * Calculates the matrix in which all elements are derivatives of a rectified linear unit (in place).
+   */
+  @Override
+  public Matrix derivativei(final Matrix m) {
+    for (int i = 0; i < m.getLength(); ++i) {
+      if (m.get(i) == 0) {
+        m.put(i, 0.0f);
+      } else {
+        m.put(i, 1.0f);
+      }
+    }
+    return m;
+  }
+}

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/blas/function/ReLU.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/blas/function/ReLU.java
@@ -20,7 +20,7 @@ import edu.snu.dolphin.dnn.blas.Matrix;
 /**
  * Rectified linear unit.
  */
-public final class ReLU implements Function {
+final class ReLU implements Function {
 
   /**
    * Applies a rectified linear unit to all elements of the specified matrix.

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/blas/function/Sigmoid.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/blas/function/Sigmoid.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2015 Seoul National University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.snu.dolphin.dnn.blas.function;
+
+import edu.snu.dolphin.dnn.blas.Matrix;
+import edu.snu.dolphin.dnn.blas.MatrixFunctions;
+
+/**
+ * Sigmoid function.
+ */
+final class Sigmoid implements Function {
+
+  /**
+   * Applies a sigmoid function to all elements of the specified matrix.
+   */
+  @Override
+  public Matrix apply(final Matrix m) {
+    return applyi(m.dup());
+  }
+
+  /**
+   * Applies a sigmoid function to all elements of the specified matrix (in place).
+   */
+  @Override
+  public Matrix applyi(final Matrix m) {
+    return MatrixFunctions.expi(MatrixFunctions.negi(m)).addi(1.0f).rdivi(1.0f);
+  }
+
+  /**
+   * Calculates the matrix in which all elements are derivatives of a sigmoid function.
+   */
+  @Override
+  public Matrix derivative(final Matrix m) {
+    return derivativei(m.dup());
+  }
+
+  /**
+   * Calculates the matrix in which all elements are derivatives of a sigmoid function (in place).
+   */
+  @Override
+  public Matrix derivativei(final Matrix m) {
+    return m.muli(m.rsub(1.0f));
+  }
+}

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/blas/function/Tanh.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/blas/function/Tanh.java
@@ -50,7 +50,7 @@ final class Tanh implements Function {
   /**
    * Calculates the matrix in which all elements are derivatives of a hyperbolic tangent function (in place).
    * <p>
-   *   derivatives of tanh: 1 - tanh(x)^2
+   *   derivative of tanh: 1 - tanh(x)^2
    * </p>
    */
   @Override

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/blas/function/Tanh.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/blas/function/Tanh.java
@@ -21,7 +21,7 @@ import edu.snu.dolphin.dnn.blas.MatrixFunctions;
 /**
  * Hyperbolic tangent function.
  */
-public final class Tanh implements Function {
+final class Tanh implements Function {
 
   /**
    * Applies a hyperbolic tangent function to all elements of the specified matrix.

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/blas/function/Tanh.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/blas/function/Tanh.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2015 Seoul National University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.snu.dolphin.dnn.blas.function;
+
+import edu.snu.dolphin.dnn.blas.Matrix;
+import edu.snu.dolphin.dnn.blas.MatrixFunctions;
+
+/**
+ * Hyperbolic tangent function.
+ */
+public final class Tanh implements Function {
+
+  /**
+   * Applies a hyperbolic tangent function to all elements of the specified matrix.
+   */
+  @Override
+  public Matrix apply(final Matrix m) {
+    return applyi(m.dup());
+  }
+
+  /**
+   * Applies a hyperbolic tangent function to all elements of the specified matrix (in place).
+   */
+  @Override
+  public Matrix applyi(final Matrix m) {
+    return MatrixFunctions.tanhi(m);
+  }
+
+  /**
+   * Calculates the matrix in which all elements are derivatives of a hyperbolic tangent function.
+   */
+  @Override
+  public Matrix derivative(final Matrix m) {
+    return derivativei(m.dup());
+  }
+
+  /**
+   * Calculates the matrix in which all elements are derivatives of a hyperbolic tangent function (in place).
+   * <p>
+   *   derivatives of tanh: 1 - tanh(x)^2
+   * </p>
+   */
+  @Override
+  public Matrix derivativei(final Matrix m) {
+    MatrixFunctions.powi(m, 2);
+    return m.rsubi(1);
+  }
+}

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/blas/function/package-info.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/blas/function/package-info.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright (C) 2015 Seoul National University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Classes for activation functions.
+ */
+package edu.snu.dolphin.dnn.blas.function;

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/blas/jblas/MatrixJBLASFactory.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/blas/jblas/MatrixJBLASFactory.java
@@ -159,7 +159,7 @@ public final class MatrixJBLASFactory implements MatrixFactory {
         ret.putRow(i, a.getRow(i));
       }
       for (int i = 0; i < b.getRows(); ++i) {
-        ret.putRow(a.getColumns() + i, b.getRow(i));
+        ret.putRow(a.getRows() + i, b.getRow(i));
       }
       return ret;
     }

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/blas/jblas/MatrixJBLASFactory.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/blas/jblas/MatrixJBLASFactory.java
@@ -93,7 +93,7 @@ public final class MatrixJBLASFactory implements MatrixFactory {
       data[i] = RANDOM.nextFloat();
     }
 
-    return new MatrixJBLASImpl(new FloatMatrix(rows, columns, data));
+    return create(data, rows, columns);
   }
 
   @Override
@@ -116,7 +116,7 @@ public final class MatrixJBLASFactory implements MatrixFactory {
       data[i] = (float) RANDOM.nextGaussian();
     }
 
-    return new MatrixJBLASImpl(new FloatMatrix(rows, columns, data));
+    return create(data, rows, columns);
   }
 
   @Override

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/blas/jblas/MatrixJBLASFactory.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/blas/jblas/MatrixJBLASFactory.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright (C) 2015 Seoul National University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.snu.dolphin.dnn.blas.jblas;
+
+import edu.snu.dolphin.dnn.blas.Matrix;
+import edu.snu.dolphin.dnn.blas.MatrixFactory;
+import org.apache.commons.math3.random.MersenneTwister;
+import org.apache.commons.math3.random.SynchronizedRandomGenerator;
+import org.jblas.FloatMatrix;
+
+import javax.inject.Inject;
+
+/**
+ * Factory class for JBLAS based matrix implementation.
+ */
+public final class MatrixJBLASFactory implements MatrixFactory {
+
+  private static final SynchronizedRandomGenerator RANDOM = new SynchronizedRandomGenerator(new MersenneTwister());
+
+  @Inject
+  private MatrixJBLASFactory() {
+  }
+
+  @Override
+  public Matrix create(final int length) {
+    return new MatrixJBLASImpl(new FloatMatrix(1, length));
+  }
+
+  @Override
+  public Matrix create(final int rows, final int columns) {
+    return new MatrixJBLASImpl(new FloatMatrix(rows, columns));
+  }
+
+  @Override
+  public Matrix create(final float[] data) {
+    return new MatrixJBLASImpl(new FloatMatrix(1, data.length, data));
+  }
+
+  @Override
+  public Matrix create(final float[][] data) {
+    return new MatrixJBLASImpl(new FloatMatrix(data));
+  }
+
+  @Override
+  public Matrix create(final float[] data, final int rows, final int columns) {
+    return new MatrixJBLASImpl(new FloatMatrix(rows, columns, data));
+  }
+
+  @Override
+  public Matrix ones(final int length) {
+    return new MatrixJBLASImpl(FloatMatrix.ones(1, length));
+  }
+
+  @Override
+  public Matrix ones(final int rows, final int columns) {
+    return new MatrixJBLASImpl(FloatMatrix.ones(rows, columns));
+  }
+
+  @Override
+  public Matrix zeros(final int length) {
+    return new MatrixJBLASImpl(FloatMatrix.zeros(1, length));
+  }
+
+  @Override
+  public Matrix zeros(final int rows, final int columns) {
+    return new MatrixJBLASImpl(FloatMatrix.zeros(rows, columns));
+  }
+
+  @Override
+  public Matrix rand(final int length) {
+    return rand(1, length);
+  }
+
+  @Override
+  public Matrix rand(final int rows, final int columns) {
+    final int length = rows * columns;
+    final float[] data = new float[length];
+
+    for (int i = 0; i < length; ++i) {
+      data[i] = RANDOM.nextFloat();
+    }
+
+    return new MatrixJBLASImpl(new FloatMatrix(rows, columns, data));
+  }
+
+  @Override
+  public Matrix rand(final int rows, final int columns, final long seed) {
+    RANDOM.setSeed(seed);
+    return rand(rows, columns);
+  }
+
+  @Override
+  public Matrix randn(final int length) {
+    return randn(1, length);
+  }
+
+  @Override
+  public Matrix randn(final int rows, final int columns) {
+    final int length = rows * columns;
+    final float[] data = new float[length];
+
+    for (int i = 0; i < length; ++i) {
+      data[i] = (float) RANDOM.nextGaussian();
+    }
+
+    return new MatrixJBLASImpl(new FloatMatrix(rows, columns, data));
+  }
+
+  @Override
+  public Matrix randn(final int rows, final int columns, final long seed) {
+    RANDOM.setSeed(seed);
+    return randn(rows, columns);
+  }
+
+  @Override
+  public Matrix concatHorizontally(final Matrix a, final Matrix b) {
+    if (a instanceof MatrixJBLASImpl && b instanceof MatrixJBLASImpl) {
+      return MatrixJBLASImpl.concatHorizontally((MatrixJBLASImpl) a, (MatrixJBLASImpl) b);
+    } else {
+      throw new IllegalArgumentException("Matrices for the concatenation should be JBLAS based");
+    }
+  }
+
+  @Override
+  public Matrix concatVertically(final Matrix a, final Matrix b) {
+    if (a instanceof MatrixJBLASImpl && b instanceof MatrixJBLASImpl) {
+      return MatrixJBLASImpl.concatVertically((MatrixJBLASImpl) a, (MatrixJBLASImpl) b);
+    } else {
+      throw new IllegalArgumentException("Matrices for the concatenation should be JBLAS based");
+    }
+  }
+}

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/blas/jblas/MatrixJBLASFactory.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/blas/jblas/MatrixJBLASFactory.java
@@ -129,8 +129,19 @@ public final class MatrixJBLASFactory implements MatrixFactory {
   public Matrix concatHorizontally(final Matrix a, final Matrix b) {
     if (a instanceof MatrixJBLASImpl && b instanceof MatrixJBLASImpl) {
       return MatrixJBLASImpl.concatHorizontally((MatrixJBLASImpl) a, (MatrixJBLASImpl) b);
+    }
+
+    if (a.getRows() != b.getRows()) {
+      throw new RuntimeException("Matrices do not have the same number of rows");
     } else {
-      throw new IllegalArgumentException("Matrices for the concatenation should be JBLAS based");
+      final Matrix ret = create(a.getRows(), a.getColumns() + b.getColumns());
+      for (int i = 0; i < a.getColumns(); ++i) {
+        ret.putColumn(i, a.getColumn(i));
+      }
+      for (int i = 0; i < b.getColumns(); ++i) {
+        ret.putColumn(a.getColumns() + i, b.getColumn(i));
+      }
+      return ret;
     }
   }
 
@@ -138,8 +149,19 @@ public final class MatrixJBLASFactory implements MatrixFactory {
   public Matrix concatVertically(final Matrix a, final Matrix b) {
     if (a instanceof MatrixJBLASImpl && b instanceof MatrixJBLASImpl) {
       return MatrixJBLASImpl.concatVertically((MatrixJBLASImpl) a, (MatrixJBLASImpl) b);
+    }
+
+    if (a.getColumns() != b.getColumns()) {
+      throw new RuntimeException("Matrices do not have the same number of columns");
     } else {
-      throw new IllegalArgumentException("Matrices for the concatenation should be JBLAS based");
+      final Matrix ret = create(a.getRows() + b.getRows(), a.getColumns());
+      for (int i = 0; i < a.getRows(); ++i) {
+        ret.putRow(i, a.getRow(i));
+      }
+      for (int i = 0; i < b.getRows(); ++i) {
+        ret.putRow(a.getColumns() + i, b.getRow(i));
+      }
+      return ret;
     }
   }
 }

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/blas/jblas/MatrixJBLASImpl.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/blas/jblas/MatrixJBLASImpl.java
@@ -481,6 +481,7 @@ class MatrixJBLASImpl implements Matrix {
 
   private void checkImpl(final Matrix matrix) {
     if (!(matrix instanceof MatrixJBLASImpl)) {
+      // TODO #147: different matrix implementations
       throw new IllegalArgumentException("The given matrix should be JBLAS based");
     }
   }

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/blas/jblas/MatrixJBLASImpl.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/blas/jblas/MatrixJBLASImpl.java
@@ -1,0 +1,440 @@
+/*
+ * Copyright (C) 2015 Seoul National University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.snu.dolphin.dnn.blas.jblas;
+
+import edu.snu.dolphin.dnn.blas.Matrix;
+import org.jblas.FloatMatrix;
+
+/**
+ * Matrix implementation based on JBLAS.
+ */
+public class MatrixJBLASImpl implements Matrix {
+
+  private final FloatMatrix matrix;
+
+  MatrixJBLASImpl(final FloatMatrix matrix) {
+    this.matrix = matrix;
+  }
+
+  @Override
+  public int getRows() {
+    return matrix.getRows();
+  }
+
+  @Override
+  public int getColumns() {
+    return matrix.getColumns();
+  }
+
+  @Override
+  public float get(final int i) {
+    return matrix.get(i);
+  }
+
+  @Override
+  public Matrix get(final int[] indices) {
+    return new MatrixJBLASImpl(matrix.get(indices));
+  }
+
+  @Override
+  public float get(final int rowIndex, final int columnIndex) {
+    return matrix.get(rowIndex, columnIndex);
+  }
+
+  @Override
+  public Matrix put(final int i, final float v) {
+    matrix.put(i, v);
+    return this;
+  }
+
+  @Override
+  public Matrix put(final int rowIndex, final int columnIndex, final float v) {
+    matrix.put(rowIndex, columnIndex, v);
+    return this;
+  }
+
+  @Override
+  public void putColumn(final int i, final Matrix v) {
+    checkImpl(v);
+    matrix.putColumn(i, ((MatrixJBLASImpl) v).matrix);
+  }
+
+  @Override
+  public void putRow(final int i, final Matrix v) {
+    checkImpl(v);
+    matrix.putRow(i, ((MatrixJBLASImpl) v).matrix);
+  }
+
+  @Override
+  public Matrix getColumn(final int i) {
+    return new MatrixJBLASImpl(matrix.getColumn(i));
+  }
+
+  @Override
+  public Matrix getRow(final int i) {
+    return new MatrixJBLASImpl(matrix.getRow(i));
+  }
+
+  @Override
+  public int getLength() {
+    return matrix.getLength();
+  }
+
+  @Override
+  public boolean isColumnVector() {
+    return matrix.isColumnVector();
+  }
+
+  @Override
+  public boolean isRowVector() {
+    return matrix.isRowVector();
+  }
+
+  @Override
+  public Matrix fill(final float v) {
+    matrix.fill(v);
+    return this;
+  }
+
+  @Override
+  public Matrix reshape(final int newRows, final int newColumns) {
+    matrix.reshape(newRows, newColumns);
+    return this;
+  }
+
+  @Override
+  public String toString() {
+    return matrix.toString();
+  }
+
+  @Override
+  public float[] toFloatArray() {
+    return matrix.toArray();
+  }
+
+  @Override
+  public Matrix copy(final Matrix m) {
+    checkImpl(m);
+    matrix.copy(((MatrixJBLASImpl) m).matrix);
+    return m;
+  }
+
+  @Override
+  public Matrix dup() {
+    return new MatrixJBLASImpl(matrix.dup());
+  }
+
+  @Override
+  public Matrix transpose() {
+    return new MatrixJBLASImpl(matrix.transpose());
+  }
+
+  @Override
+  public Matrix add(final float v) {
+    return new MatrixJBLASImpl(matrix.add(v));
+  }
+
+  @Override
+  public Matrix addi(final float v) {
+    matrix.addi(v);
+    return this;
+  }
+
+  @Override
+  public Matrix add(final Matrix m) {
+    checkImpl(m);
+    return new MatrixJBLASImpl(matrix.add(((MatrixJBLASImpl) m).matrix));
+  }
+
+  @Override
+  public Matrix addi(final Matrix m) {
+    checkImpl(m);
+    matrix.addi(((MatrixJBLASImpl) m).matrix);
+    return this;
+  }
+
+  @Override
+  public Matrix addColumnVector(final Matrix v) {
+    checkImpl(v);
+    return new MatrixJBLASImpl(matrix.addColumnVector(((MatrixJBLASImpl) v).matrix));
+  }
+
+  @Override
+  public Matrix addiColumnVector(final Matrix v) {
+    checkImpl(v);
+    matrix.addiColumnVector(((MatrixJBLASImpl) v).matrix);
+    return this;
+  }
+
+  @Override
+  public Matrix addRowVector(final Matrix v) {
+    checkImpl(v);
+    return new MatrixJBLASImpl(matrix.addRowVector(((MatrixJBLASImpl) v).matrix));
+  }
+
+  @Override
+  public Matrix addiRowVector(final Matrix v) {
+    checkImpl(v);
+    matrix.addiRowVector(((MatrixJBLASImpl) v).matrix);
+    return this;
+  }
+
+  @Override
+  public Matrix sub(final float v) {
+    return new MatrixJBLASImpl(matrix.sub(v));
+  }
+
+  @Override
+  public Matrix subi(final float v) {
+    matrix.subi(v);
+    return this;
+  }
+
+  @Override
+  public Matrix sub(final Matrix m) {
+    checkImpl(m);
+    return new MatrixJBLASImpl(matrix.sub(((MatrixJBLASImpl) m).matrix));
+  }
+
+  @Override
+  public Matrix subi(final Matrix m) {
+    checkImpl(m);
+    matrix.subi(((MatrixJBLASImpl) m).matrix);
+    return this;
+  }
+
+  @Override
+  public Matrix subColumnVector(final Matrix v) {
+    checkImpl(v);
+    return new MatrixJBLASImpl(matrix.subColumnVector(((MatrixJBLASImpl) v).matrix));
+  }
+
+  @Override
+  public Matrix subiColumnVector(final Matrix v) {
+    checkImpl(v);
+    matrix.subiColumnVector(((MatrixJBLASImpl) v).matrix);
+    return this;
+  }
+
+  @Override
+  public Matrix subRowVector(final Matrix v) {
+    checkImpl(v);
+    return new MatrixJBLASImpl(matrix.subRowVector(((MatrixJBLASImpl) v).matrix));
+  }
+
+  @Override
+  public Matrix subiRowVector(final Matrix v) {
+    checkImpl(v);
+    matrix.subiRowVector(((MatrixJBLASImpl) v).matrix);
+    return this;
+  }
+
+  @Override
+  public Matrix rsub(final float v) {
+    return new MatrixJBLASImpl(matrix.rsub(v));
+  }
+
+  @Override
+  public Matrix rsubi(final float v) {
+    matrix.rsubi(v);
+    return this;
+  }
+
+  @Override
+  public Matrix rsub(final Matrix m) {
+    checkImpl(m);
+    return new MatrixJBLASImpl(matrix.rsub(((MatrixJBLASImpl) m).matrix));
+  }
+
+  @Override
+  public Matrix rsubi(final Matrix m) {
+    checkImpl(m);
+    matrix.rsubi(((MatrixJBLASImpl) m).matrix);
+    return this;
+  }
+
+  @Override
+  public Matrix mul(final float v) {
+    return new MatrixJBLASImpl(matrix.mul(v));
+  }
+
+  @Override
+  public Matrix muli(final float v) {
+    matrix.muli(v);
+    return this;
+  }
+
+  @Override
+  public Matrix mul(final Matrix m) {
+    checkImpl(m);
+    return new MatrixJBLASImpl(matrix.mul(((MatrixJBLASImpl) m).matrix));
+  }
+
+  @Override
+  public Matrix muli(final Matrix m) {
+    checkImpl(m);
+    matrix.muli(((MatrixJBLASImpl) m).matrix);
+    return this;
+  }
+
+  @Override
+  public Matrix mulColumnVector(final Matrix v) {
+    checkImpl(v);
+    return new MatrixJBLASImpl(matrix.mulColumnVector(((MatrixJBLASImpl) v).matrix));
+  }
+
+  @Override
+  public Matrix muliColumnVector(final Matrix v) {
+    checkImpl(v);
+    matrix.muliColumnVector(((MatrixJBLASImpl) v).matrix);
+    return this;
+  }
+
+  @Override
+  public Matrix mulRowVector(final Matrix v) {
+    checkImpl(v);
+    return new MatrixJBLASImpl(matrix.mulRowVector(((MatrixJBLASImpl) v).matrix));
+  }
+
+  @Override
+  public Matrix muliRowVector(final Matrix v) {
+    checkImpl(v);
+    matrix.muliRowVector(((MatrixJBLASImpl) v).matrix);
+    return this;
+  }
+
+  @Override
+  public Matrix div(final float v) {
+    return new MatrixJBLASImpl(matrix.div(v));
+  }
+
+  @Override
+  public Matrix divi(final float v) {
+    matrix.divi(v);
+    return this;
+  }
+
+  @Override
+  public Matrix div(final Matrix m) {
+    checkImpl(m);
+    return new MatrixJBLASImpl(matrix.div(((MatrixJBLASImpl) m).matrix));
+  }
+
+  @Override
+  public Matrix divi(final Matrix m) {
+    checkImpl(m);
+    matrix.divi(((MatrixJBLASImpl) m).matrix);
+    return this;
+  }
+
+  @Override
+  public Matrix divColumnVector(final Matrix v) {
+    checkImpl(v);
+    return new MatrixJBLASImpl(matrix.divColumnVector(((MatrixJBLASImpl) v).matrix));
+  }
+
+  @Override
+  public Matrix diviColumnVector(final Matrix v) {
+    checkImpl(v);
+    matrix.diviColumnVector(((MatrixJBLASImpl) v).matrix);
+    return this;
+  }
+
+  @Override
+  public Matrix divRowVector(final Matrix v) {
+    checkImpl(v);
+    return new MatrixJBLASImpl(matrix.divRowVector(((MatrixJBLASImpl) v).matrix));
+  }
+
+  @Override
+  public Matrix diviRowVector(final Matrix v) {
+    checkImpl(v);
+    matrix.diviRowVector(((MatrixJBLASImpl) v).matrix);
+    return this;
+  }
+
+  @Override
+  public Matrix rdiv(final float v) {
+    return new MatrixJBLASImpl(matrix.rdiv(v));
+  }
+
+  @Override
+  public Matrix rdivi(final float v) {
+    matrix.rdivi(v);
+    return this;
+  }
+
+  @Override
+  public Matrix rdiv(final Matrix m) {
+    checkImpl(m);
+    return new MatrixJBLASImpl(matrix.rdiv(((MatrixJBLASImpl) m).matrix));
+  }
+
+  @Override
+  public Matrix rdivi(final Matrix m) {
+    checkImpl(m);
+    matrix.rdivi(((MatrixJBLASImpl) m).matrix);
+    return this;
+  }
+
+  @Override
+  public Matrix mmul(final Matrix m) {
+    checkImpl(m);
+    return new MatrixJBLASImpl(matrix.mmul(((MatrixJBLASImpl) m).matrix));
+  }
+
+  @Override
+  public Matrix mmuli(final Matrix m) {
+    checkImpl(m);
+    matrix.mmuli(((MatrixJBLASImpl) m).matrix);
+    return this;
+  }
+
+  @Override
+  public boolean compare(final Matrix m, final float tolerance) {
+    if (m instanceof MatrixJBLASImpl) {
+      return matrix.compare(((MatrixJBLASImpl) m).matrix, tolerance);
+    }
+    return false;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o instanceof MatrixJBLASImpl) {
+      return matrix.equals(((MatrixJBLASImpl) o).matrix);
+    }
+    return false;
+  }
+
+  @Override
+  public int hashCode() {
+    return matrix.hashCode();
+  }
+
+  public static MatrixJBLASImpl concatHorizontally(final MatrixJBLASImpl a, final MatrixJBLASImpl b) {
+    return new MatrixJBLASImpl(FloatMatrix.concatHorizontally(a.matrix, b.matrix));
+  }
+
+  public static MatrixJBLASImpl concatVertically(final MatrixJBLASImpl a, final MatrixJBLASImpl b) {
+    return new MatrixJBLASImpl(FloatMatrix.concatVertically(a.matrix, b.matrix));
+  }
+
+  private void checkImpl(final Matrix m) {
+    if (!(m instanceof MatrixJBLASImpl)) {
+      throw new IllegalArgumentException("The given matrix should be JBLAS based");
+    }
+  }
+}

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/blas/jblas/MatrixJBLASImpl.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/blas/jblas/MatrixJBLASImpl.java
@@ -131,7 +131,7 @@ class MatrixJBLASImpl implements Matrix {
   public Matrix copy(final Matrix matrix) {
     checkImpl(matrix);
     jblasMatrix.copy(((MatrixJBLASImpl) matrix).jblasMatrix);
-    return matrix;
+    return this;
   }
 
   @Override

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/blas/jblas/MatrixJBLASImpl.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/blas/jblas/MatrixJBLASImpl.java
@@ -46,7 +46,9 @@ public class MatrixJBLASImpl implements Matrix {
 
   @Override
   public Matrix get(final int[] indices) {
-    return new MatrixJBLASImpl(matrix.get(indices));
+    final FloatMatrix innerVector = matrix.get(indices); // a column vector
+    innerVector.reshape(1, innerVector.getLength()); // convert it to a row vector
+    return new MatrixJBLASImpl(innerVector);
   }
 
   @Override

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/blas/jblas/MatrixJBLASImpl.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/blas/jblas/MatrixJBLASImpl.java
@@ -21,7 +21,7 @@ import org.jblas.FloatMatrix;
 /**
  * Matrix implementation based on JBLAS.
  */
-class MatrixJBLASImpl implements Matrix {
+final class MatrixJBLASImpl implements Matrix {
 
   private final FloatMatrix jblasMatrix;
 

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/blas/jblas/MatrixJBLASImpl.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/blas/jblas/MatrixJBLASImpl.java
@@ -21,439 +21,439 @@ import org.jblas.FloatMatrix;
 /**
  * Matrix implementation based on JBLAS.
  */
-public class MatrixJBLASImpl implements Matrix {
+class MatrixJBLASImpl implements Matrix {
 
-  private final FloatMatrix matrix;
+  private final FloatMatrix jblasMatrix;
 
-  MatrixJBLASImpl(final FloatMatrix matrix) {
-    this.matrix = matrix;
+  MatrixJBLASImpl(final FloatMatrix jblasMatrix) {
+    this.jblasMatrix = jblasMatrix;
   }
 
   @Override
   public int getRows() {
-    return matrix.getRows();
+    return jblasMatrix.getRows();
   }
 
   @Override
   public int getColumns() {
-    return matrix.getColumns();
+    return jblasMatrix.getColumns();
   }
 
   @Override
-  public float get(final int i) {
-    return matrix.get(i);
+  public float get(final int index) {
+    return jblasMatrix.get(index);
   }
 
   @Override
   public Matrix get(final int[] indices) {
-    final FloatMatrix innerVector = matrix.get(indices); // a column vector
+    final FloatMatrix innerVector = jblasMatrix.get(indices); // a column vector
     innerVector.reshape(1, innerVector.getLength()); // convert it to a row vector
     return new MatrixJBLASImpl(innerVector);
   }
 
   @Override
   public float get(final int rowIndex, final int columnIndex) {
-    return matrix.get(rowIndex, columnIndex);
+    return jblasMatrix.get(rowIndex, columnIndex);
   }
 
   @Override
-  public Matrix put(final int i, final float v) {
-    matrix.put(i, v);
+  public Matrix put(final int index, final float value) {
+    jblasMatrix.put(index, value);
     return this;
   }
 
   @Override
-  public Matrix put(final int rowIndex, final int columnIndex, final float v) {
-    matrix.put(rowIndex, columnIndex, v);
+  public Matrix put(final int rowIndex, final int columnIndex, final float value) {
+    jblasMatrix.put(rowIndex, columnIndex, value);
     return this;
   }
 
   @Override
-  public void putColumn(final int i, final Matrix v) {
-    checkImpl(v);
-    matrix.putColumn(i, ((MatrixJBLASImpl) v).matrix);
+  public void putColumn(final int index, final Matrix vector) {
+    checkImpl(vector);
+    jblasMatrix.putColumn(index, ((MatrixJBLASImpl) vector).jblasMatrix);
   }
 
   @Override
-  public void putRow(final int i, final Matrix v) {
-    checkImpl(v);
-    matrix.putRow(i, ((MatrixJBLASImpl) v).matrix);
+  public void putRow(final int index, final Matrix vector) {
+    checkImpl(vector);
+    jblasMatrix.putRow(index, ((MatrixJBLASImpl) vector).jblasMatrix);
   }
 
   @Override
-  public Matrix getColumn(final int i) {
-    return new MatrixJBLASImpl(matrix.getColumn(i));
+  public Matrix getColumn(final int index) {
+    return new MatrixJBLASImpl(jblasMatrix.getColumn(index));
   }
 
   @Override
-  public Matrix getRow(final int i) {
-    return new MatrixJBLASImpl(matrix.getRow(i));
+  public Matrix getRow(final int index) {
+    return new MatrixJBLASImpl(jblasMatrix.getRow(index));
   }
 
   @Override
   public int getLength() {
-    return matrix.getLength();
+    return jblasMatrix.getLength();
   }
 
   @Override
   public boolean isColumnVector() {
-    return matrix.isColumnVector();
+    return jblasMatrix.isColumnVector();
   }
 
   @Override
   public boolean isRowVector() {
-    return matrix.isRowVector();
+    return jblasMatrix.isRowVector();
   }
 
   @Override
-  public Matrix fill(final float v) {
-    matrix.fill(v);
+  public Matrix fill(final float value) {
+    jblasMatrix.fill(value);
     return this;
   }
 
   @Override
   public Matrix reshape(final int newRows, final int newColumns) {
-    matrix.reshape(newRows, newColumns);
+    jblasMatrix.reshape(newRows, newColumns);
     return this;
   }
 
   @Override
   public String toString() {
-    return matrix.toString();
+    return jblasMatrix.toString();
   }
 
   @Override
   public float[] toFloatArray() {
-    return matrix.toArray();
+    return jblasMatrix.toArray();
   }
 
   @Override
-  public Matrix copy(final Matrix m) {
-    checkImpl(m);
-    matrix.copy(((MatrixJBLASImpl) m).matrix);
-    return m;
+  public Matrix copy(final Matrix matrix) {
+    checkImpl(matrix);
+    jblasMatrix.copy(((MatrixJBLASImpl) matrix).jblasMatrix);
+    return matrix;
   }
 
   @Override
   public Matrix dup() {
-    return new MatrixJBLASImpl(matrix.dup());
+    return new MatrixJBLASImpl(jblasMatrix.dup());
   }
 
   @Override
   public Matrix transpose() {
-    return new MatrixJBLASImpl(matrix.transpose());
+    return new MatrixJBLASImpl(jblasMatrix.transpose());
   }
 
   @Override
-  public Matrix add(final float v) {
-    return new MatrixJBLASImpl(matrix.add(v));
+  public Matrix add(final float value) {
+    return new MatrixJBLASImpl(jblasMatrix.add(value));
   }
 
   @Override
-  public Matrix addi(final float v) {
-    matrix.addi(v);
+  public Matrix addi(final float value) {
+    jblasMatrix.addi(value);
     return this;
   }
 
   @Override
-  public Matrix add(final Matrix m) {
-    checkImpl(m);
-    return new MatrixJBLASImpl(matrix.add(((MatrixJBLASImpl) m).matrix));
+  public Matrix add(final Matrix matrix) {
+    checkImpl(matrix);
+    return new MatrixJBLASImpl(this.jblasMatrix.add(((MatrixJBLASImpl) matrix).jblasMatrix));
   }
 
   @Override
-  public Matrix addi(final Matrix m) {
-    checkImpl(m);
-    matrix.addi(((MatrixJBLASImpl) m).matrix);
+  public Matrix addi(final Matrix matrix) {
+    checkImpl(matrix);
+    this.jblasMatrix.addi(((MatrixJBLASImpl) matrix).jblasMatrix);
     return this;
   }
 
   @Override
-  public Matrix addColumnVector(final Matrix v) {
-    checkImpl(v);
-    return new MatrixJBLASImpl(matrix.addColumnVector(((MatrixJBLASImpl) v).matrix));
+  public Matrix addColumnVector(final Matrix vector) {
+    checkImpl(vector);
+    return new MatrixJBLASImpl(jblasMatrix.addColumnVector(((MatrixJBLASImpl) vector).jblasMatrix));
   }
 
   @Override
-  public Matrix addiColumnVector(final Matrix v) {
-    checkImpl(v);
-    matrix.addiColumnVector(((MatrixJBLASImpl) v).matrix);
+  public Matrix addiColumnVector(final Matrix vector) {
+    checkImpl(vector);
+    jblasMatrix.addiColumnVector(((MatrixJBLASImpl) vector).jblasMatrix);
     return this;
   }
 
   @Override
-  public Matrix addRowVector(final Matrix v) {
-    checkImpl(v);
-    return new MatrixJBLASImpl(matrix.addRowVector(((MatrixJBLASImpl) v).matrix));
+  public Matrix addRowVector(final Matrix vector) {
+    checkImpl(vector);
+    return new MatrixJBLASImpl(jblasMatrix.addRowVector(((MatrixJBLASImpl) vector).jblasMatrix));
   }
 
   @Override
-  public Matrix addiRowVector(final Matrix v) {
-    checkImpl(v);
-    matrix.addiRowVector(((MatrixJBLASImpl) v).matrix);
+  public Matrix addiRowVector(final Matrix vector) {
+    checkImpl(vector);
+    jblasMatrix.addiRowVector(((MatrixJBLASImpl) vector).jblasMatrix);
     return this;
   }
 
   @Override
-  public Matrix sub(final float v) {
-    return new MatrixJBLASImpl(matrix.sub(v));
+  public Matrix sub(final float value) {
+    return new MatrixJBLASImpl(jblasMatrix.sub(value));
   }
 
   @Override
-  public Matrix subi(final float v) {
-    matrix.subi(v);
+  public Matrix subi(final float value) {
+    jblasMatrix.subi(value);
     return this;
   }
 
   @Override
-  public Matrix sub(final Matrix m) {
-    checkImpl(m);
-    return new MatrixJBLASImpl(matrix.sub(((MatrixJBLASImpl) m).matrix));
+  public Matrix sub(final Matrix matrix) {
+    checkImpl(matrix);
+    return new MatrixJBLASImpl(jblasMatrix.sub(((MatrixJBLASImpl) matrix).jblasMatrix));
   }
 
   @Override
-  public Matrix subi(final Matrix m) {
-    checkImpl(m);
-    matrix.subi(((MatrixJBLASImpl) m).matrix);
+  public Matrix subi(final Matrix matrix) {
+    checkImpl(matrix);
+    jblasMatrix.subi(((MatrixJBLASImpl) matrix).jblasMatrix);
     return this;
   }
 
   @Override
-  public Matrix subColumnVector(final Matrix v) {
-    checkImpl(v);
-    return new MatrixJBLASImpl(matrix.subColumnVector(((MatrixJBLASImpl) v).matrix));
+  public Matrix subColumnVector(final Matrix vector) {
+    checkImpl(vector);
+    return new MatrixJBLASImpl(jblasMatrix.subColumnVector(((MatrixJBLASImpl) vector).jblasMatrix));
   }
 
   @Override
-  public Matrix subiColumnVector(final Matrix v) {
-    checkImpl(v);
-    matrix.subiColumnVector(((MatrixJBLASImpl) v).matrix);
+  public Matrix subiColumnVector(final Matrix vector) {
+    checkImpl(vector);
+    jblasMatrix.subiColumnVector(((MatrixJBLASImpl) vector).jblasMatrix);
     return this;
   }
 
   @Override
-  public Matrix subRowVector(final Matrix v) {
-    checkImpl(v);
-    return new MatrixJBLASImpl(matrix.subRowVector(((MatrixJBLASImpl) v).matrix));
+  public Matrix subRowVector(final Matrix vector) {
+    checkImpl(vector);
+    return new MatrixJBLASImpl(jblasMatrix.subRowVector(((MatrixJBLASImpl) vector).jblasMatrix));
   }
 
   @Override
-  public Matrix subiRowVector(final Matrix v) {
-    checkImpl(v);
-    matrix.subiRowVector(((MatrixJBLASImpl) v).matrix);
+  public Matrix subiRowVector(final Matrix vector) {
+    checkImpl(vector);
+    jblasMatrix.subiRowVector(((MatrixJBLASImpl) vector).jblasMatrix);
     return this;
   }
 
   @Override
-  public Matrix rsub(final float v) {
-    return new MatrixJBLASImpl(matrix.rsub(v));
+  public Matrix rsub(final float value) {
+    return new MatrixJBLASImpl(jblasMatrix.rsub(value));
   }
 
   @Override
-  public Matrix rsubi(final float v) {
-    matrix.rsubi(v);
+  public Matrix rsubi(final float value) {
+    jblasMatrix.rsubi(value);
     return this;
   }
 
   @Override
-  public Matrix rsub(final Matrix m) {
-    checkImpl(m);
-    return new MatrixJBLASImpl(matrix.rsub(((MatrixJBLASImpl) m).matrix));
+  public Matrix rsub(final Matrix matrix) {
+    checkImpl(matrix);
+    return new MatrixJBLASImpl(jblasMatrix.rsub(((MatrixJBLASImpl) matrix).jblasMatrix));
   }
 
   @Override
-  public Matrix rsubi(final Matrix m) {
-    checkImpl(m);
-    matrix.rsubi(((MatrixJBLASImpl) m).matrix);
+  public Matrix rsubi(final Matrix matrix) {
+    checkImpl(matrix);
+    jblasMatrix.rsubi(((MatrixJBLASImpl) matrix).jblasMatrix);
     return this;
   }
 
   @Override
-  public Matrix mul(final float v) {
-    return new MatrixJBLASImpl(matrix.mul(v));
+  public Matrix mul(final float value) {
+    return new MatrixJBLASImpl(jblasMatrix.mul(value));
   }
 
   @Override
-  public Matrix muli(final float v) {
-    matrix.muli(v);
+  public Matrix muli(final float value) {
+    jblasMatrix.muli(value);
     return this;
   }
 
   @Override
-  public Matrix mul(final Matrix m) {
-    checkImpl(m);
-    return new MatrixJBLASImpl(matrix.mul(((MatrixJBLASImpl) m).matrix));
+  public Matrix mul(final Matrix matrix) {
+    checkImpl(matrix);
+    return new MatrixJBLASImpl(jblasMatrix.mul(((MatrixJBLASImpl) matrix).jblasMatrix));
   }
 
   @Override
-  public Matrix muli(final Matrix m) {
-    checkImpl(m);
-    matrix.muli(((MatrixJBLASImpl) m).matrix);
+  public Matrix muli(final Matrix matrix) {
+    checkImpl(matrix);
+    jblasMatrix.muli(((MatrixJBLASImpl) matrix).jblasMatrix);
     return this;
   }
 
   @Override
-  public Matrix mulColumnVector(final Matrix v) {
-    checkImpl(v);
-    return new MatrixJBLASImpl(matrix.mulColumnVector(((MatrixJBLASImpl) v).matrix));
+  public Matrix mulColumnVector(final Matrix vector) {
+    checkImpl(vector);
+    return new MatrixJBLASImpl(jblasMatrix.mulColumnVector(((MatrixJBLASImpl) vector).jblasMatrix));
   }
 
   @Override
-  public Matrix muliColumnVector(final Matrix v) {
-    checkImpl(v);
-    matrix.muliColumnVector(((MatrixJBLASImpl) v).matrix);
+  public Matrix muliColumnVector(final Matrix vector) {
+    checkImpl(vector);
+    jblasMatrix.muliColumnVector(((MatrixJBLASImpl) vector).jblasMatrix);
     return this;
   }
 
   @Override
-  public Matrix mulRowVector(final Matrix v) {
-    checkImpl(v);
-    return new MatrixJBLASImpl(matrix.mulRowVector(((MatrixJBLASImpl) v).matrix));
+  public Matrix mulRowVector(final Matrix vector) {
+    checkImpl(vector);
+    return new MatrixJBLASImpl(jblasMatrix.mulRowVector(((MatrixJBLASImpl) vector).jblasMatrix));
   }
 
   @Override
-  public Matrix muliRowVector(final Matrix v) {
-    checkImpl(v);
-    matrix.muliRowVector(((MatrixJBLASImpl) v).matrix);
+  public Matrix muliRowVector(final Matrix vector) {
+    checkImpl(vector);
+    jblasMatrix.muliRowVector(((MatrixJBLASImpl) vector).jblasMatrix);
     return this;
   }
 
   @Override
-  public Matrix div(final float v) {
-    return new MatrixJBLASImpl(matrix.div(v));
+  public Matrix div(final float value) {
+    return new MatrixJBLASImpl(jblasMatrix.div(value));
   }
 
   @Override
-  public Matrix divi(final float v) {
-    matrix.divi(v);
+  public Matrix divi(final float value) {
+    jblasMatrix.divi(value);
     return this;
   }
 
   @Override
-  public Matrix div(final Matrix m) {
-    checkImpl(m);
-    return new MatrixJBLASImpl(matrix.div(((MatrixJBLASImpl) m).matrix));
+  public Matrix div(final Matrix matrix) {
+    checkImpl(matrix);
+    return new MatrixJBLASImpl(jblasMatrix.div(((MatrixJBLASImpl) matrix).jblasMatrix));
   }
 
   @Override
-  public Matrix divi(final Matrix m) {
-    checkImpl(m);
-    matrix.divi(((MatrixJBLASImpl) m).matrix);
+  public Matrix divi(final Matrix matrix) {
+    checkImpl(matrix);
+    jblasMatrix.divi(((MatrixJBLASImpl) matrix).jblasMatrix);
     return this;
   }
 
   @Override
-  public Matrix divColumnVector(final Matrix v) {
-    checkImpl(v);
-    return new MatrixJBLASImpl(matrix.divColumnVector(((MatrixJBLASImpl) v).matrix));
+  public Matrix divColumnVector(final Matrix vector) {
+    checkImpl(vector);
+    return new MatrixJBLASImpl(jblasMatrix.divColumnVector(((MatrixJBLASImpl) vector).jblasMatrix));
   }
 
   @Override
-  public Matrix diviColumnVector(final Matrix v) {
-    checkImpl(v);
-    matrix.diviColumnVector(((MatrixJBLASImpl) v).matrix);
+  public Matrix diviColumnVector(final Matrix vector) {
+    checkImpl(vector);
+    jblasMatrix.diviColumnVector(((MatrixJBLASImpl) vector).jblasMatrix);
     return this;
   }
 
   @Override
-  public Matrix divRowVector(final Matrix v) {
-    checkImpl(v);
-    return new MatrixJBLASImpl(matrix.divRowVector(((MatrixJBLASImpl) v).matrix));
+  public Matrix divRowVector(final Matrix vector) {
+    checkImpl(vector);
+    return new MatrixJBLASImpl(jblasMatrix.divRowVector(((MatrixJBLASImpl) vector).jblasMatrix));
   }
 
   @Override
-  public Matrix diviRowVector(final Matrix v) {
-    checkImpl(v);
-    matrix.diviRowVector(((MatrixJBLASImpl) v).matrix);
+  public Matrix diviRowVector(final Matrix vector) {
+    checkImpl(vector);
+    jblasMatrix.diviRowVector(((MatrixJBLASImpl) vector).jblasMatrix);
     return this;
   }
 
   @Override
-  public Matrix rdiv(final float v) {
-    return new MatrixJBLASImpl(matrix.rdiv(v));
+  public Matrix rdiv(final float value) {
+    return new MatrixJBLASImpl(jblasMatrix.rdiv(value));
   }
 
   @Override
-  public Matrix rdivi(final float v) {
-    matrix.rdivi(v);
+  public Matrix rdivi(final float value) {
+    jblasMatrix.rdivi(value);
     return this;
   }
 
   @Override
-  public Matrix rdiv(final Matrix m) {
-    checkImpl(m);
-    return new MatrixJBLASImpl(matrix.rdiv(((MatrixJBLASImpl) m).matrix));
+  public Matrix rdiv(final Matrix matrix) {
+    checkImpl(matrix);
+    return new MatrixJBLASImpl(jblasMatrix.rdiv(((MatrixJBLASImpl) matrix).jblasMatrix));
   }
 
   @Override
-  public Matrix rdivi(final Matrix m) {
-    checkImpl(m);
-    matrix.rdivi(((MatrixJBLASImpl) m).matrix);
+  public Matrix rdivi(final Matrix matrix) {
+    checkImpl(matrix);
+    jblasMatrix.rdivi(((MatrixJBLASImpl) matrix).jblasMatrix);
     return this;
   }
 
   @Override
-  public Matrix mmul(final Matrix m) {
-    checkImpl(m);
-    return new MatrixJBLASImpl(matrix.mmul(((MatrixJBLASImpl) m).matrix));
+  public Matrix mmul(final Matrix matrix) {
+    checkImpl(matrix);
+    return new MatrixJBLASImpl(jblasMatrix.mmul(((MatrixJBLASImpl) matrix).jblasMatrix));
   }
 
   @Override
-  public Matrix mmuli(final Matrix m) {
-    checkImpl(m);
-    matrix.mmuli(((MatrixJBLASImpl) m).matrix);
+  public Matrix mmuli(final Matrix matrix) {
+    checkImpl(matrix);
+    jblasMatrix.mmuli(((MatrixJBLASImpl) matrix).jblasMatrix);
     return this;
   }
 
   @Override
   public float max() {
-    return matrix.max();
+    return jblasMatrix.max();
   }
 
   @Override
   public Matrix columnMaxs() {
-    return new MatrixJBLASImpl(matrix.columnMaxs());
+    return new MatrixJBLASImpl(jblasMatrix.columnMaxs());
   }
 
   @Override
   public Matrix rowMaxs() {
-    return new MatrixJBLASImpl(matrix.rowMaxs());
+    return new MatrixJBLASImpl(jblasMatrix.rowMaxs());
   }
 
   @Override
   public float min() {
-    return matrix.min();
+    return jblasMatrix.min();
   }
 
   @Override
   public Matrix columnMins() {
-    return new MatrixJBLASImpl(matrix.columnMins());
+    return new MatrixJBLASImpl(jblasMatrix.columnMins());
   }
 
   @Override
   public Matrix rowMins() {
-    return new MatrixJBLASImpl(matrix.rowMins());
+    return new MatrixJBLASImpl(jblasMatrix.rowMins());
   }
 
   @Override
   public Matrix columnSums() {
-    return new MatrixJBLASImpl(matrix.columnSums());
+    return new MatrixJBLASImpl(jblasMatrix.columnSums());
   }
 
   @Override
   public Matrix rowSums() {
-    return new MatrixJBLASImpl(matrix.rowSums());
+    return new MatrixJBLASImpl(jblasMatrix.rowSums());
   }
 
   @Override
   public float sum() {
-    return matrix.sum();
+    return jblasMatrix.sum();
   }
 
   @Override
-  public boolean compare(final Matrix m, final float tolerance) {
-    if (m instanceof MatrixJBLASImpl) {
-      return matrix.compare(((MatrixJBLASImpl) m).matrix, tolerance);
+  public boolean compare(final Matrix matrix, final float tolerance) {
+    if (matrix instanceof MatrixJBLASImpl) {
+      return jblasMatrix.compare(((MatrixJBLASImpl) matrix).jblasMatrix, tolerance);
     }
     return false;
   }
@@ -461,26 +461,26 @@ public class MatrixJBLASImpl implements Matrix {
   @Override
   public boolean equals(final Object o) {
     if (o instanceof MatrixJBLASImpl) {
-      return matrix.equals(((MatrixJBLASImpl) o).matrix);
+      return jblasMatrix.equals(((MatrixJBLASImpl) o).jblasMatrix);
     }
     return false;
   }
 
   @Override
   public int hashCode() {
-    return matrix.hashCode();
+    return jblasMatrix.hashCode();
   }
 
   public static MatrixJBLASImpl concatHorizontally(final MatrixJBLASImpl a, final MatrixJBLASImpl b) {
-    return new MatrixJBLASImpl(FloatMatrix.concatHorizontally(a.matrix, b.matrix));
+    return new MatrixJBLASImpl(FloatMatrix.concatHorizontally(a.jblasMatrix, b.jblasMatrix));
   }
 
   public static MatrixJBLASImpl concatVertically(final MatrixJBLASImpl a, final MatrixJBLASImpl b) {
-    return new MatrixJBLASImpl(FloatMatrix.concatVertically(a.matrix, b.matrix));
+    return new MatrixJBLASImpl(FloatMatrix.concatVertically(a.jblasMatrix, b.jblasMatrix));
   }
 
-  private void checkImpl(final Matrix m) {
-    if (!(m instanceof MatrixJBLASImpl)) {
+  private void checkImpl(final Matrix matrix) {
+    if (!(matrix instanceof MatrixJBLASImpl)) {
       throw new IllegalArgumentException("The given matrix should be JBLAS based");
     }
   }

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/blas/jblas/MatrixJBLASImpl.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/blas/jblas/MatrixJBLASImpl.java
@@ -404,6 +404,51 @@ public class MatrixJBLASImpl implements Matrix {
   }
 
   @Override
+  public float max() {
+    return matrix.max();
+  }
+
+  @Override
+  public Matrix columnMaxs() {
+    return new MatrixJBLASImpl(matrix.columnMaxs());
+  }
+
+  @Override
+  public Matrix rowMaxs() {
+    return new MatrixJBLASImpl(matrix.rowMaxs());
+  }
+
+  @Override
+  public float min() {
+    return matrix.min();
+  }
+
+  @Override
+  public Matrix columnMins() {
+    return new MatrixJBLASImpl(matrix.columnMins());
+  }
+
+  @Override
+  public Matrix rowMins() {
+    return new MatrixJBLASImpl(matrix.rowMins());
+  }
+
+  @Override
+  public Matrix columnSums() {
+    return new MatrixJBLASImpl(matrix.columnSums());
+  }
+
+  @Override
+  public Matrix rowSums() {
+    return new MatrixJBLASImpl(matrix.rowSums());
+  }
+
+  @Override
+  public float sum() {
+    return matrix.sum();
+  }
+
+  @Override
   public boolean compare(final Matrix m, final float tolerance) {
     if (m instanceof MatrixJBLASImpl) {
       return matrix.compare(((MatrixJBLASImpl) m).matrix, tolerance);

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/blas/jblas/package-info.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/blas/jblas/package-info.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright (C) 2015 Seoul National University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * BLAS implementation based on JBLAS.
+ */
+package edu.snu.dolphin.dnn.blas.jblas;

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/blas/package-info.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/blas/package-info.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright (C) 2015 Seoul National University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Interfaces and classes for BLAS (Basic Linear Algebra Subprograms).
+ */
+package edu.snu.dolphin.dnn.blas;

--- a/dolphin-dnn/src/test/java/edu/snu/dolphin/dnn/blas/function/IdentityTest.java
+++ b/dolphin-dnn/src/test/java/edu/snu/dolphin/dnn/blas/function/IdentityTest.java
@@ -51,13 +51,13 @@ public final class IdentityTest {
 
   @Test
   public void testIdentityApply() {
-    final Matrix output = Function.Factory.getFunction("identity").apply(input);
+    final Matrix output = FunctionFactory.getSingleInstance("identity").apply(input);
     assertTrue(expectedOutput.compare(output, TOLERANCE));
   }
 
   @Test
   public void testIdentityDerivative() {
-    final Matrix derivative = Function.Factory.getFunction("identity").derivative(expectedOutput);
+    final Matrix derivative = FunctionFactory.getSingleInstance("identity").derivative(expectedOutput);
     assertTrue(expectedDerivative.compare(derivative, TOLERANCE));
   }
 }

--- a/dolphin-dnn/src/test/java/edu/snu/dolphin/dnn/blas/function/IdentityTest.java
+++ b/dolphin-dnn/src/test/java/edu/snu/dolphin/dnn/blas/function/IdentityTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2015 Seoul National University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.snu.dolphin.dnn.blas.function;
+
+import edu.snu.dolphin.dnn.blas.Matrix;
+import edu.snu.dolphin.dnn.blas.MatrixFactory;
+import edu.snu.dolphin.dnn.blas.jblas.MatrixJBLASFactory;
+import org.apache.reef.tang.Configuration;
+import org.apache.reef.tang.Tang;
+import org.apache.reef.tang.exceptions.InjectionException;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Class for testing {@link Identity}.
+ */
+public final class IdentityTest {
+
+  private static final float TOLERANCE = 1e-6f;
+
+  private Matrix input;
+  private Matrix expectedOutput;
+  private Matrix expectedDerivative;
+
+  @Before
+  public void setup() throws InjectionException {
+    final Configuration conf = Tang.Factory.getTang().newConfigurationBuilder()
+        .bindImplementation(MatrixFactory.class, MatrixJBLASFactory.class)
+        .build();
+    final MatrixFactory matrixFactory = Tang.Factory.getTang().newInjector(conf).getInstance(MatrixFactory.class);
+
+    this.input = matrixFactory.create(new float[][]{{1.0f, 2.0f, 3.0f}, {4.0f, 5.0f, 6.0f}});
+    this.expectedOutput = input.dup();
+    this.expectedDerivative = matrixFactory.ones(input.getRows(), input.getColumns());
+  }
+
+  @Test
+  public void testIdentityApply() {
+    final Matrix output = Function.Factory.getFunction("identity").apply(input);
+    assertTrue(expectedOutput.compare(output, TOLERANCE));
+  }
+
+  @Test
+  public void testIdentityDerivative() {
+    final Matrix derivative = Function.Factory.getFunction("identity").derivative(expectedOutput);
+    assertTrue(expectedDerivative.compare(derivative, TOLERANCE));
+  }
+}

--- a/dolphin-dnn/src/test/java/edu/snu/dolphin/dnn/blas/function/ReLUTest.java
+++ b/dolphin-dnn/src/test/java/edu/snu/dolphin/dnn/blas/function/ReLUTest.java
@@ -53,13 +53,13 @@ public final class ReLUTest {
 
   @Test
   public void testReLUApply() {
-    final Matrix output = Function.Factory.getFunction("relu").apply(input);
+    final Matrix output = FunctionFactory.getSingleInstance("relu").apply(input);
     assertTrue(expectedOutput.compare(output, TOLERANCE));
   }
 
   @Test
   public void testReLUDerivative() {
-    final Matrix derivative = Function.Factory.getFunction("relu").derivative(expectedOutput);
+    final Matrix derivative = FunctionFactory.getSingleInstance("relu").derivative(expectedOutput);
     assertTrue(expectedDerivative.compare(derivative, TOLERANCE));
   }
 }

--- a/dolphin-dnn/src/test/java/edu/snu/dolphin/dnn/blas/function/ReLUTest.java
+++ b/dolphin-dnn/src/test/java/edu/snu/dolphin/dnn/blas/function/ReLUTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2015 Seoul National University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.snu.dolphin.dnn.blas.function;
+
+import edu.snu.dolphin.dnn.blas.Matrix;
+import edu.snu.dolphin.dnn.blas.MatrixFactory;
+import edu.snu.dolphin.dnn.blas.jblas.MatrixJBLASFactory;
+import org.apache.reef.tang.Configuration;
+import org.apache.reef.tang.Tang;
+import org.apache.reef.tang.exceptions.InjectionException;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Class for testing {@link ReLU}.
+ */
+public final class ReLUTest {
+
+  private static final float TOLERANCE = 1e-6f;
+
+  private Matrix input;
+  private Matrix expectedOutput;
+  private Matrix expectedDerivative;
+
+  @Before
+  public void setup() throws InjectionException {
+    final Configuration conf = Tang.Factory.getTang().newConfigurationBuilder()
+        .bindImplementation(MatrixFactory.class, MatrixJBLASFactory.class)
+        .build();
+    final MatrixFactory matrixFactory = Tang.Factory.getTang().newInjector(conf).getInstance(MatrixFactory.class);
+
+    this.input = matrixFactory.create(new float[][]{{1.0f, -2.0f, 3.0f}, {-4.0f, 5.0f, -6.0f}});
+    this.expectedOutput = matrixFactory.create(new float[][]{
+        {1.0f, 0.0f, 3.0f}, {0.0f, 5.0f, 0.0f}});
+    this.expectedDerivative = matrixFactory.create(new float[][]{
+        {1.0f, 0.0f, 1.0f}, {0.0f, 1.0f, 0.0f}});
+  }
+
+  @Test
+  public void testReLUApply() {
+    final Matrix output = Function.Factory.getFunction("relu").apply(input);
+    assertTrue(expectedOutput.compare(output, TOLERANCE));
+  }
+
+  @Test
+  public void testReLUDerivative() {
+    final Matrix derivative = Function.Factory.getFunction("relu").derivative(expectedOutput);
+    assertTrue(expectedDerivative.compare(derivative, TOLERANCE));
+  }
+}

--- a/dolphin-dnn/src/test/java/edu/snu/dolphin/dnn/blas/function/SigmoidTest.java
+++ b/dolphin-dnn/src/test/java/edu/snu/dolphin/dnn/blas/function/SigmoidTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2015 Seoul National University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.snu.dolphin.dnn.blas.function;
+
+import edu.snu.dolphin.dnn.blas.Matrix;
+import edu.snu.dolphin.dnn.blas.MatrixFactory;
+import edu.snu.dolphin.dnn.blas.jblas.MatrixJBLASFactory;
+import org.apache.reef.tang.Configuration;
+import org.apache.reef.tang.Tang;
+import org.apache.reef.tang.exceptions.InjectionException;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Class for testing {@link Sigmoid}.
+ */
+public final class SigmoidTest {
+
+  private static final float TOLERANCE = 1e-6f;
+
+  private Matrix input;
+  private Matrix expectedOutput;
+  private Matrix expectedDerivative;
+
+  @Before
+  public void setup() throws InjectionException {
+    final Configuration conf = Tang.Factory.getTang().newConfigurationBuilder()
+        .bindImplementation(MatrixFactory.class, MatrixJBLASFactory.class)
+        .build();
+    final MatrixFactory matrixFactory = Tang.Factory.getTang().newInjector(conf).getInstance(MatrixFactory.class);
+
+    this.input = matrixFactory.create(new float[][]{{1.0f, 2.0f, 3.0f}, {4.0f, 5.0f, 6.0f}});
+    this.expectedOutput = matrixFactory.create(new float[][]{
+        {7.310585786e-01f, 8.807970780e-01f, 9.525741268e-01f},
+        {9.820137900e-01f, 9.933071491e-01f, 9.975273768e-01f}});
+    this.expectedDerivative = matrixFactory.create(new float[][]{
+        {1.966119332e-01f, 1.049935854e-01f, 4.517665973e-02f},
+        {1.766270621e-02f, 6.648056671e-03f, 2.466509291e-03f}});
+  }
+
+  @Test
+  public void testSigmoidApply() {
+    final Matrix output = Function.Factory.getFunction("sigmoid").apply(input);
+    assertTrue(expectedOutput.compare(output, TOLERANCE));
+  }
+
+  @Test
+  public void testSigmoidDerivative() {
+    final Matrix derivative = Function.Factory.getFunction("sigmoid").derivative(expectedOutput);
+    assertTrue(expectedDerivative.compare(derivative, TOLERANCE));
+  }
+}

--- a/dolphin-dnn/src/test/java/edu/snu/dolphin/dnn/blas/function/SigmoidTest.java
+++ b/dolphin-dnn/src/test/java/edu/snu/dolphin/dnn/blas/function/SigmoidTest.java
@@ -55,13 +55,13 @@ public final class SigmoidTest {
 
   @Test
   public void testSigmoidApply() {
-    final Matrix output = Function.Factory.getFunction("sigmoid").apply(input);
+    final Matrix output = FunctionFactory.getSingleInstance("sigmoid").apply(input);
     assertTrue(expectedOutput.compare(output, TOLERANCE));
   }
 
   @Test
   public void testSigmoidDerivative() {
-    final Matrix derivative = Function.Factory.getFunction("sigmoid").derivative(expectedOutput);
+    final Matrix derivative = FunctionFactory.getSingleInstance("sigmoid").derivative(expectedOutput);
     assertTrue(expectedDerivative.compare(derivative, TOLERANCE));
   }
 }

--- a/dolphin-dnn/src/test/java/edu/snu/dolphin/dnn/blas/function/TanhTest.java
+++ b/dolphin-dnn/src/test/java/edu/snu/dolphin/dnn/blas/function/TanhTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2015 Seoul National University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.snu.dolphin.dnn.blas.function;
+
+import edu.snu.dolphin.dnn.blas.Matrix;
+import edu.snu.dolphin.dnn.blas.MatrixFactory;
+import edu.snu.dolphin.dnn.blas.jblas.MatrixJBLASFactory;
+import org.apache.reef.tang.Configuration;
+import org.apache.reef.tang.Tang;
+import org.apache.reef.tang.exceptions.InjectionException;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Class for testing {@link Tanh}.
+ */
+public final class TanhTest {
+
+  private static final float TOLERANCE = 1e-6f;
+
+  private Matrix input;
+  private Matrix expectedOutput;
+  private Matrix expectedDerivative;
+
+  @Before
+  public void setup() throws InjectionException {
+    final Configuration conf = Tang.Factory.getTang().newConfigurationBuilder()
+        .bindImplementation(MatrixFactory.class, MatrixJBLASFactory.class)
+        .build();
+    final MatrixFactory matrixFactory = Tang.Factory.getTang().newInjector(conf).getInstance(MatrixFactory.class);
+
+    this.input = matrixFactory.create(new float[][]{{1.0f, 2.0f, 3.0f}, {4.0f, 5.0f, 6.0f}});
+    this.expectedOutput = matrixFactory.create(new float[][]{
+        {7.615941560e-01f, 9.640275801e-01f, 9.950547537e-01f},
+        {9.993292997e-01f, 9.999092043e-01f, 9.999877117e-01f}});
+    this.expectedDerivative = matrixFactory.create(new float[][]{
+        {4.199743416e-01f, 7.065082485e-02f, 9.866037165e-03f},
+        {1.340950683e-03f, 1.815832309e-04f, 2.457654741e-05f}});
+  }
+
+  @Test
+  public void testTanhApply() {
+    final Matrix output = Function.Factory.getFunction("tanh").apply(input);
+    assertTrue(expectedOutput.compare(output, TOLERANCE));
+  }
+
+  @Test
+  public void testTanhDerivative() {
+    final Matrix derivative = Function.Factory.getFunction("tanh").derivative(expectedOutput);
+    assertTrue(expectedDerivative.compare(derivative, TOLERANCE));
+  }
+}

--- a/dolphin-dnn/src/test/java/edu/snu/dolphin/dnn/blas/function/TanhTest.java
+++ b/dolphin-dnn/src/test/java/edu/snu/dolphin/dnn/blas/function/TanhTest.java
@@ -55,13 +55,13 @@ public final class TanhTest {
 
   @Test
   public void testTanhApply() {
-    final Matrix output = Function.Factory.getFunction("tanh").apply(input);
+    final Matrix output = FunctionFactory.getSingleInstance("tanh").apply(input);
     assertTrue(expectedOutput.compare(output, TOLERANCE));
   }
 
   @Test
   public void testTanhDerivative() {
-    final Matrix derivative = Function.Factory.getFunction("tanh").derivative(expectedOutput);
+    final Matrix derivative = FunctionFactory.getSingleInstance("tanh").derivative(expectedOutput);
     assertTrue(expectedDerivative.compare(derivative, TOLERANCE));
   }
 }

--- a/dolphin-dnn/src/test/java/edu/snu/dolphin/dnn/blas/function/package-info.java
+++ b/dolphin-dnn/src/test/java/edu/snu/dolphin/dnn/blas/function/package-info.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright (C) 2015 Seoul National University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Classes for testing {@link edu.snu.dolphin.dnn.blas.function.Function}.
+ */
+package edu.snu.dolphin.dnn.blas.function;

--- a/dolphin-ps/pom.xml
+++ b/dolphin-ps/pom.xml
@@ -73,10 +73,6 @@
       <artifactId>protobuf-java</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.nd4j</groupId>
-      <artifactId>nd4j-java</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.apache.avro</groupId>
       <artifactId>avro</artifactId>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,7 @@
     <avro.version>1.7.7</avro.version>
     <mockito.version>1.10.19</mockito.version>
     <junit.version>4.11</junit.version>
+    <jblas.version>1.2.4</jblas.version>
     <build-helper-maven-plugin.version>1.9.1</build-helper-maven-plugin.version>
   </properties>
 
@@ -128,6 +129,11 @@
         <groupId>org.mockito</groupId>
         <artifactId>mockito-core</artifactId>
         <version>${mockito.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jblas</groupId>
+        <artifactId>jblas</artifactId>
+        <version>${jblas.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
Since `Nd4j` has several problem as mentioned in #142, this pull request introduces a new `Matrix` interface that supports `float` data type and will replace `Nd4j` library, and an implementation based on [jblas](http://jblas.org/).
The interface of `Matrix` is motivated by jblas's `FloatMatrix`, but does not have all methods of `FloatMatrix`. We can add methods which have not been implemented later if needed. 
In addition, this pull request also introduces `Function` interface for activation functions and `MatrixUtils`, a utility class for `Matrix`.
The implementation of a sigmoid function is included in this PR and other implementations such as ReLU, Softmax, Tanh will be added later. `MatrixUtils` provides functions for comparison and `readNumpy()` for loading matrix data from Numpy-compatible plain text files.