### PR TITLE
Separates activation functions from fully connected layers and Introduces activation layers

### DIFF
--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/NeuralNetwork.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/NeuralNetwork.java
@@ -172,6 +172,8 @@ public final class NeuralNetwork {
    */
   public INDArray[] backPropagate(final INDArray[] activations,
                                   final INDArray label) {
+    // Process backpropagation to the second layer
+    // because the error the first layer generates, is not needed to generate a gradient for learning the first layer.
     return backPropagateTo(1, activations, label);
   }
 
@@ -185,11 +187,6 @@ public final class NeuralNetwork {
   public INDArray[] backPropagateTo(final int end,
                                     final INDArray[] activations,
                                     final INDArray label) {
-    if (end == 0) {
-      throw new IllegalArgumentException("The ending layer cannot be the first layer: " +
-          "the error of an input value does not make sense.");
-    }
-
     final int lastLayerIndex = layers.length - 1;
 
     // The first element of activations is the input data.
@@ -211,6 +208,11 @@ public final class NeuralNetwork {
                                         final INDArray nextError) {
     if (begin == layers.length - 1) {
       throw new IllegalArgumentException("The beginning layer of backPropagateFromTo cannot be the output layer");
+    }
+    if (end == 0) {
+      // The errors for generating gradients of the first layer are calculated by the next layer, not the first layer.
+      throw new IllegalArgumentException("The ending layer cannot be the first layer: " +
+          "The error that is propagated to the input is unnecessary to generate gradients for the first layer");
     }
     if (begin < end) {
       throw new IllegalArgumentException(String.format(

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/NeuralNetwork.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/NeuralNetwork.java
@@ -28,6 +28,7 @@ import org.apache.reef.tang.annotations.Parameter;
 import org.apache.reef.tang.exceptions.InjectionException;
 import org.apache.reef.tang.formats.ConfigurationSerializer;
 import org.nd4j.linalg.api.ndarray.INDArray;
+import org.nd4j.linalg.factory.Nd4j;
 import org.nd4j.linalg.util.FeatureUtil;
 
 import javax.inject.Inject;
@@ -59,6 +60,9 @@ public final class NeuralNetwork {
    * The number of processed training inputs.
    */
   private int trainedCount;
+
+  private static final INDArray EMPTY = Nd4j.create(0);
+
 
   @Inject
   private NeuralNetwork(final ConfigurationSerializer configurationSerializer,
@@ -191,7 +195,7 @@ public final class NeuralNetwork {
 
     // The first element of activations is the input data.
     // So, (i + 1)-th element of activations refers to the activation of i-th layer.
-    final INDArray error = layers[lastLayerIndex].backPropagate(activations[lastLayerIndex + 1], label);
+    final INDArray error = layers[lastLayerIndex].backPropagate(label, activations[lastLayerIndex + 1], EMPTY);
 
     if (lastLayerIndex == end) {
       return new INDArray[]{error};

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/NeuralNetwork.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/NeuralNetwork.java
@@ -192,7 +192,12 @@ public final class NeuralNetwork {
     // The first element of activations is the input data.
     // So, (i + 1)-th element of activations refers to the activation of i-th layer.
     final INDArray error = layers[lastLayerIndex].backPropagate(activations[lastLayerIndex + 1], label);
-    return ArrayUtils.add(backPropagateFromTo(lastLayerIndex - 1, end, activations, error), error);
+
+    if (lastLayerIndex == end) {
+      return new INDArray[]{error};
+    } else {
+      return ArrayUtils.add(backPropagateFromTo(lastLayerIndex - 1, end, activations, error), error);
+    }
   }
 
   /**

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/NeuralNetworkDriverParameters.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/NeuralNetworkDriverParameters.java
@@ -18,6 +18,7 @@ package edu.snu.dolphin.dnn;
 import com.google.protobuf.TextFormat;
 import edu.snu.dolphin.bsp.examples.ml.parameters.MaxIterations;
 import edu.snu.dolphin.dnn.NeuralNetworkParameterUpdater.LogPeriod;
+import edu.snu.dolphin.dnn.conf.ActivationLayerConfigurationBuilder;
 import edu.snu.dolphin.dnn.conf.FullyConnectedLayerConfigurationBuilder;
 import edu.snu.dolphin.dnn.conf.NeuralNetworkConfigurationBuilder;
 import edu.snu.dolphin.dnn.layerparam.provider.GroupCommParameterProvider;
@@ -165,6 +166,9 @@ public final class NeuralNetworkDriverParameters {
     switch (layerConf.getType().toLowerCase()) {
     case "fullyconnected":
       return FullyConnectedLayerConfigurationBuilder.newConfigurationBuilder()
+          .fromProtoConfiguration(layerConf).build();
+    case "activation":
+      return ActivationLayerConfigurationBuilder.newConfigurationBuilder()
           .fromProtoConfiguration(layerConf).build();
     default:
       throw new IllegalArgumentException("Illegal layer type: " + layerConf.getType());

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/NeuralNetworkDriverParameters.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/NeuralNetworkDriverParameters.java
@@ -19,6 +19,7 @@ import com.google.protobuf.TextFormat;
 import edu.snu.dolphin.bsp.examples.ml.parameters.MaxIterations;
 import edu.snu.dolphin.dnn.NeuralNetworkParameterUpdater.LogPeriod;
 import edu.snu.dolphin.dnn.conf.ActivationLayerConfigurationBuilder;
+import edu.snu.dolphin.dnn.conf.ActivationWithLossLayerConfigurationBuilder;
 import edu.snu.dolphin.dnn.conf.FullyConnectedLayerConfigurationBuilder;
 import edu.snu.dolphin.dnn.conf.NeuralNetworkConfigurationBuilder;
 import edu.snu.dolphin.dnn.layerparam.provider.GroupCommParameterProvider;
@@ -169,6 +170,9 @@ public final class NeuralNetworkDriverParameters {
           .fromProtoConfiguration(layerConf).build();
     case "activation":
       return ActivationLayerConfigurationBuilder.newConfigurationBuilder()
+          .fromProtoConfiguration(layerConf).build();
+    case "activationwithloss":
+      return ActivationWithLossLayerConfigurationBuilder.newConfigurationBuilder()
           .fromProtoConfiguration(layerConf).build();
     default:
       throw new IllegalArgumentException("Illegal layer type: " + layerConf.getType());

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/conf/ActivationLayerConfigurationBuilder.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/conf/ActivationLayerConfigurationBuilder.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2015 Seoul National University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.snu.dolphin.dnn.conf;
+
+import edu.snu.dolphin.dnn.layerparam.initializer.DefaultLayerParameterInitializer;
+import edu.snu.dolphin.dnn.layerparam.initializer.LayerParameterInitializer;
+import edu.snu.dolphin.dnn.layers.ActivationLayer;
+import edu.snu.dolphin.dnn.layers.LayerBase;
+import edu.snu.dolphin.dnn.proto.NeuralNetworkProtos;
+import org.apache.reef.tang.Configuration;
+import org.apache.reef.tang.Tang;
+import org.apache.reef.util.Builder;
+
+/**
+ * Configuration builder for activation layer.
+ *
+ * The configuration that this builder generates is used to create an activation layer instance.
+ */
+public final class ActivationLayerConfigurationBuilder implements Builder<Configuration> {
+
+  public static ActivationLayerConfigurationBuilder newConfigurationBuilder() {
+    return new ActivationLayerConfigurationBuilder();
+  }
+
+  private int numInput;
+  private int numOutput;
+  private String activationFunction;
+
+  public synchronized ActivationLayerConfigurationBuilder setNumInput(final int numInput) {
+    this.numInput = numInput;
+    return this;
+  }
+
+  public synchronized ActivationLayerConfigurationBuilder setNumOutput(final int numOutput) {
+    this.numOutput = numOutput;
+    return this;
+  }
+
+  public synchronized ActivationLayerConfigurationBuilder setActivationFunction(final String activationFunction) {
+    this.activationFunction = activationFunction;
+    return this;
+  }
+
+  public synchronized ActivationLayerConfigurationBuilder fromProtoConfiguration(
+      final NeuralNetworkProtos.LayerConfiguration protoConf) {
+    numInput = protoConf.getNumInput();
+    numOutput = protoConf.getNumOutput();
+    activationFunction = protoConf.getActivationParam().getActivationFunction();
+    return this;
+  }
+
+  @Override
+  public synchronized Configuration build() {
+    return Tang.Factory.getTang().newConfigurationBuilder()
+        .bindNamedParameter(LayerConfigurationParameters.NumberOfInput.class, String.valueOf(numInput))
+        .bindNamedParameter(LayerConfigurationParameters.NumberOfOutput.class, String.valueOf(numOutput))
+        .bindNamedParameter(LayerConfigurationParameters.ActivationFunction.class, String.valueOf(activationFunction))
+        .bindImplementation(LayerBase.class, ActivationLayer.class)
+        .bindImplementation(LayerParameterInitializer.class, DefaultLayerParameterInitializer.class)
+        .build();
+  }
+}

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/conf/ActivationLayerConfigurationBuilder.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/conf/ActivationLayerConfigurationBuilder.java
@@ -15,8 +15,6 @@
  */
 package edu.snu.dolphin.dnn.conf;
 
-import edu.snu.dolphin.dnn.layerparam.initializer.DefaultLayerParameterInitializer;
-import edu.snu.dolphin.dnn.layerparam.initializer.LayerParameterInitializer;
 import edu.snu.dolphin.dnn.layers.ActivationLayer;
 import edu.snu.dolphin.dnn.layers.LayerBase;
 import edu.snu.dolphin.dnn.proto.NeuralNetworkProtos;
@@ -69,7 +67,6 @@ public final class ActivationLayerConfigurationBuilder implements Builder<Config
         .bindNamedParameter(LayerConfigurationParameters.NumberOfOutput.class, String.valueOf(numOutput))
         .bindNamedParameter(LayerConfigurationParameters.ActivationFunction.class, String.valueOf(activationFunction))
         .bindImplementation(LayerBase.class, ActivationLayer.class)
-        .bindImplementation(LayerParameterInitializer.class, DefaultLayerParameterInitializer.class)
         .build();
   }
 }

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/conf/ActivationWithLossLayerConfigurationBuilder.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/conf/ActivationWithLossLayerConfigurationBuilder.java
@@ -28,7 +28,7 @@ import org.apache.reef.util.Builder;
 /**
  * Configuration builder for activation with loss layer.
  *
- * The configuration that this builder generates is used to create an activation with layer instance.
+ * The configuration that this builder generates is used to create an activation with loss layer instance.
  */
 public final class ActivationWithLossLayerConfigurationBuilder implements Builder<Configuration> {
 

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/conf/ActivationWithLossLayerConfigurationBuilder.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/conf/ActivationWithLossLayerConfigurationBuilder.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (C) 2015 Seoul National University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.snu.dolphin.dnn.conf;
+
+import edu.snu.dolphin.dnn.layers.ActivationWithLossLayer;
+import edu.snu.dolphin.dnn.layers.LayerBase;
+import edu.snu.dolphin.dnn.proto.NeuralNetworkProtos;
+import edu.snu.dolphin.dnn.conf.NeuralNetworkConfigurationParameters.SerializedLayerConfiguartion;
+import org.apache.reef.tang.Configuration;
+import org.apache.reef.tang.Tang;
+import org.apache.reef.tang.formats.AvroConfigurationSerializer;
+import org.apache.reef.tang.formats.ConfigurationSerializer;
+import org.apache.reef.util.Builder;
+
+/**
+ * Configuration builder for activation with loss layer.
+ *
+ * The configuration that this builder generates is used to create an activation with layer instance.
+ */
+public final class ActivationWithLossLayerConfigurationBuilder implements Builder<Configuration> {
+
+  public static ActivationWithLossLayerConfigurationBuilder newConfigurationBuilder() {
+    return new ActivationWithLossLayerConfigurationBuilder();
+  }
+
+  private int numInput;
+  private int numOutput;
+  private String activationFunction;
+  private String lossFunction;
+
+  private ConfigurationSerializer configurationSerializer = new AvroConfigurationSerializer();
+
+  public synchronized ActivationWithLossLayerConfigurationBuilder setNumInput(final int numInput) {
+    this.numInput = numInput;
+    return this;
+  }
+
+  public synchronized ActivationWithLossLayerConfigurationBuilder setNumOutput(final int numOutput) {
+    this.numOutput = numOutput;
+    return this;
+  }
+
+  public synchronized ActivationWithLossLayerConfigurationBuilder setActivationFunction(
+      final String activationFunction) {
+    this.activationFunction = activationFunction;
+    return this;
+  }
+
+  public synchronized ActivationWithLossLayerConfigurationBuilder setLossFunction(final String lossFunction) {
+    this.lossFunction = lossFunction;
+    return this;
+  }
+
+  public synchronized ActivationWithLossLayerConfigurationBuilder fromProtoConfiguration(
+      final NeuralNetworkProtos.LayerConfiguration protoConf) {
+    numInput = protoConf.getNumInput();
+    numOutput = protoConf.getNumOutput();
+    activationFunction = protoConf.getActivationWithLossParam().getActivationFunction();
+    lossFunction = protoConf.getActivationWithLossParam().getLossFunction();
+    return this;
+  }
+
+  @Override
+  public synchronized Configuration build() {
+    final Configuration layerConf = ActivationLayerConfigurationBuilder.newConfigurationBuilder()
+        .setNumInput(numInput)
+        .setNumOutput(numOutput)
+        .setActivationFunction(activationFunction)
+        .build();
+
+    return Tang.Factory.getTang().newConfigurationBuilder()
+        .bindNamedParameter(LayerConfigurationParameters.NumberOfOutput.class, String.valueOf(numOutput))
+        .bindNamedParameter(LayerConfigurationParameters.LossFunction.class, lossFunction)
+        .bindNamedParameter(SerializedLayerConfiguartion.class, configurationSerializer.toString(layerConf))
+        .bindImplementation(LayerBase.class, ActivationWithLossLayer.class)
+        .build();
+  }
+}

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/conf/FullyConnectedLayerConfigurationBuilder.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/conf/FullyConnectedLayerConfigurationBuilder.java
@@ -40,7 +40,6 @@ public final class FullyConnectedLayerConfigurationBuilder implements Builder<Co
   private long randomSeed = System.currentTimeMillis();
   private float initWeight;
   private float initBias;
-  private String activationFunction;
 
   public synchronized FullyConnectedLayerConfigurationBuilder setNumInput(final int numInput) {
     this.numInput = numInput;
@@ -67,11 +66,6 @@ public final class FullyConnectedLayerConfigurationBuilder implements Builder<Co
     return this;
   }
 
-  public synchronized FullyConnectedLayerConfigurationBuilder setActivationFunction(final String activationFunction) {
-    this.activationFunction = activationFunction;
-    return this;
-  }
-
   public synchronized FullyConnectedLayerConfigurationBuilder fromProtoConfiguration(
       final NeuralNetworkProtos.LayerConfiguration protoConf) {
     numInput = protoConf.getNumInput();
@@ -82,7 +76,6 @@ public final class FullyConnectedLayerConfigurationBuilder implements Builder<Co
     }
     initWeight = protoConf.getFullyConnectedParam().getInitWeight();
     initBias = protoConf.getFullyConnectedParam().getInitBias();
-    activationFunction = protoConf.getFullyConnectedParam().getActivationFunction();
     return this;
   }
 
@@ -94,7 +87,6 @@ public final class FullyConnectedLayerConfigurationBuilder implements Builder<Co
         .bindNamedParameter(LayerConfigurationParameters.RandomSeed.class, String.valueOf(randomSeed))
         .bindNamedParameter(LayerConfigurationParameters.InitialWeight.class, String.valueOf(initWeight))
         .bindNamedParameter(LayerConfigurationParameters.InitialBias.class, String.valueOf(initBias))
-        .bindNamedParameter(LayerConfigurationParameters.ActivationFunction.class, String.valueOf(activationFunction))
         .bindImplementation(LayerBase.class, FullyConnectedLayer.class)
         .bindImplementation(LayerParameterInitializer.class, FullyConnectedLayerParameterInitializer.class)
         .build();

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/conf/LayerConfigurationParameters.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/conf/LayerConfigurationParameters.java
@@ -54,4 +54,8 @@ public final class LayerConfigurationParameters {
   @NamedParameter(doc = "activation function of layer node", short_name = "activationFunc")
   public static final class ActivationFunction implements Name<String> {
   }
+
+  @NamedParameter(doc = "loss function of loss layer", short_name = "lossFunc")
+  public static final class LossFunction implements Name<String> {
+  }
 }

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/conf/NeuralNetworkConfigurationParameters.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/conf/NeuralNetworkConfigurationParameters.java
@@ -28,6 +28,10 @@ public final class NeuralNetworkConfigurationParameters {
   private NeuralNetworkConfigurationParameters() {
   }
 
+  @NamedParameter(doc = "a serialized layer configuration")
+  public static final class SerializedLayerConfiguartion implements Name<String> {
+  }
+
   @NamedParameter(doc = "a set of strings that are serializations of network layers")
   public static final class SerializedLayerConfigurationSet implements Name<Set<String>> {
   }

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/layerparam/initializer/DefaultLayerParameterInitializer.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/layerparam/initializer/DefaultLayerParameterInitializer.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2015 Seoul National University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.snu.dolphin.dnn.layerparam.initializer;
+
+import edu.snu.dolphin.dnn.conf.LayerConfigurationParameters;
+import edu.snu.dolphin.dnn.layers.LayerParameter;
+import org.apache.reef.tang.annotations.Parameter;
+
+import javax.inject.Inject;
+
+/**
+ * Default parameter initializer.
+ *
+ * This initializer is for layers which do not have layer parameters (i.e. not learnable layer).
+ */
+public final class DefaultLayerParameterInitializer implements LayerParameterInitializer {
+
+  private final int index;
+
+  @Inject
+  public DefaultLayerParameterInitializer(
+      @Parameter(LayerConfigurationParameters.LayerIndex.class) final int index) {
+    this.index = index;
+  }
+
+  /**
+   * @return the initial parameter of the layer.
+   */
+  public LayerParameter generateInitialParameter() {
+    return LayerParameter.EMPTY;
+  }
+
+  /**
+   * @return the index of the layer.
+   */
+  public int getIndex() {
+    return index;
+  }
+}

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/layerparam/initializer/LayerParameterInitializer.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/layerparam/initializer/LayerParameterInitializer.java
@@ -16,12 +16,14 @@
 package edu.snu.dolphin.dnn.layerparam.initializer;
 
 import edu.snu.dolphin.dnn.layers.LayerParameter;
+import org.apache.reef.tang.annotations.DefaultImplementation;
 
 /**
  * Interface for parameter initializer.
  *
  * The parameter initializer generates the initial parameter of the layer by the layer configuration.
  */
+@DefaultImplementation(DefaultLayerParameterInitializer.class)
 public interface LayerParameterInitializer {
 
   /**

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/layers/ActivationLayer.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/layers/ActivationLayer.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) 2015 Seoul National University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.snu.dolphin.dnn.layers;
+
+import edu.snu.dolphin.dnn.conf.LayerConfigurationParameters.ActivationFunction;
+import edu.snu.dolphin.dnn.conf.LayerConfigurationParameters.LayerIndex;
+import edu.snu.dolphin.dnn.conf.LayerConfigurationParameters.NumberOfOutput;
+import org.apache.reef.tang.annotations.Parameter;
+import org.nd4j.linalg.api.ndarray.INDArray;
+import org.nd4j.linalg.factory.Nd4j;
+
+import javax.inject.Inject;
+
+/**
+ * Activation Layer.
+ */
+public final class ActivationLayer extends LayerBase {
+
+  private final String activationFunction;
+
+  @Inject
+  public ActivationLayer(@Parameter(LayerIndex.class) final int index,
+                         @Parameter(ActivationFunction.class) final String activationFunction,
+                         @Parameter(NumberOfOutput.class) final int numOutput) {
+    super(index, numOutput);
+    this.activationFunction = activationFunction;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public boolean isLearnable() {
+    return false;
+  }
+
+  /**
+   * Applies the specified activation function.
+   * @param input an input value for this layer.
+   * @return the activation.
+   */
+  @Override
+  public INDArray feedForward(final INDArray input) {
+    // apply activation function.
+    return Nd4j.getExecutioner().execAndReturn(Nd4j.getOpFactory().createTransform(activationFunction, input.dup()));
+  }
+
+  /**
+   * Computes an error for this activation layer.
+   * @param input the input value.
+   * @param activation the activation value.
+   * @param nextError an error of the next layer - the one closer to the output layer.
+   * @return an error for this activation layer.
+   */
+  @Override
+  public INDArray backPropagate(final INDArray input, final INDArray activation, final INDArray nextError) {
+    final INDArray derivative = Nd4j.getExecutioner().execAndReturn(
+        Nd4j.getOpFactory().createTransform(activationFunction, activation.dup()).derivative());
+    return nextError.mul(derivative);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public INDArray backPropagate(final INDArray input, final INDArray label) {
+    return input.sub(label);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public LayerParameter generateParameterGradient(final INDArray input, final INDArray error) {
+    throw new RuntimeException("This layer is not learnable");
+  }
+}

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/layers/ActivationLayer.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/layers/ActivationLayer.java
@@ -25,7 +25,10 @@ import org.nd4j.linalg.factory.Nd4j;
 import javax.inject.Inject;
 
 /**
- * Activation Layer.
+ * Activation layer.
+ *
+ * This layer applies the specified activation function to each element of an input, maintaining the input's shape.
+ * This layer does not have parameters, in other words, is not learnable.
  */
 public final class ActivationLayer extends LayerBase {
 

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/layers/ActivationLayer.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/layers/ActivationLayer.java
@@ -72,12 +72,6 @@ public final class ActivationLayer extends LayerBase {
 
   /** {@inheritDoc} */
   @Override
-  public INDArray backPropagate(final INDArray activation, final INDArray label) {
-    return activation.sub(label);
-  }
-
-  /** {@inheritDoc} */
-  @Override
   public LayerParameter generateParameterGradient(final INDArray input, final INDArray error) {
     throw new RuntimeException("This layer is not learnable");
   }

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/layers/ActivationLayer.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/layers/ActivationLayer.java
@@ -72,8 +72,8 @@ public final class ActivationLayer extends LayerBase {
 
   /** {@inheritDoc} */
   @Override
-  public INDArray backPropagate(final INDArray input, final INDArray label) {
-    return input.sub(label);
+  public INDArray backPropagate(final INDArray activation, final INDArray label) {
+    return activation.sub(label);
   }
 
   /** {@inheritDoc} */

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/layers/ActivationWithLossLayer.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/layers/ActivationWithLossLayer.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (C) 2015 Seoul National University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.snu.dolphin.dnn.layers;
+
+import edu.snu.dolphin.dnn.conf.LayerConfigurationParameters.LayerIndex;
+import edu.snu.dolphin.dnn.conf.LayerConfigurationParameters.NumberOfOutput;
+import edu.snu.dolphin.dnn.conf.LayerConfigurationParameters.LossFunction;
+import edu.snu.dolphin.dnn.conf.NeuralNetworkConfigurationParameters.SerializedLayerConfiguartion;
+import org.apache.reef.tang.Configuration;
+import org.apache.reef.tang.Tang;
+import org.apache.reef.tang.annotations.Parameter;
+import org.apache.reef.tang.exceptions.InjectionException;
+import org.apache.reef.tang.formats.ConfigurationSerializer;
+import org.nd4j.linalg.api.ndarray.INDArray;
+
+import javax.inject.Inject;
+import java.io.IOException;
+
+/**
+ * Loss Layer with activation function.
+ */
+public final class ActivationWithLossLayer extends LayerBase {
+
+  private final LayerBase activationLayer;
+  private final String lossFunction;
+
+  @Inject
+  private ActivationWithLossLayer(@Parameter(LayerIndex.class) final int index,
+                                  @Parameter(NumberOfOutput.class) final int numOutput,
+                                  @Parameter(SerializedLayerConfiguartion.class) final String serializedLayerConf,
+                                  final ConfigurationSerializer configurationSerializer,
+                                  @Parameter(LossFunction.class) final String lossFunction) {
+    super(index, numOutput);
+    this.lossFunction = lossFunction;
+
+    try {
+      final Configuration layerConf = Tang.Factory.getTang().newConfigurationBuilder(
+          configurationSerializer.fromString(serializedLayerConf))
+          .bindNamedParameter(LayerIndex.class, String.valueOf(index)) // bind a layer index for injecting inner layer.
+          .build();
+      this.activationLayer = Tang.Factory.getTang().newInjector(layerConf).getInstance(LayerBase.class);
+    } catch (final IOException ioException) {
+      throw new RuntimeException("IOException while de-serializing a layer configuration: " + ioException);
+    } catch (final InjectionException injectException) {
+      throw new RuntimeException("InjectionException while injecting activation layer: " + injectException);
+    }
+  }
+
+  @Override
+  public boolean isLearnable() {
+    return false;
+  }
+
+  @Override
+  public INDArray feedForward(final INDArray input) {
+    return activationLayer.feedForward(input);
+  }
+
+  /**
+   * Compute the error for the specified loss function.
+   * @param label the label value.
+   * @param activation the activation value.
+   * @param nextError an error of the next layer - this argument is ignored.
+   * @return the error with respect to the activation and label values.
+   */
+  @Override
+  public INDArray backPropagate(final INDArray label, final INDArray activation, final INDArray nextError) {
+    switch (lossFunction.toLowerCase()) {
+    case "cross-entropy":
+      return activation.sub(label);
+    default:
+      throw new IllegalArgumentException("Unsupported loss function");
+    }
+
+  }
+
+  @Override
+  public LayerParameter generateParameterGradient(final INDArray input, final INDArray error) {
+    throw new RuntimeException("This layer is not learnable");
+  }
+}

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/layers/ActivationWithLossLayer.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/layers/ActivationWithLossLayer.java
@@ -30,7 +30,15 @@ import javax.inject.Inject;
 import java.io.IOException;
 
 /**
- * Loss Layer with activation function.
+ * Loss layer with activation function.
+ *
+ * This layer is intended to be the last layer, in most cases.
+ * This layer is not learnable.
+ * <br/>
+ * In a forward pass,
+ * this layer applies the specified activation function to each element of an input (same to {@link ActivationLayer}).
+ * In a backward pass,
+ * this layer computes the derivative of the specified loss function.
  */
 public final class ActivationWithLossLayer extends LayerBase {
 
@@ -79,7 +87,7 @@ public final class ActivationWithLossLayer extends LayerBase {
   @Override
   public INDArray backPropagate(final INDArray label, final INDArray activation, final INDArray nextError) {
     switch (lossFunction.toLowerCase()) {
-    case "cross-entropy":
+    case "crossentropy":
       return activation.sub(label);
     default:
       throw new IllegalArgumentException("Unsupported loss function");

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/layers/FullyConnectedLayer.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/layers/FullyConnectedLayer.java
@@ -73,12 +73,6 @@ public final class FullyConnectedLayer extends LayerBase {
 
   /** {@inheritDoc} */
   @Override
-  public INDArray backPropagate(final INDArray activation, final INDArray label) {
-    return activation.sub(label);
-  }
-
-  /** {@inheritDoc} */
-  @Override
   public LayerParameter generateParameterGradient(final INDArray input, final INDArray error) {
     if (!error.isRowVector()) {
       throw new RuntimeException(String.format("Invalid error shape %s. " +

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/layers/FullyConnectedLayer.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/layers/FullyConnectedLayer.java
@@ -25,7 +25,11 @@ import javax.inject.Inject;
 import java.util.Arrays;
 
 /**
- * Fully connected Layer.
+ * Fully connected layer.
+ *
+ * This layer is learnable having the updatable parameter (weight and bias).
+ * This layer computes the inner product between an input and its weight matrix,
+ * and adds the bias vector to its output.
  */
 public final class FullyConnectedLayer extends LayerBase {
 

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/layers/FullyConnectedLayer.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/layers/FullyConnectedLayer.java
@@ -73,8 +73,8 @@ public final class FullyConnectedLayer extends LayerBase {
 
   /** {@inheritDoc} */
   @Override
-  public INDArray backPropagate(final INDArray input, final INDArray label) {
-    return input.sub(label);
+  public INDArray backPropagate(final INDArray activation, final INDArray label) {
+    return activation.sub(label);
   }
 
   /** {@inheritDoc} */

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/layers/LayerBase.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/layers/LayerBase.java
@@ -93,11 +93,11 @@ public abstract class LayerBase {
 
   /**
    * Computes the error. (only for output layer)
-   * @param input an input value for output layer.
+   * @param activation an activation value for output layer.
    * @param label the expected output.
    * @return an error for the output layer with the specified label.
    */
-  public abstract INDArray backPropagate(final INDArray input,
+  public abstract INDArray backPropagate(final INDArray activation,
                                          final INDArray label);
 
   /**

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/layers/LayerBase.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/layers/LayerBase.java
@@ -74,44 +74,37 @@ public abstract class LayerBase {
   public abstract boolean isLearnable();
 
   /**
-   * Applies a derivative of the activation function of the layer to each element of matrix.
-   * @param activation an activation value of the layer.
-   * @return a derivative for the given activation.
-   */
-  public abstract INDArray derivative(final INDArray activation);
-
-  /**
-   * Computes an activation value.
-   * @param input an input value for the layer.
-   * @return a activation value.
+   * Computes an output value.
+   * @param input an input value for this layer.
+   * @return an output value for this layer.
    */
   public abstract INDArray feedForward(final INDArray input);
 
   /**
    * Computes an error.
-   * @param activation an activation value.
-   * @param nextParameter the parameter of the next layer - the one closer to the output layer.
+   * @param input the input value.
+   * @param activation the activation value.
    * @param nextError an error of the next layer - the one closer to the output layer.
-   * @return an error for this layer with the specified activation value.
+   * @return an error for this layer with the specified input value.
    */
-  public abstract INDArray backPropagate(final INDArray activation,
-                                         final LayerParameter nextParameter,
+  public abstract INDArray backPropagate(final INDArray input,
+                                         final INDArray activation,
                                          final INDArray nextError);
 
   /**
    * Computes the error. (only for output layer)
-   * @param activation an activation for output layer.
+   * @param input an input value for output layer.
    * @param label the expected output.
    * @return an error for the output layer with the specified label.
    */
-  public abstract INDArray backPropagate(final INDArray activation,
+  public abstract INDArray backPropagate(final INDArray input,
                                          final INDArray label);
 
   /**
    * Computes a parameter gradient for this layer.
    * @param input an input value for this layer.
    * @param error an error for this layer.
-   * @return a parameter gradient for this layer.
+   * @return a parameter gradient for this layer or {@code null} if this layer is not learnable.
    */
   public abstract LayerParameter generateParameterGradient(final INDArray input, final INDArray error);
 }

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/layers/LayerBase.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/layers/LayerBase.java
@@ -82,7 +82,7 @@ public abstract class LayerBase {
 
   /**
    * Computes an error.
-   * @param input the input value.
+   * @param input the input value for this layer, or the expected output if the layer is a loss layer.
    * @param activation the activation value.
    * @param nextError an error of the next layer - the one closer to the output layer.
    * @return an error for this layer with the specified input value.
@@ -90,15 +90,6 @@ public abstract class LayerBase {
   public abstract INDArray backPropagate(final INDArray input,
                                          final INDArray activation,
                                          final INDArray nextError);
-
-  /**
-   * Computes the error. (only for output layer)
-   * @param activation an activation value for output layer.
-   * @param label the expected output.
-   * @return an error for the output layer with the specified label.
-   */
-  public abstract INDArray backPropagate(final INDArray activation,
-                                         final INDArray label);
 
   /**
    * Computes a parameter gradient for this layer.

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/layers/LayerParameter.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/layers/LayerParameter.java
@@ -16,6 +16,7 @@
 package edu.snu.dolphin.dnn.layers;
 
 import org.nd4j.linalg.api.ndarray.INDArray;
+import org.nd4j.linalg.factory.Nd4j;
 
 /**
  * The parameter of the layer.
@@ -23,6 +24,8 @@ import org.nd4j.linalg.api.ndarray.INDArray;
 public final class LayerParameter {
   private final INDArray weightParam;
   private final INDArray biasParam;
+
+  public static final LayerParameter EMPTY = new LayerParameter(Nd4j.create(0), Nd4j.create(0));
 
   /**
    * @return a new LayerParameter builder.

--- a/dolphin-dnn/src/main/proto/neural_network.proto
+++ b/dolphin-dnn/src/main/proto/neural_network.proto
@@ -20,7 +20,10 @@ message FullyConnectedLayerConfiguration {
   required float init_bias = 1;
   required float init_weight = 2;
   optional uint32 random_seed = 3;
-  required string activation_function = 4;
+}
+
+message ActivationLayerConfiguration {
+  required string activation_function = 1;
 }
 
 message LayerConfiguration {
@@ -28,6 +31,7 @@ message LayerConfiguration {
   required uint32 num_input = 2;
   required uint32 num_output = 3;
   optional FullyConnectedLayerConfiguration fully_connected_param = 4;
+  optional ActivationLayerConfiguration activation_param = 5;
 }
 
 message ParameterProviderConfiguration {

--- a/dolphin-dnn/src/main/proto/neural_network.proto
+++ b/dolphin-dnn/src/main/proto/neural_network.proto
@@ -26,12 +26,18 @@ message ActivationLayerConfiguration {
   required string activation_function = 1;
 }
 
+message ActivationWithLossLayerConfiguration {
+  required string activation_function = 1;
+  required string loss_function = 2;
+}
+
 message LayerConfiguration {
   required string type = 1;
   required uint32 num_input = 2;
   required uint32 num_output = 3;
   optional FullyConnectedLayerConfiguration fully_connected_param = 4;
   optional ActivationLayerConfiguration activation_param = 5;
+  optional ActivationWithLossLayerConfiguration activation_with_loss_param = 6;
 }
 
 message ParameterProviderConfiguration {

--- a/dolphin-dnn/src/test/java/edu/snu/dolphin/dnn/NeuralNetworkTest.java
+++ b/dolphin-dnn/src/test/java/edu/snu/dolphin/dnn/NeuralNetworkTest.java
@@ -86,7 +86,7 @@ public class NeuralNetworkTest {
           .setNumInput(expectedOutput.length())
           .setNumOutput(expectedOutput.length())
           .setActivationFunction("sigmoid")
-          .setLossFunction("cross-entropy")
+          .setLossFunction("crossentropy")
           .build())
       .build();
 

--- a/dolphin-dnn/src/test/java/edu/snu/dolphin/dnn/NeuralNetworkTest.java
+++ b/dolphin-dnn/src/test/java/edu/snu/dolphin/dnn/NeuralNetworkTest.java
@@ -15,6 +15,7 @@
  */
 package edu.snu.dolphin.dnn;
 
+import edu.snu.dolphin.dnn.conf.ActivationLayerConfigurationBuilder;
 import edu.snu.dolphin.dnn.conf.FullyConnectedLayerConfigurationBuilder;
 import edu.snu.dolphin.dnn.conf.NeuralNetworkConfigurationBuilder;
 import edu.snu.dolphin.dnn.layers.LayerParameter;
@@ -47,7 +48,11 @@ public class NeuralNetworkTest {
 
   private final INDArray[] expectedActivations = new INDArray[] {
       Nd4j.create(new float[]{
+          1.37635572407e-02f, 2.03896454414e-02f, 8.84165997677e-03f, 2.93623838992e-02f, -7.07258002822e-03f}),
+      Nd4j.create(new float[]{
           5.03440834992e-01f, 5.05097234769e-01f, 5.02210400594e-01f, 5.07340068629e-01f, 4.98231862363e-01f}),
+      Nd4j.create(new float[]{
+          3.88833699304e-01f, 2.18417981391e-01f, -4.49433566656e-02f}),
       expectedOutput};
 
   private final Configuration neuralNetworkConfiguration = NeuralNetworkConfigurationBuilder.newConfigurationBuilder()
@@ -61,6 +66,11 @@ public class NeuralNetworkTest {
               .setInitWeight(0.0001f)
               .setInitBias(0.0002f)
               .setRandomSeed(10)
+              .build())
+      .addLayerConfiguration(
+          ActivationLayerConfigurationBuilder.newConfigurationBuilder()
+              .setNumInput(numHiddenUnits)
+              .setNumOutput(numHiddenUnits)
               .setActivationFunction("sigmoid")
               .build())
       .addLayerConfiguration(
@@ -70,8 +80,12 @@ public class NeuralNetworkTest {
               .setInitWeight(0.2f)
               .setInitBias(0.3f)
               .setRandomSeed(10)
-              .setActivationFunction("sigmoid")
               .build())
+      .addLayerConfiguration(ActivationLayerConfigurationBuilder.newConfigurationBuilder()
+          .setNumInput(expectedOutput.length())
+          .setNumOutput(expectedOutput.length())
+          .setActivationFunction("sigmoid")
+          .build())
       .build();
 
   private NeuralNetwork neuralNetwork;
@@ -79,6 +93,8 @@ public class NeuralNetworkTest {
   private final INDArray[] expectedErrors = new INDArray[] {
       Nd4j.create(new float[]{
           -1.10814514935e-02f, 4.75458113254e-02f, 2.79511566851e-02f, -3.76325218465e-02f, -6.66430042946e-02f}),
+      Nd4j.create(new float[]{
+          -4.43279052273e-02f, 1.90203012570e-01f, 1.11806811835e-01f, -1.50562534580e-01f, -2.66575350768e-01f}),
       Nd4j.create(new float[]{5.96001904648e-01f, -4.45611556065e-01f, 4.88766051729e-01f})};
 
   private final LayerParameter[] expectedParams = new LayerParameter[]{
@@ -97,6 +113,7 @@ public class NeuralNetworkTest {
               3.10814514935e-04f, -2.75458113254e-04f, -7.95115668513e-05f, 5.76325218465e-04f, 8.66430042946e-04f})
               .reshape(1, numHiddenUnits))
           .build(),
+      LayerParameter.EMPTY, // sigmoid activation layer
       LayerParameter.newBuilder()
           .setWeightParam(Nd4j.create(new float[]{
               -2.03014116811e-01f, 2.44876642191e-01f, 9.28304253913e-02f, 1.87009753641e-02f, 7.41970556867e-03f,
@@ -105,7 +122,8 @@ public class NeuralNetworkTest {
               .reshape(numHiddenUnits, expectedOutput.length()))
           .setBiasParam(Nd4j.create(new float[]{2.94039980954e-01f, 3.04456115561e-01f, 2.95112339483e-01f})
               .reshape(1, expectedOutput.length()))
-          .build()};
+          .build(),
+      LayerParameter.EMPTY}; // sigmoid activation layer
 
   @Before
   public void buildNeuralNetwork() throws InjectionException {
@@ -119,8 +137,8 @@ public class NeuralNetworkTest {
   @Test
   public void feedForwardTest() {
     final INDArray[] activations = neuralNetwork.feedForward(input);
-    assertTrue(Nd4jUtils.equals(activations, expectedActivations, tolerance));
     assertTrue(Nd4jUtils.equals(activations[activations.length - 1], expectedOutput, tolerance));
+    assertTrue(Nd4jUtils.equals(activations, expectedActivations, tolerance));
   }
 
   /**

--- a/dolphin-dnn/src/test/java/edu/snu/dolphin/dnn/NeuralNetworkTest.java
+++ b/dolphin-dnn/src/test/java/edu/snu/dolphin/dnn/NeuralNetworkTest.java
@@ -16,6 +16,7 @@
 package edu.snu.dolphin.dnn;
 
 import edu.snu.dolphin.dnn.conf.ActivationLayerConfigurationBuilder;
+import edu.snu.dolphin.dnn.conf.ActivationWithLossLayerConfigurationBuilder;
 import edu.snu.dolphin.dnn.conf.FullyConnectedLayerConfigurationBuilder;
 import edu.snu.dolphin.dnn.conf.NeuralNetworkConfigurationBuilder;
 import edu.snu.dolphin.dnn.layers.LayerParameter;
@@ -81,10 +82,11 @@ public class NeuralNetworkTest {
               .setInitBias(0.3f)
               .setRandomSeed(10)
               .build())
-      .addLayerConfiguration(ActivationLayerConfigurationBuilder.newConfigurationBuilder()
+      .addLayerConfiguration(ActivationWithLossLayerConfigurationBuilder.newConfigurationBuilder()
           .setNumInput(expectedOutput.length())
           .setNumOutput(expectedOutput.length())
           .setActivationFunction("sigmoid")
+          .setLossFunction("cross-entropy")
           .build())
       .build();
 

--- a/dolphin-dnn/src/test/java/edu/snu/dolphin/dnn/layers/ActivationLayerTest.java
+++ b/dolphin-dnn/src/test/java/edu/snu/dolphin/dnn/layers/ActivationLayerTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2015 Seoul National University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.snu.dolphin.dnn.layers;
+
+import edu.snu.dolphin.dnn.conf.ActivationLayerConfigurationBuilder;
+import edu.snu.dolphin.dnn.conf.LayerConfigurationParameters;
+import edu.snu.dolphin.dnn.util.Nd4jUtils;
+import org.apache.reef.tang.Configuration;
+import org.apache.reef.tang.Tang;
+import org.apache.reef.tang.exceptions.InjectionException;
+import org.junit.Before;
+import org.junit.Test;
+import org.nd4j.linalg.api.ndarray.INDArray;
+import org.nd4j.linalg.factory.Nd4j;
+
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Test class for activation layer.
+ */
+public final class ActivationLayerTest {
+
+  private static final float TOLERANCE = 1e-6f;
+
+  private final INDArray input = Nd4j.create(new float[][]{{-1.0f, -0.5f, 0.5f, 1.0f}, {-0.6f, -0.3f, 0.3f, 0.6f}});
+  private final INDArray expectedSigmoidActivation = Nd4j.create(new float[][]{
+      {2.689414214e-01f, 3.775406688e-01f, 6.224593312e-01f, 7.310585786e-01f},
+      {3.543436938e-01f, 4.255574832e-01f, 5.744425168e-01f, 6.456563062e-01f}});
+  private final INDArray nextError = Nd4j.create(new float[][]{
+      {0.1f, 0.5f, -0.2f, 0.3f},
+      {0.18f, -0.23f, 0.195f, -0.076f}});
+  private final INDArray expectedSigmoidError = Nd4j.create(new float[][]{
+      {1.96611933241e-02f, 1.17501856101e-01f, -4.70007424403e-02f, 5.89835799724e-02f},
+      {4.11811632822e-02f, -5.62254116889e-02f, 4.76693707797e-02f, -1.73876022747e-02f}});
+
+  private LayerBase sigmoidActivationLayer;
+
+  public ActivationLayerTest() {
+  }
+
+  @Before
+  public void setup() throws InjectionException {
+    final Configuration layerConf = Tang.Factory.getTang().newConfigurationBuilder()
+        .bindNamedParameter(LayerConfigurationParameters.LayerIndex.class, String.valueOf(0))
+        .build();
+
+    final ActivationLayerConfigurationBuilder builder = ActivationLayerConfigurationBuilder.newConfigurationBuilder()
+        .setNumInput(input.length())
+        .setNumOutput(expectedSigmoidActivation.length());
+
+    this.sigmoidActivationLayer =
+        Tang.Factory.getTang().newInjector(layerConf, builder.setActivationFunction("sigmoid").build())
+        .getInstance(LayerBase.class);
+  }
+
+  @Test
+  public void testSigmoidActivation() {
+    final INDArray activation = sigmoidActivationLayer.feedForward(input);
+    assertTrue(Nd4jUtils.equals(expectedSigmoidActivation, activation, TOLERANCE));
+  }
+
+  @Test
+  public void testSigmoidBackPropagate() {
+    final INDArray error = sigmoidActivationLayer.backPropagate(input, expectedSigmoidActivation, nextError);
+    assertTrue(Nd4jUtils.equals(expectedSigmoidError, error, TOLERANCE));
+  }
+}

--- a/dolphin-dnn/src/test/java/edu/snu/dolphin/dnn/layers/package-info.java
+++ b/dolphin-dnn/src/test/java/edu/snu/dolphin/dnn/layers/package-info.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright (C) 2015 Seoul National University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Classes for testing neural network layers.
+ */
+package edu.snu.dolphin.dnn.layers;

--- a/dolphin-dnn/src/test/resources/configuration/neuralnet
+++ b/dolphin-dnn/src/test/resources/configuration/neuralnet
@@ -30,6 +30,13 @@ layer {
   fully_connected_param {
     init_weight: 1e-4
     init_bias: 2e-4
+  }
+}
+layer {
+  type: "Activation"
+  num_input: 50
+  num_output: 50
+  activation_param {
     activation_function: "sigmoid"
   }
 }
@@ -40,6 +47,13 @@ layer {
   fully_connected_param {
     init_weight: 1e-2
     init_bias: 2e-2
+  }
+}
+layer {
+  type: "Activation"
+  num_input: 10
+  num_output: 10
+  activation_param {
     activation_function: "sigmoid"
   }
 }

--- a/dolphin-dnn/src/test/resources/configuration/neuralnet
+++ b/dolphin-dnn/src/test/resources/configuration/neuralnet
@@ -55,6 +55,6 @@ layer {
   num_output: 10
   activation_with_loss_param {
     activation_function: "sigmoid"
-    loss_function: "cross-entropy"
+    loss_function: "crossentropy"
   }
 }

--- a/dolphin-dnn/src/test/resources/configuration/neuralnet
+++ b/dolphin-dnn/src/test/resources/configuration/neuralnet
@@ -50,10 +50,11 @@ layer {
   }
 }
 layer {
-  type: "Activation"
+  type: "ActivationWithLoss"
   num_input: 10
   num_output: 10
-  activation_param {
+  activation_with_loss_param {
     activation_function: "sigmoid"
+    loss_function: "cross-entropy"
   }
 }


### PR DESCRIPTION
This pull request removes activation functions from fully connected layers and introduces activation layers. The activation layer applies the activation function specified by the configuration file to its input value.

This pull request includes the following changes
* Changes API of `LayerBase`'s '`backPropagate()` method.
* Introduces `DefaultLayerParameterInitializer` and an empty layer parameter `EMPTY` for layers which are not learnable.
* Changes the type of exceptions related to invalid indices from `RuntimeException` to `IllegalArgumentException`.
* Fixes bugs related to indices in `backPropagateFromTo()`.
* Fixes typo `isForward`.
* Adds test for activation layers.

The change of `LayerBase`'s `backPropagate()` method API includes the removal of `nextParameter` and the introduction of `input`. The introduction of activation layers makes `nextParameter` unnecessary in `backPropagate()`. Also, although the input value is not needed now, it will be needed for computing gradients of some functions such as absolute value and power functions.

This closes #144.