### PR TITLE
Support batch processing for deep neural networks

### DIFF
--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/GroupCommParameterServerTask.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/GroupCommParameterServerTask.java
@@ -157,9 +157,9 @@ public final class GroupCommParameterServerTask implements Task {
 
       // aggregate parameter gradients
       int batchSizeSum = 0;
-      for (final Pair<Integer, LayerParameter[]> integerAndParameterGradientPair : result) {
-        batchSizeSum += integerAndParameterGradientPair.getFirst();
-        final LayerParameter[] parameterGradient = integerAndParameterGradientPair.getSecond();
+      for (final Pair<Integer, LayerParameter[]> intAndParameterGradientPair : result) {
+        batchSizeSum += intAndParameterGradientPair.getFirst();
+        final LayerParameter[] parameterGradient = intAndParameterGradientPair.getSecond();
         for (int index = 0; index < deltaLayerParameters.length; index++) {
           deltaLayerParameters[index].getWeightParam().addi(parameterGradient[index].getWeightParam());
           deltaLayerParameters[index].getBiasParam().addi(parameterGradient[index].getBiasParam());

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/NeuralNetworkDriverParameters.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/NeuralNetworkDriverParameters.java
@@ -24,6 +24,7 @@ import edu.snu.dolphin.dnn.conf.ActivationLayerConfigurationBuilder;
 import edu.snu.dolphin.dnn.conf.ActivationWithLossLayerConfigurationBuilder;
 import edu.snu.dolphin.dnn.conf.FullyConnectedLayerConfigurationBuilder;
 import edu.snu.dolphin.dnn.conf.NeuralNetworkConfigurationBuilder;
+import edu.snu.dolphin.dnn.conf.NeuralNetworkConfigurationParameters.BatchSize;
 import edu.snu.dolphin.dnn.layerparam.provider.GroupCommParameterProvider;
 import edu.snu.dolphin.dnn.layerparam.provider.LocalNeuralNetParameterProvider;
 import edu.snu.dolphin.dnn.layerparam.provider.ParameterProvider;
@@ -57,6 +58,7 @@ public final class NeuralNetworkDriverParameters {
   private final ProviderType providerType;
   private final int logPeriod;
   private final String serializedBlasConfiguration;
+  private final int batchSize;
 
   @NamedParameter(doc = "neural network configuration file path", short_name = "conf")
   public static class ConfigurationPath implements Name<String> {
@@ -93,6 +95,7 @@ public final class NeuralNetworkDriverParameters {
     this.maxIterations = maxIterations;
     this.logPeriod = logPeriod;
     this.serializedBlasConfiguration = configurationSerializer.toString(buildBlasConfiguration(blasLibrary));
+    this.batchSize = neuralNetConf.getBatchSize();
   }
 
   /**
@@ -197,8 +200,7 @@ public final class NeuralNetworkDriverParameters {
     final NeuralNetworkConfigurationBuilder neuralNetConfBuilder =
         NeuralNetworkConfigurationBuilder.newConfigurationBuilder();
 
-    neuralNetConfBuilder.setBatchSize(neuralNetConf.getBatchSize())
-        .setStepsize(neuralNetConf.getStepsize())
+    neuralNetConfBuilder.setStepsize(neuralNetConf.getStepsize())
         .setParameterProviderClass(getParameterProviderClass(neuralNetConf.getParameterProvider().getType()));
 
     // Adds the configuration of each layer.
@@ -243,6 +245,7 @@ public final class NeuralNetworkDriverParameters {
         .bindNamedParameter(MaxIterations.class, String.valueOf(maxIterations))
         .bindNamedParameter(LogPeriod.class, String.valueOf(logPeriod))
         .bindNamedParameter(NeuralNetworkESParameters.SerializedBlasConf.class, serializedBlasConfiguration)
+        .bindNamedParameter(BatchSize.class, String.valueOf(batchSize))
         .build();
   }
 

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/NeuralNetworkESParameters.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/NeuralNetworkESParameters.java
@@ -17,6 +17,7 @@ package edu.snu.dolphin.dnn;
 
 import edu.snu.dolphin.bsp.examples.ml.parameters.MaxIterations;
 import edu.snu.dolphin.dnn.NeuralNetworkDriverParameters.Delimiter;
+import edu.snu.dolphin.dnn.conf.NeuralNetworkConfigurationParameters.BatchSize;
 import org.apache.reef.tang.Configuration;
 import org.apache.reef.tang.Tang;
 import org.apache.reef.tang.annotations.Name;
@@ -36,6 +37,7 @@ public final class NeuralNetworkESParameters {
   private final Configuration blasConfiguration;
   private final String delimiter;
   private final int maxIterations;
+  private final int batchSize;
 
   @NamedParameter(doc = "serialized neural network configuration")
   public static class SerializedNeuralNetConf implements Name<String> {
@@ -50,11 +52,13 @@ public final class NeuralNetworkESParameters {
                                     @Parameter(SerializedNeuralNetConf.class) final String serializedNeuralNetConf,
                                     @Parameter(SerializedBlasConf.class) final String serializedBlasConf,
                                     @Parameter(Delimiter.class) final String delimiter,
-                                    @Parameter(MaxIterations.class) final int maxIterations) throws IOException {
+                                    @Parameter(MaxIterations.class) final int maxIterations,
+                                    @Parameter(BatchSize.class) final int batchSize) throws IOException {
     this.neuralNetworkConfiguration = configurationSerializer.fromString(serializedNeuralNetConf);
     this.blasConfiguration = configurationSerializer.fromString(serializedBlasConf);
     this.delimiter = delimiter;
     this.maxIterations = maxIterations;
+    this.batchSize = batchSize;
   }
 
   /**
@@ -63,6 +67,7 @@ public final class NeuralNetworkESParameters {
   public Configuration getServiceConfiguration() {
     return Tang.Factory.getTang().newConfigurationBuilder(blasConfiguration)
         .bindNamedParameter(Delimiter.class, delimiter)
+        .bindNamedParameter(BatchSize.class, String.valueOf(batchSize))
         .build();
   }
 

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/NeuralNetworkGroupCommDriver.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/NeuralNetworkGroupCommDriver.java
@@ -88,7 +88,7 @@ public final class NeuralNetworkGroupCommDriver {
                 .build())
         .addReduce(ParameterGradientReduce.class,
             ReduceOperatorSpec.newBuilder()
-                .setDataCodecClass(LayerParameterArrayListCodec.class)
+                .setDataCodecClass(IntAndLayerParameterArrayPairListCodec.class)
                 .setReduceFunctionClass(ListReduceFunction.class)
                 .setReceiverId(GroupCommParameterServerTask.TASK_ID)
                 .build())

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/NeuralNetworkGroupCommDriver.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/NeuralNetworkGroupCommDriver.java
@@ -88,8 +88,8 @@ public final class NeuralNetworkGroupCommDriver {
                 .build())
         .addReduce(ParameterGradientReduce.class,
             ReduceOperatorSpec.newBuilder()
-                .setDataCodecClass(IntAndLayerParameterArrayPairListCodec.class)
-                .setReduceFunctionClass(ListReduceFunction.class)
+                .setDataCodecClass(IntAndLayerParameterArrayPairCodec.class)
+                .setReduceFunctionClass(IntAndLayerParameterArrayPairReduceFunction.class)
                 .setReceiverId(GroupCommParameterServerTask.TASK_ID)
                 .build())
         .addReduce(ValidationStatsPairReduce.class,

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/NeuralNetworkParameterUpdater.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/NeuralNetworkParameterUpdater.java
@@ -105,7 +105,7 @@ public final class NeuralNetworkParameterUpdater
    */
   private LayerParameter[] processLayerParameters(final String key,
                                                   final LayerParameter[] parameterGradients) {
-    if (parameterGradients == null || parameterGradients.length == 0 || !key.equals(WHOLE_MODEL)) {
+    if (parameterGradients == null || !key.equals(WHOLE_MODEL)) {
       return null;
     }
 
@@ -171,6 +171,10 @@ public final class NeuralNetworkParameterUpdater
    */
   private LayerParameter[] updateLayerParameter(final LayerParameter[] layerParameters,
                                                 final LayerParameter[] parameterGradients) {
+    if (layerParameters.length != parameterGradients.length) {
+      throw new RuntimeException("The number of parameter gradients is not equal to the number of layers.");
+    }
+
     for (int index = 0; index < layerParameters.length; ++index) {
       final LayerParameter layerParameter = layerParameters[index];
       final LayerParameter parameterGradient = parameterGradients[index];

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/NeuralNetworkParameterUpdater.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/NeuralNetworkParameterUpdater.java
@@ -15,7 +15,6 @@
  */
 package edu.snu.dolphin.dnn;
 
-import edu.snu.dolphin.dnn.blas.MatrixFactory;
 import edu.snu.dolphin.dnn.conf.NeuralNetworkConfigurationParameters;
 import edu.snu.dolphin.dnn.conf.NeuralNetworkConfigurationParameters.SerializedLayerConfigurationSet;
 import edu.snu.dolphin.dnn.data.NeuralNetParamServerData;
@@ -61,7 +60,6 @@ public final class NeuralNetworkParameterUpdater
   public static final String WHOLE_MODEL = "WHOLE_MODEL";
   public static final String VALIDATION = "VALIDATION";
 
-  private final MatrixFactory matrixFactory;
   private final Set<String> serializedLayerConfigurationSet;
   private final float stepsize;
   private final ConfigurationSerializer configurationSerializer;
@@ -71,13 +69,11 @@ public final class NeuralNetworkParameterUpdater
 
   @Inject
   private NeuralNetworkParameterUpdater(
-      final MatrixFactory matrixFactory,
       @Parameter(SerializedLayerConfigurationSet.class) final Set<String> serializedLayerConfigurationSet,
       @Parameter(NeuralNetworkConfigurationParameters.Stepsize.class) final float stepsize,
       final ConfigurationSerializer configurationSerializer,
       @Parameter(LogPeriod.class) final int logPeriod,
       final Injector injector) {
-    this.matrixFactory = matrixFactory;
     this.serializedLayerConfigurationSet = serializedLayerConfigurationSet;
     this.stepsize = stepsize;
     this.configurationSerializer = configurationSerializer;

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/NeuralNetworkParameterUpdater.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/NeuralNetworkParameterUpdater.java
@@ -15,7 +15,6 @@
  */
 package edu.snu.dolphin.dnn;
 
-import edu.snu.dolphin.dnn.blas.Matrix;
 import edu.snu.dolphin.dnn.blas.MatrixFactory;
 import edu.snu.dolphin.dnn.conf.NeuralNetworkConfigurationParameters;
 import edu.snu.dolphin.dnn.conf.NeuralNetworkConfigurationParameters.SerializedLayerConfigurationSet;
@@ -35,8 +34,6 @@ import org.apache.reef.tang.formats.ConfigurationSerializer;
 
 import javax.inject.Inject;
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -103,47 +100,24 @@ public final class NeuralNetworkParameterUpdater
     if (neuralNetParamServerData.isValidationStatsPair()) {
       return new NeuralNetParamServerData(neuralNetParamServerData.getValidationStatsPair());
     } else {
-      return new NeuralNetParamServerData(processLayerParametersList(key,
-          neuralNetParamServerData.getLayerParametersList()));
+      return new NeuralNetParamServerData(processLayerParameters(key, neuralNetParamServerData.getLayerParameters()));
     }
   }
 
   /**
-   * Aggregate parameter gradients by computing the average of all gradients, per layer,
-   * and multiplying the step size.
+   * Multiplies the step size (in-place update).
    */
-  private List<LayerParameter[]> processLayerParametersList(final String key,
-                                                            final List<LayerParameter[]> parameterGradientsList) {
-    if (parameterGradientsList == null || parameterGradientsList.size() == 0 || !key.equals(WHOLE_MODEL)) {
+  private LayerParameter[] processLayerParameters(final String key,
+                                                  final LayerParameter[] parameterGradients) {
+    if (parameterGradients == null || parameterGradients.length == 0 || !key.equals(WHOLE_MODEL)) {
       return null;
     }
 
-    final LayerParameter[] aggregatedParameterGradients = new LayerParameter[parameterGradientsList.get(0).length];
-    for (int index = 0; index < aggregatedParameterGradients.length; index++) {
-      final Matrix weight = parameterGradientsList.get(0)[index].getWeightParam();
-      final Matrix bias = parameterGradientsList.get(0)[index].getBiasParam();
-
-      aggregatedParameterGradients[index] = LayerParameter.newBuilder()
-          .setWeightParam(matrixFactory.zeros(weight.getRows(), weight.getColumns()))
-          .setBiasParam(matrixFactory.zeros(bias.getRows(), bias.getColumns()))
-          .build();
+    for (final LayerParameter parameterGradient : parameterGradients) {
+      parameterGradient.getWeightParam().muli(stepsize);
+      parameterGradient.getBiasParam().muli(stepsize);
     }
-
-    for (final LayerParameter[] parameterGradient : parameterGradientsList) {
-      for (int index = 0; index < aggregatedParameterGradients.length; index++) {
-        aggregatedParameterGradients[index].getWeightParam().addi(parameterGradient[index].getWeightParam());
-        aggregatedParameterGradients[index].getBiasParam().addi(parameterGradient[index].getBiasParam());
-      }
-    }
-
-    for (final LayerParameter sumParameterGradient : aggregatedParameterGradients) {
-      sumParameterGradient.getWeightParam().divi(parameterGradientsList.size()).muli(stepsize);
-      sumParameterGradient.getBiasParam().divi(parameterGradientsList.size()).muli(stepsize);
-    }
-
-    final List<LayerParameter[]> retList = new ArrayList<>(1);
-    retList.add(aggregatedParameterGradients);
-    return retList;
+    return parameterGradients;
   }
 
   /**
@@ -163,7 +137,7 @@ public final class NeuralNetworkParameterUpdater
         throw new RuntimeException("NeuralNetParamServerData oldData and delta have the same key but different format");
       }
       return new NeuralNetParamServerData(updateLayerParameter(
-          oldData.getLayerParametersList().get(0), delta.getLayerParametersList().get(0)));
+          oldData.getLayerParameters(), delta.getLayerParameters()));
     }
   }
 
@@ -197,20 +171,17 @@ public final class NeuralNetworkParameterUpdater
   }
 
   /**
-   * Subtract the parameter gradients from the current layer parameter values.
+   * Subtract the parameter gradients from the current layer parameter values (in-place update).
    */
-  private List<LayerParameter[]> updateLayerParameter(final LayerParameter[] layerParameters,
-                                                      final LayerParameter[] parameterGradients) {
+  private LayerParameter[] updateLayerParameter(final LayerParameter[] layerParameters,
+                                                final LayerParameter[] parameterGradients) {
     for (int index = 0; index < layerParameters.length; ++index) {
       final LayerParameter layerParameter = layerParameters[index];
       final LayerParameter parameterGradient = parameterGradients[index];
       layerParameter.getWeightParam().subi(parameterGradient.getWeightParam());
       layerParameter.getBiasParam().subi(parameterGradient.getBiasParam());
     }
-
-    final List<LayerParameter[]> retList = new ArrayList<>(1);
-    retList.add(layerParameters);
-    return retList;
+    return layerParameters;
   }
 
   /**
@@ -238,7 +209,7 @@ public final class NeuralNetworkParameterUpdater
   /**
    * Use {@link LayerParameterInitializer} to generate initial layer parameter values.
    */
-  private List<LayerParameter[]> initValueLayerParameters() {
+  private LayerParameter[] initValueLayerParameters() {
     final LayerParameter[] layerParameters = new LayerParameter[serializedLayerConfigurationSet.size()];
 
     for (final String serializedInitializerConfiguration : serializedLayerConfigurationSet) {
@@ -258,8 +229,6 @@ public final class NeuralNetworkParameterUpdater
       }
     }
 
-    final List<LayerParameter[]> retList = new ArrayList<>(1);
-    retList.add(layerParameters);
-    return retList;
+    return layerParameters;
   }
 }

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/ParameterServerNeuralNetworkTask.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/ParameterServerNeuralNetworkTask.java
@@ -44,13 +44,13 @@ public final class ParameterServerNeuralNetworkTask implements Task {
 
   private final Validator crossValidator;
   private final Validator trainingValidator;
-  private final DataParser<List<Pair<Pair<Matrix, Integer>, Boolean>>> dataParser;
+  private final DataParser<List<Pair<Pair<Matrix, int[]>, Boolean>>> dataParser;
   private final NeuralNetwork neuralNetwork;
   private final int maxIterations;
   private final ParameterWorker<String, NeuralNetParamServerData, ?> worker;
 
   @Inject
-  ParameterServerNeuralNetworkTask(final DataParser<List<Pair<Pair<Matrix, Integer>, Boolean>>> dataParser,
+  ParameterServerNeuralNetworkTask(final DataParser<List<Pair<Pair<Matrix, int[]>, Boolean>>> dataParser,
                                    final NeuralNetwork neuralNetwork,
                                    @Parameter(MaxIterations.class) final int maxIterations,
                                    final ParameterWorker<String, NeuralNetParamServerData, ?> worker) {
@@ -67,7 +67,7 @@ public final class ParameterServerNeuralNetworkTask implements Task {
   public byte[] call(final byte[] bytes) throws Exception {
     LOG.log(Level.INFO, "ComputeTask.call() commencing....");
 
-    final List<Pair<Pair<Matrix, Integer>, Boolean>> dataSet = dataParser.get();
+    final List<Pair<Pair<Matrix, int[]>, Boolean>> dataSet = dataParser.get();
     for (int i = 0; i < maxIterations; ++i) {
       runIteration(dataSet, neuralNetwork, trainingValidator, crossValidator);
 

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/blas/MatrixUtils.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/blas/MatrixUtils.java
@@ -133,4 +133,19 @@ public final class MatrixUtils {
   public static Matrix createOutputVector(final MatrixFactory matrixFactory, final int index, final int length) {
     return matrixFactory.zeros(length).put(index, 1.0f);
   }
+
+  /**
+   * Creates a matrix of which each row is a one-hot vector specified by each element of the given indices array.
+   * @param matrixFactory a matrix factory used to create a matrix
+   * @param indices the array of indices that indicate the one-hot positions
+   * @param length the length of each row vector, in other words, the number of columns of the return matrix
+   * @return the generated matrix
+   */
+  public static Matrix createOutputMatrix(final MatrixFactory matrixFactory, final int[] indices, final int length) {
+    final Matrix ret = matrixFactory.zeros(indices.length, length);
+    for (int i = 0; i < indices.length; ++i) {
+      ret.put(i, indices[i], 1.0f);
+    }
+    return ret;
+  }
 }

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/conf/NeuralNetworkConfigurationBuilder.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/conf/NeuralNetworkConfigurationBuilder.java
@@ -36,7 +36,6 @@ import java.util.Collection;
 public final class NeuralNetworkConfigurationBuilder implements Builder<Configuration> {
 
   private Collection<String> layerConfigurations = new ArrayList<>();
-  private int batchSize = 1;
   private int index = 0;
   private ConfigurationSerializer configurationSerializer = new AvroConfigurationSerializer();
   private Class<? extends ParameterProvider> parameterProviderClass;
@@ -58,11 +57,6 @@ public final class NeuralNetworkConfigurationBuilder implements Builder<Configur
     return this;
   }
 
-  public synchronized NeuralNetworkConfigurationBuilder setBatchSize(final int batchSize) {
-    this.batchSize = batchSize;
-    return this;
-  }
-
   public synchronized NeuralNetworkConfigurationBuilder setParameterProviderClass(
       final Class<? extends ParameterProvider> parameterProviderClass) {
     this.parameterProviderClass = parameterProviderClass;
@@ -76,8 +70,7 @@ public final class NeuralNetworkConfigurationBuilder implements Builder<Configur
 
   @Override
   public synchronized Configuration build() {
-    final JavaConfigurationBuilder jb = Tang.Factory.getTang().newConfigurationBuilder()
-        .bindNamedParameter(NeuralNetworkConfigurationParameters.BatchSize.class, String.valueOf(batchSize));
+    final JavaConfigurationBuilder jb = Tang.Factory.getTang().newConfigurationBuilder();
 
     for (final String layerConfiguration : layerConfigurations) {
       jb.bindSetEntry(NeuralNetworkConfigurationParameters.SerializedLayerConfigurationSet.class, layerConfiguration);

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/data/IntAndLayerParameterArrayPairCodec.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/data/IntAndLayerParameterArrayPairCodec.java
@@ -38,24 +38,24 @@ public final class IntAndLayerParameterArrayPairCodec
   }
 
   @Override
-  public byte[] encode(final Pair<Integer, LayerParameter[]> integerAndLayerParametersPair) {
+  public byte[] encode(final Pair<Integer, LayerParameter[]> intAndLayerParametersPair) {
     try (final ByteArrayOutputStream bstream = new ByteArrayOutputStream();
          final DataOutputStream dstream = new DataOutputStream(bstream)) {
-      encodeToStream(integerAndLayerParametersPair, dstream);
+      encodeToStream(intAndLayerParametersPair, dstream);
       return bstream.toByteArray();
     } catch (final IOException e) {
-      throw new RuntimeException("IOException during IntegerAndLayerParameterArrayPairCodec.encode()", e);
+      throw new RuntimeException("IOException during IntAndLayerParameterArrayPairCodec.encode()", e);
     }
   }
 
   @Override
-  public void encodeToStream(final Pair<Integer, LayerParameter[]> integerAndLayerParametersPair,
+  public void encodeToStream(final Pair<Integer, LayerParameter[]> intAndLayerParametersPair,
                              final DataOutputStream dstream) {
     try {
-      dstream.writeInt(integerAndLayerParametersPair.getFirst());
-      layerParameterArrayCodec.encodeToStream(integerAndLayerParametersPair.getSecond(), dstream);
+      dstream.writeInt(intAndLayerParametersPair.getFirst());
+      layerParameterArrayCodec.encodeToStream(intAndLayerParametersPair.getSecond(), dstream);
     } catch (final IOException e) {
-      throw new RuntimeException("IOException during IntegerAndLayerParameterArrayPairCodec.encodeToStream()", e);
+      throw new RuntimeException("IOException during IntAndLayerParameterArrayPairCodec.encodeToStream()", e);
     }
   }
 
@@ -64,7 +64,7 @@ public final class IntAndLayerParameterArrayPairCodec
     try (final DataInputStream dstream = new DataInputStream(new ByteArrayInputStream(data))) {
       return decodeFromStream(dstream);
     } catch (final IOException e) {
-      throw new RuntimeException("IOException during IntegerAndLayerParameterArrayPairCodec.decode()", e);
+      throw new RuntimeException("IOException during IntAndLayerParameterArrayPairCodec.decode()", e);
     }
   }
 
@@ -74,7 +74,7 @@ public final class IntAndLayerParameterArrayPairCodec
       final int firstValue = dstream.readInt();
       return new Pair<>(firstValue, layerParameterArrayCodec.decodeFromStream(dstream));
     } catch (final IOException e) {
-      throw new RuntimeException("IOException during IntegerAndLayerParameterArrayPairCodec.decodeFromStream()", e);
+      throw new RuntimeException("IOException during IntAndLayerParameterArrayPairCodec.decodeFromStream()", e);
     }
   }
 }

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/data/IntAndLayerParameterArrayPairCodec.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/data/IntAndLayerParameterArrayPairCodec.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2015 Seoul National University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.snu.dolphin.dnn.data;
+
+import edu.snu.dolphin.dnn.layers.LayerParameter;
+import org.apache.reef.io.network.impl.StreamingCodec;
+import org.apache.reef.io.network.util.Pair;
+import org.apache.reef.io.serialization.Codec;
+
+import javax.inject.Inject;
+import java.io.*;
+
+/**
+ * Serialization codec for a pair of an integer and a layer parameter array.
+ * Internally uses {@link LayerParameterArrayCodec}.
+ */
+public final class IntAndLayerParameterArrayPairCodec
+    implements StreamingCodec<Pair<Integer, LayerParameter[]>>, Codec<Pair<Integer, LayerParameter[]>> {
+
+  private final LayerParameterArrayCodec layerParameterArrayCodec;
+
+  @Inject
+  private IntAndLayerParameterArrayPairCodec(final LayerParameterArrayCodec layerParameterArrayCodec) {
+    this.layerParameterArrayCodec = layerParameterArrayCodec;
+  }
+
+  @Override
+  public byte[] encode(final Pair<Integer, LayerParameter[]> integerAndLayerParametersPair) {
+    try (final ByteArrayOutputStream bstream = new ByteArrayOutputStream();
+         final DataOutputStream dstream = new DataOutputStream(bstream)) {
+      encodeToStream(integerAndLayerParametersPair, dstream);
+      return bstream.toByteArray();
+    } catch (final IOException e) {
+      throw new RuntimeException("IOException during IntegerAndLayerParameterArrayPairCodec.encode()", e);
+    }
+  }
+
+  @Override
+  public void encodeToStream(final Pair<Integer, LayerParameter[]> integerAndLayerParametersPair,
+                             final DataOutputStream dstream) {
+    try {
+      dstream.writeInt(integerAndLayerParametersPair.getFirst());
+      layerParameterArrayCodec.encodeToStream(integerAndLayerParametersPair.getSecond(), dstream);
+    } catch (final IOException e) {
+      throw new RuntimeException("IOException during IntegerAndLayerParameterArrayPairCodec.encodeToStream()", e);
+    }
+  }
+
+  @Override
+  public Pair<Integer, LayerParameter[]> decode(final byte[] data) {
+    try (final DataInputStream dstream = new DataInputStream(new ByteArrayInputStream(data))) {
+      return decodeFromStream(dstream);
+    } catch (final IOException e) {
+      throw new RuntimeException("IOException during IntegerAndLayerParameterArrayPairCodec.decode()", e);
+    }
+  }
+
+  @Override
+  public Pair<Integer, LayerParameter[]> decodeFromStream(final DataInputStream dstream) {
+    try {
+      final int firstValue = dstream.readInt();
+      return new Pair<>(firstValue, layerParameterArrayCodec.decodeFromStream(dstream));
+    } catch (final IOException e) {
+      throw new RuntimeException("IOException during IntegerAndLayerParameterArrayPairCodec.decodeFromStream()", e);
+    }
+  }
+}

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/data/IntAndLayerParameterArrayPairListCodec.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/data/IntAndLayerParameterArrayPairListCodec.java
@@ -47,7 +47,7 @@ public final class IntAndLayerParameterArrayPairListCodec
       encodeToStream(intAndLayerParametersPairList, dstream);
       return bstream.toByteArray();
     } catch (final IOException e) {
-      throw new RuntimeException("IOException during IntegerAndLayerParameterArrayPairListCodec.encode()", e);
+      throw new RuntimeException("IOException during IntAndLayerParameterArrayPairListCodec.encode()", e);
     }
   }
 
@@ -60,7 +60,7 @@ public final class IntAndLayerParameterArrayPairListCodec
         intAndLayerParameterArrayPairCodec.encodeToStream(intAndLayerParameterPair, dstream);
       }
     } catch (final IOException e) {
-      throw new RuntimeException("IOException during IntegerAndLayerParameterArrayPairListCodec.encodeToStream()", e);
+      throw new RuntimeException("IOException during IntAndLayerParameterArrayPairListCodec.encodeToStream()", e);
     }
   }
 
@@ -69,7 +69,7 @@ public final class IntAndLayerParameterArrayPairListCodec
     try (final DataInputStream dstream = new DataInputStream(new ByteArrayInputStream(data))) {
       return decodeFromStream(dstream);
     } catch (final IOException e) {
-      throw new RuntimeException("IOException during IntegerAndLayerParameterArrayPairListCodec.decode()", e);
+      throw new RuntimeException("IOException during IntAndLayerParameterArrayPairListCodec.decode()", e);
     }
   }
 
@@ -83,7 +83,7 @@ public final class IntAndLayerParameterArrayPairListCodec
       }
       return ret;
     } catch (final IOException e) {
-      throw new RuntimeException("IOException during IntegerAndLayerParameterArrayPairListCodec.decodeFromStream()", e);
+      throw new RuntimeException("IOException during IntAndLayerParameterArrayPairListCodec.decodeFromStream()", e);
     }
   }
 }

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/data/IntAndLayerParameterArrayPairListCodec.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/data/IntAndLayerParameterArrayPairListCodec.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (C) 2015 Seoul National University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.snu.dolphin.dnn.data;
+
+import edu.snu.dolphin.dnn.layers.LayerParameter;
+import org.apache.reef.io.network.impl.StreamingCodec;
+import org.apache.reef.io.network.util.Pair;
+import org.apache.reef.io.serialization.Codec;
+
+import javax.inject.Inject;
+import java.io.*;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Serialization codec for a list of pairs of an integer and a layer parameter array.
+ * Internally uses {@link IntAndLayerParameterArrayPairCodec}.
+ */
+public final class IntAndLayerParameterArrayPairListCodec
+    implements StreamingCodec<List<Pair<Integer, LayerParameter[]>>>, Codec<List<Pair<Integer, LayerParameter[]>>> {
+
+  private final IntAndLayerParameterArrayPairCodec intAndLayerParameterArrayPairCodec;
+
+  @Inject
+  private IntAndLayerParameterArrayPairListCodec(
+      final IntAndLayerParameterArrayPairCodec intAndLayerParameterArrayPairCodec) {
+    this.intAndLayerParameterArrayPairCodec = intAndLayerParameterArrayPairCodec;
+  }
+
+  @Override
+  public byte[] encode(final List<Pair<Integer, LayerParameter[]>> intAndLayerParametersPairList) {
+    try (final ByteArrayOutputStream bstream = new ByteArrayOutputStream();
+         final DataOutputStream dstream = new DataOutputStream(bstream)) {
+      encodeToStream(intAndLayerParametersPairList, dstream);
+      return bstream.toByteArray();
+    } catch (final IOException e) {
+      throw new RuntimeException("IOException during IntegerAndLayerParameterArrayPairListCodec.encode()", e);
+    }
+  }
+
+  @Override
+  public void encodeToStream(final List<Pair<Integer, LayerParameter[]>> intAndLayerParameterPairList,
+                             final DataOutputStream dstream) {
+    try {
+      dstream.writeInt(intAndLayerParameterPairList.size());
+      for (final Pair<Integer, LayerParameter[]> intAndLayerParameterPair : intAndLayerParameterPairList) {
+        intAndLayerParameterArrayPairCodec.encodeToStream(intAndLayerParameterPair, dstream);
+      }
+    } catch (final IOException e) {
+      throw new RuntimeException("IOException during IntegerAndLayerParameterArrayPairListCodec.encodeToStream()", e);
+    }
+  }
+
+  @Override
+  public List<Pair<Integer, LayerParameter[]>> decode(final byte[] data) {
+    try (final DataInputStream dstream = new DataInputStream(new ByteArrayInputStream(data))) {
+      return decodeFromStream(dstream);
+    } catch (final IOException e) {
+      throw new RuntimeException("IOException during IntegerAndLayerParameterArrayPairListCodec.decode()", e);
+    }
+  }
+
+  @Override
+  public List<Pair<Integer, LayerParameter[]>> decodeFromStream(final DataInputStream dstream) {
+    try {
+      final int size = dstream.readInt();
+      final List<Pair<Integer, LayerParameter[]>> ret = new ArrayList<>(size);
+      for (int i = 0; i < size; ++i) {
+        ret.add(intAndLayerParameterArrayPairCodec.decodeFromStream(dstream));
+      }
+      return ret;
+    } catch (final IOException e) {
+      throw new RuntimeException("IOException during IntegerAndLayerParameterArrayPairListCodec.decodeFromStream()", e);
+    }
+  }
+}

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/data/IntAndLayerParameterArrayPairReduceFunction.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/data/IntAndLayerParameterArrayPairReduceFunction.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C) 2015 Seoul National University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.snu.dolphin.dnn.data;
+
+import edu.snu.dolphin.dnn.layers.LayerParameter;
+import org.apache.reef.io.network.group.api.operators.Reduce;
+import org.apache.reef.io.network.util.Pair;
+
+import javax.inject.Inject;
+import java.util.Iterator;
+
+/**
+ * Reduce function for pairs of an integer and an array of layer parameters.
+ * Sums the integers and element-wise sums layer parameters.
+ */
+public final class IntAndLayerParameterArrayPairReduceFunction
+    implements Reduce.ReduceFunction<Pair<Integer, LayerParameter[]>> {
+
+  @Inject
+  private IntAndLayerParameterArrayPairReduceFunction() {
+  }
+
+  @Override
+  public Pair<Integer, LayerParameter[]> apply(
+      final Iterable<Pair<Integer, LayerParameter[]>> intAndLayerParameterArrayPair) {
+
+    final Iterator<Pair<Integer, LayerParameter[]>> iterator = intAndLayerParameterArrayPair.iterator();
+    int intSum;
+    final LayerParameter[] layerParameterSum;
+
+    Pair<Integer, LayerParameter[]> element = getNonEmpty(iterator);
+    if (element == null) {
+      return new Pair<>(0, new LayerParameter[0]);
+    }
+    intSum = element.getFirst();
+    layerParameterSum = element.getSecond();
+
+    element = getNonEmpty(iterator);
+    while (element != null) {
+      intSum += element.getFirst();
+      final LayerParameter[] layerParameters = element.getSecond();
+      if (layerParameters.length != layerParameterSum.length) {
+        throw new RuntimeException("The number of layer parameters is not consistent");
+      }
+      for (int i = 0; i < layerParameters.length; ++i) {
+        layerParameterSum[i].getWeightParam().addi(layerParameters[i].getWeightParam());
+        layerParameterSum[i].getBiasParam().addi(layerParameters[i].getBiasParam());
+      }
+      element = getNonEmpty(iterator);
+    }
+
+    return new Pair<>(intSum, layerParameterSum);
+  }
+
+  /**
+   * @param iterator an iterator of pairs of an integer and an array of layer parameters.
+   * @return a non empty pair or {@code null} if such pair does not exist.
+   */
+  private Pair<Integer, LayerParameter[]> getNonEmpty(final Iterator<Pair<Integer, LayerParameter[]>> iterator) {
+    while (iterator.hasNext()) {
+      final Pair<Integer, LayerParameter[]> element = iterator.next();
+      if (element.getFirst() > 0) {
+        return element;
+      }
+    }
+    return null;
+  }
+}

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/data/NeuralNetParamServerData.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/data/NeuralNetParamServerData.java
@@ -20,24 +20,22 @@ import edu.snu.dolphin.dnn.util.ValidationStats;
 import org.apache.reef.io.network.util.Pair;
 import org.apache.reef.util.Optional;
 
-import java.util.List;
-
 /**
  * This class represents the data transmitted between the parameter server and worker.
- * This can contain either a pair of {@link ValidationStats}, or a list of {@link LayerParameter} arrays.
+ * This can contain either a pair of {@link ValidationStats}, or an array of {@link LayerParameter}s.
  */
 public final class NeuralNetParamServerData {
   private final Optional<Pair<ValidationStats, ValidationStats>> validationStatsPair;
-  private final Optional<List<LayerParameter[]>> layerParametersList;
+  private final Optional<LayerParameter[]> layerParameters;
 
   public NeuralNetParamServerData(final Pair<ValidationStats, ValidationStats> validationStatsPair) {
     this.validationStatsPair = Optional.of(validationStatsPair);
-    this.layerParametersList = Optional.empty();
+    this.layerParameters = Optional.empty();
   }
 
-  public NeuralNetParamServerData(final List<LayerParameter[]> layerParametersList) {
+  public NeuralNetParamServerData(final LayerParameter[] layerParameters) {
     this.validationStatsPair = Optional.empty();
-    this.layerParametersList = Optional.of(layerParametersList);
+    this.layerParameters = Optional.of(layerParameters);
   }
 
   public boolean isValidationStatsPair() {
@@ -48,7 +46,7 @@ public final class NeuralNetParamServerData {
     return this.validationStatsPair.get();
   }
 
-  public List<LayerParameter[]> getLayerParametersList() {
-    return this.layerParametersList.get();
+  public LayerParameter[] getLayerParameters() {
+    return this.layerParameters.get();
   }
 }

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/data/NeuralNetParamServerDataCodec.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/data/NeuralNetParamServerDataCodec.java
@@ -22,17 +22,17 @@ import java.io.*;
 
 /**
  * Codec for serializing {@link NeuralNetParamServerData}.
- * Internally uses {@link LayerParameterArrayListCodec} and {@link ValidationStatsPairCodec}.
+ * Internally uses {@link LayerParameterArrayCodec} and {@link ValidationStatsPairCodec}.
  */
 public final class NeuralNetParamServerDataCodec implements Codec<NeuralNetParamServerData> {
 
-  private final LayerParameterArrayListCodec layerParameterArrayListCodec;
+  private final LayerParameterArrayCodec layerParameterArrayCodec;
   private final ValidationStatsPairCodec validationStatsPairCodec;
 
   @Inject
-  private NeuralNetParamServerDataCodec(final LayerParameterArrayListCodec layerParameterArrayListCodec,
+  private NeuralNetParamServerDataCodec(final LayerParameterArrayCodec layerParameterArrayCodec,
                                         final ValidationStatsPairCodec validationStatsPairCodec) {
-    this.layerParameterArrayListCodec = layerParameterArrayListCodec;
+    this.layerParameterArrayCodec = layerParameterArrayCodec;
     this.validationStatsPairCodec = validationStatsPairCodec;
   }
 
@@ -46,7 +46,7 @@ public final class NeuralNetParamServerDataCodec implements Codec<NeuralNetParam
         validationStatsPairCodec.encodeToStream(neuralNetParamServerData.getValidationStatsPair(), dstream);
       } else {
         dstream.writeBoolean(false);
-        layerParameterArrayListCodec.encodeToStream(neuralNetParamServerData.getLayerParametersList(), dstream);
+        layerParameterArrayCodec.encodeToStream(neuralNetParamServerData.getLayerParameters(), dstream);
       }
       return bstream.toByteArray();
 
@@ -62,7 +62,7 @@ public final class NeuralNetParamServerDataCodec implements Codec<NeuralNetParam
       if (isValidationStatsPair) {
         return new NeuralNetParamServerData(validationStatsPairCodec.decodeFromStream(dstream));
       } else {
-        return new NeuralNetParamServerData(layerParameterArrayListCodec.decodeFromStream(dstream));
+        return new NeuralNetParamServerData(layerParameterArrayCodec.decodeFromStream(dstream));
       }
 
     } catch (final IOException e) {

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/data/NeuralNetworkDataParser.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/data/NeuralNetworkDataParser.java
@@ -20,6 +20,8 @@ import edu.snu.dolphin.bsp.core.ParseException;
 import edu.snu.dolphin.dnn.NeuralNetworkDriverParameters.Delimiter;
 import edu.snu.dolphin.dnn.blas.Matrix;
 import edu.snu.dolphin.dnn.blas.MatrixFactory;
+import edu.snu.dolphin.dnn.conf.NeuralNetworkConfigurationParameters.BatchSize;
+import org.apache.commons.lang.ArrayUtils;
 import org.apache.hadoop.io.LongWritable;
 import org.apache.hadoop.io.Text;
 import org.apache.reef.io.data.loading.api.DataSet;
@@ -39,26 +41,29 @@ import static edu.snu.dolphin.dnn.blas.MatrixUtils.readNumpy;
  *
  * Parses Numpy compatible plain text file.
  */
-public final class NeuralNetworkDataParser implements DataParser<List<Pair<Pair<Matrix, Integer>, Boolean>>> {
+public final class NeuralNetworkDataParser implements DataParser<List<Pair<Pair<Matrix, int[]>, Boolean>>> {
 
   private final MatrixFactory matrixFactory;
   private final DataSet<LongWritable, Text> dataSet;
   private final String delimiter;
-  private List<Pair<Pair<Matrix, Integer>, Boolean>> result;
+  private final int batchSize;
+  private List<Pair<Pair<Matrix, int[]>, Boolean>> result;
   private ParseException parseException;
 
   @Inject
   private NeuralNetworkDataParser(final MatrixFactory matrixFactory,
                                   final DataSet<LongWritable, Text> dataSet,
-                                  @Parameter(Delimiter.class)final String delimiter) {
+                                  @Parameter(Delimiter.class)final String delimiter,
+                                  @Parameter(BatchSize.class) final int batchSize) {
     this.matrixFactory = matrixFactory;
     this.dataSet = dataSet;
     this.delimiter = delimiter;
+    this.batchSize = batchSize;
   }
 
   /** {@inheritDoc} */
   @Override
-  public List<Pair<Pair<Matrix, Integer>, Boolean>> get() throws ParseException {
+  public List<Pair<Pair<Matrix, int[]>, Boolean>> get() throws ParseException {
     if (result == null) {
       parse();
     }
@@ -71,7 +76,9 @@ public final class NeuralNetworkDataParser implements DataParser<List<Pair<Pair<
   /** {@inheritDoc} */
   @Override
   public void parse() {
-    final List<Pair<Pair<Matrix, Integer>, Boolean>> trainingData = new ArrayList<>();
+    final List<Pair<Pair<Matrix, int[]>, Boolean>> dataList = new ArrayList<>();
+    final BatchGenerator trainingBatchGenerator = new BatchGenerator(matrixFactory, batchSize);
+    final BatchGenerator validationBatchGenerator = new BatchGenerator(matrixFactory, batchSize);
 
     for (final Pair<LongWritable, Text> keyValue : dataSet) {
       final String text = keyValue.getSecond().toString().trim();
@@ -83,13 +90,33 @@ public final class NeuralNetworkDataParser implements DataParser<List<Pair<Pair<
         final Matrix data = input.get(range(0, input.getColumns() - 2));
         final int label = (int) input.get(input.getColumns() - 2);
         final boolean isValidation = ((int) input.get(input.getColumns() - 1) == 1);
-        trainingData.add(new Pair<>(new Pair<>(data, label), isValidation));
+
+        if (isValidation) {
+          final Pair<Matrix, int[]> batch = validationBatchGenerator.push(data, label);
+          if (batch != null) {
+            dataList.add(new Pair<>(batch, true));
+          }
+        } else {
+          final Pair<Matrix, int[]> batch = trainingBatchGenerator.push(data, label);
+          if (batch != null) {
+            dataList.add(new Pair<>(batch, false));
+          }
+        }
       } catch (final IOException e) {
         parseException = new ParseException("IOException: " + e.toString());
         return;
       }
     }
-    result = trainingData;
+
+    if (validationBatchGenerator.size() > 0) {
+      dataList.add(new Pair<>(validationBatchGenerator.pull(), false));
+    }
+
+    if (trainingBatchGenerator.size() > 0) {
+      dataList.add(new Pair<>(trainingBatchGenerator.pull(), false));
+    }
+
+    result = dataList;
   }
 
   /**
@@ -112,5 +139,76 @@ public final class NeuralNetworkDataParser implements DataParser<List<Pair<Pair<
       ret[i] = begin + i;
     }
     return ret;
+  }
+
+  /**
+   * Class for generating batch matrix and an array of labels with the specified batch size.
+   */
+  public static final class BatchGenerator {
+    private final MatrixFactory matrixFactory;
+    private final int batchSize;
+    private final List<Matrix> dataList;
+    private final List<Integer> labelList;
+
+    public BatchGenerator(final MatrixFactory matrixFactory, final int batchSize) {
+      this.matrixFactory = matrixFactory;
+      this.batchSize = batchSize;
+      this.dataList = new ArrayList<>(batchSize);
+      this.labelList = new ArrayList<>(batchSize);
+    }
+
+    /**
+     * @return the number of aggregated data.
+     */
+    public int size() {
+      return dataList.size();
+    }
+
+    /**
+     * Pushes a data and label.
+     * @param data a single datum
+     * @param label a label for the datum.
+     * @return a pair of a batch input matrix and an array of labels, if data have been pushed
+     *         with the specified batch size. or {@code null}, otherwise.
+     */
+    public Pair<Matrix, int[]> push(final Matrix data, final int label) {
+      dataList.add(data);
+      labelList.add(label);
+
+      if (dataList.size() == batchSize) {
+        return pull();
+      } else {
+        return null;
+      }
+    }
+
+    /**
+     * @return a pair of a batch input matrix and an array of labels that have been pushed.
+     */
+    public Pair<Matrix, int[]> pull() {
+      final Pair<Matrix, int[]> ret = new Pair<>(makeBatch(dataList),
+          ArrayUtils.toPrimitive(labelList.toArray(new Integer[labelList.size()])));
+      dataList.clear();
+      labelList.clear();
+      return ret;
+    }
+
+    /**
+     * Generates a batch input matrix with the specified list of input data.
+     * @param inputs a list of input data
+     * @return a batch input matrix
+     */
+    private Matrix makeBatch(final List<Matrix> inputs) {
+      if (inputs.size() > 0) {
+        final Matrix ret = matrixFactory.create(inputs.size(), inputs.get(0).getLength());
+        int i = 0;
+        for (final Matrix vector : inputs) {
+          ret.putRow(i++, vector);
+        }
+        return ret;
+      } else {
+        throw new IllegalArgumentException("At least one ndarray is needed to make batch");
+      }
+    }
   }
 }

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/layerparam/provider/GroupCommParameterProvider.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/layerparam/provider/GroupCommParameterProvider.java
@@ -39,7 +39,7 @@ import java.util.*;
 public final class GroupCommParameterProvider implements ParameterProvider {
 
   private final Broadcast.Receiver<LayerParameter[]> layerParamBroadcastReceiver;
-  private final Reduce.Sender<List<Pair<Integer, LayerParameter[]>>> parameterGradientReduceSender;
+  private final Reduce.Sender<Pair<Integer, LayerParameter[]>> parameterGradientReduceSender;
   private final Reduce.Sender<Pair<ValidationStats, ValidationStats>> validationStatsReduceSender;
 
   @Inject
@@ -59,9 +59,9 @@ public final class GroupCommParameterProvider implements ParameterProvider {
   public synchronized void push(final int batchSize, final LayerParameter[] parameterGradients) {
     try {
       if (batchSize == 0 || parameterGradients == null || parameterGradients.length == 0) {
-        parameterGradientReduceSender.send(Collections.<Pair<Integer, LayerParameter[]>>emptyList());
+        parameterGradientReduceSender.send(new Pair<>(0, new LayerParameter[0]));
       } else {
-        parameterGradientReduceSender.send(Collections.singletonList(new Pair<>(batchSize, parameterGradients)));
+        parameterGradientReduceSender.send(new Pair<>(batchSize, parameterGradients));
       }
     } catch (final NetworkException e) {
       throw new RuntimeException("NetworkException while trying to send reduce", e);

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/layerparam/provider/GroupCommParameterProvider.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/layerparam/provider/GroupCommParameterProvider.java
@@ -16,7 +16,6 @@
 package edu.snu.dolphin.dnn.layerparam.provider;
 
 import edu.snu.dolphin.dnn.NeuralNetworkGroupCommDriver;
-import edu.snu.dolphin.dnn.conf.NeuralNetworkConfigurationParameters;
 import edu.snu.dolphin.dnn.layers.LayerParameter;
 import edu.snu.dolphin.dnn.util.ValidationStats;
 import org.apache.reef.exception.evaluator.NetworkException;
@@ -25,7 +24,6 @@ import org.apache.reef.io.network.group.api.operators.Reduce;
 import org.apache.reef.io.network.group.api.task.CommunicationGroupClient;
 import org.apache.reef.io.network.group.api.task.GroupCommClient;
 import org.apache.reef.io.network.util.Pair;
-import org.apache.reef.tang.annotations.Parameter;
 
 import javax.annotation.concurrent.ThreadSafe;
 import javax.inject.Inject;
@@ -34,27 +32,18 @@ import java.util.*;
 /**
  * Parameter provider for a neural network that uses REEF Group Communication.
  * <p/>
- * Sends parameter gradients to the server with a certain batch size.
+ * Sends parameter gradients to the server.
  * Receives updated parameters from the server.
  */
 @ThreadSafe
 public final class GroupCommParameterProvider implements ParameterProvider {
 
-  private final List<LayerParameter[]> parameterGradientList;
-  private final int batchSize;
   private final Broadcast.Receiver<LayerParameter[]> layerParamBroadcastReceiver;
-  private final Reduce.Sender<List<LayerParameter[]>> parameterGradientReduceSender;
+  private final Reduce.Sender<List<Pair<Integer, LayerParameter[]>>> parameterGradientReduceSender;
   private final Reduce.Sender<Pair<ValidationStats, ValidationStats>> validationStatsReduceSender;
-  private int pushCount;
 
   @Inject
-  private GroupCommParameterProvider(
-      @Parameter(NeuralNetworkConfigurationParameters.BatchSize.class) final int batchSize,
-      final GroupCommClient groupCommClient) {
-
-    this.parameterGradientList = new ArrayList<>(batchSize);
-    this.batchSize = batchSize;
-    this.pushCount = 0;
+  private GroupCommParameterProvider(final GroupCommClient groupCommClient) {
 
     final CommunicationGroupClient commGroup =
         groupCommClient.getCommunicationGroup(NeuralNetworkGroupCommDriver.NeuralNetworkCommGroup.class);
@@ -67,23 +56,17 @@ public final class GroupCommParameterProvider implements ParameterProvider {
   }
 
   @Override
-  public synchronized void push(final LayerParameter[] parameterGradients) {
-    // do not store the input if it is not valid
-    if (!(parameterGradients == null || parameterGradients.length == 0)) {
-      parameterGradientList.add(parameterGradients);
-    }
-
-    if (++pushCount >= batchSize) {
-      pushCount = 0;
-
-      try {
-        parameterGradientReduceSender.send(parameterGradientList);
-      } catch (final NetworkException e) {
-        throw new RuntimeException("NetworkException while trying to send reduce", e);
-      } catch (final InterruptedException e) {
-        throw new RuntimeException("InterruptedException while trying to send reduce", e);
+  public synchronized void push(final int batchSize, final LayerParameter[] parameterGradients) {
+    try {
+      if (batchSize == 0 || parameterGradients == null || parameterGradients.length == 0) {
+        parameterGradientReduceSender.send(Collections.<Pair<Integer, LayerParameter[]>>emptyList());
+      } else {
+        parameterGradientReduceSender.send(Collections.singletonList(new Pair<>(batchSize, parameterGradients)));
       }
-      parameterGradientList.clear();
+    } catch (final NetworkException e) {
+      throw new RuntimeException("NetworkException while trying to send reduce", e);
+    } catch (final InterruptedException e) {
+      throw new RuntimeException("InterruptedException while trying to send reduce", e);
     }
   }
 

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/layerparam/provider/ParameterProvider.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/layerparam/provider/ParameterProvider.java
@@ -23,10 +23,11 @@ import edu.snu.dolphin.dnn.layers.LayerParameter;
 public interface ParameterProvider {
 
   /**
-   * Pushes parameter gradients of all layers for a training input.
-   * @param parameterGradients parameter gradients of all layers.
+   * Pushes parameter gradients for an input batch.
+   * @param batchSize the size of an input batch
+   * @param parameterGradients parameter gradients sums for an input batch
    */
-  void push(final LayerParameter[] parameterGradients);
+  void push(final int batchSize, final LayerParameter[] parameterGradients);
 
   /**
    * @return the updated parameters of the whole network.

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/layers/FullyConnectedLayer.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/layers/FullyConnectedLayer.java
@@ -47,39 +47,35 @@ public final class FullyConnectedLayer extends LayerBase {
   }
 
   /**
-   * Computes an activation for this fully connected layer.
-   * @param input an input value for this layer.
-   * @return an activation row vector.
+   * Computes output values for this fully connected layer.
+   * @param input input values for this layer.
+   * @return output values for this layer.
    */
   @Override
   public Matrix feedForward(final Matrix input) {
-    // (output row vector) = (input row vector) x (weight matrix) + (bias row vector)
+    // (output matrix) = (input matrix) x (weight matrix) + (bias row vector)
     return input.mmul(getLayerParameter().getWeightParam()).addiRowVector(getLayerParameter().getBiasParam());
   }
 
   /**
-   * Computes an error for this fully connected layer.
-   * @param input the input value.
-   * @param activation the activation value.
-   * @param nextError the error of the next layer - the one closer to the output layer.
-   * @return an error for this layer.
+   * Computes errors for this fully connected layer.
+   * @param input the input values for this layer.
+   * @param activation the output values.
+   * @param nextError the errors of the next layer - the one closer to the output layer.
+   * @return errors for this layer with the specified input value.
    */
   @Override
   public Matrix backPropagate(final Matrix input, final Matrix activation, final Matrix nextError) {
-    // (next error row vector) x (weight matrix of this layer)
+    // ((next error matrix) x (weight matrix of the next layer))
     return nextError.mmul(getLayerParameter().getWeightParam().transpose());
   }
 
   /** {@inheritDoc} */
   @Override
   public LayerParameter generateParameterGradient(final Matrix input, final Matrix error) {
-    if (!error.isRowVector()) {
-      throw new RuntimeException(String.format("Invalid error (rows=%d columns=%d). " +
-          "An error for a fully connected layer must be a row vector.",  error.getRows(), error.getColumns()));
-    }
     return LayerParameter.newBuilder()
         .setWeightParam(input.transpose().mmul(error))
-        .setBiasParam(error)
+        .setBiasParam(error.columnSums())
         .build();
   }
 }

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/layers/LayerBase.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/layers/LayerBase.java
@@ -74,28 +74,29 @@ public abstract class LayerBase {
   public abstract boolean isLearnable();
 
   /**
-   * Computes an output value.
-   * @param input an input value for this layer.
-   * @return an output value for this layer.
+   * Computes output values.
+   * @param input input values for this layer.
+   * @return output values for this layer.
    */
   public abstract Matrix feedForward(final Matrix input);
 
   /**
-   * Computes an error.
-   * @param input the input value for this layer, or the expected output if the layer is a loss layer.
-   * @param activation the activation value.
-   * @param nextError an error of the next layer - the one closer to the output layer.
-   * @return an error for this layer with the specified input value.
+   * Computes errors.
+   * @param input the input values for this layer, or the expected output if the layer is a loss layer.
+   * @param activation the output values.
+   * @param nextError the errors of the next layer - the one closer to the output layer.
+   * @return errors for this layer with the specified input value.
    */
   public abstract Matrix backPropagate(final Matrix input,
                                        final Matrix activation,
                                        final Matrix nextError);
 
   /**
-   * Computes a parameter gradient for this layer.
-   * @param input an input value for this layer.
-   * @param error an error for this layer.
-   * @return a parameter gradient for this layer or {@code null} if this layer is not learnable.
+   * Computes parameter gradients for this layer.
+   * @param input inputs for this layer.
+   * @param error errors for this layer.
+   * @return the element-wise sum of parameter gradients for the specified input and error,
+   *         or {@code null} if this layer is not learnable.
    */
   public abstract LayerParameter generateParameterGradient(final Matrix input, final Matrix error);
 }

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/util/Validator.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/util/Validator.java
@@ -31,24 +31,28 @@ public final class Validator {
     this.validationStats = new ValidationStats();
   }
 
-  public void validate(final Matrix input, final int label) {
+  public void validate(final Matrix input, final int[] labels) {
     final Matrix[] activations = network.feedForward(input);
-    final Matrix output = activations[activations.length - 1];
-    float maxValue = output.get(0);
+    final Matrix outputMatrix = activations[activations.length - 1];
 
-    // Find the index with highest probability.
-    int maxIndex = 0;
-    for (int i = 1; i < output.getLength(); ++i) {
-      if (output.get(i) > maxValue) {
-        maxValue = output.get(i);
-        maxIndex = i;
+    for (int i = 0; i < outputMatrix.getRows(); ++i) {
+      final Matrix output = outputMatrix.getRow(i);
+      float maxValue = output.get(0);
+
+      // Find the index with highest probability.
+      int maxIndex = 0;
+      for (int j = 1; j < output.getLength(); ++j) {
+        if (output.get(j) > maxValue) {
+          maxValue = output.get(j);
+          maxIndex = j;
+        }
       }
-    }
 
-    if (maxIndex == label) {
-      validationStats.validationCorrect();
-    } else {
-      validationStats.validationIncorrect();
+      if (maxIndex == labels[i]) {
+        validationStats.validationCorrect();
+      } else {
+        validationStats.validationIncorrect();
+      }
     }
   }
 

--- a/dolphin-dnn/src/test/java/edu/snu/dolphin/dnn/NeuralNetworkTest.java
+++ b/dolphin-dnn/src/test/java/edu/snu/dolphin/dnn/NeuralNetworkTest.java
@@ -72,7 +72,6 @@ public final class NeuralNetworkTest {
       expectedOutput};
 
   private final Configuration neuralNetworkConfiguration = NeuralNetworkConfigurationBuilder.newConfigurationBuilder()
-      .setBatchSize(1)
       .setStepsize(1e-2f)
       .setParameterProviderClass(LocalNeuralNetParameterProvider.class)
       .addLayerConfiguration(
@@ -205,7 +204,110 @@ public final class NeuralNetworkTest {
     final LocalNeuralNetParameterProvider localNeuralNetParameterProvider = Tang.Factory.getTang()
         .newInjector(blasConfiguration, neuralNetworkConfiguration).getInstance(LocalNeuralNetParameterProvider.class);
 
-    localNeuralNetParameterProvider.push(neuralNetwork.generateParameterGradients(activations, expectedErrors));
+    localNeuralNetParameterProvider.push(input.getRows(),
+        neuralNetwork.generateParameterGradients(activations, expectedErrors));
     assertTrue(compare(expectedParams, localNeuralNetParameterProvider.pull(), TOLERANCE));
+  }
+
+  private final Matrix batchInput = matrixFactory.create(new float[][]{
+      {77, 57, 30, 26, 75, 74, 87, 75},
+      {61, 5, 18, 18, 16, 4, 67, 29},
+      {68, 85, 4, 50, 19, 3, 5, 18}});
+
+  private final Matrix expectedBatchOutput = matrixFactory.create(new float[][]{
+      {5.61329743164e-01f, 5.97883503916e-01f, 4.79822915984e-01f},
+      {5.60976372061e-01f, 5.97821453723e-01f, 4.80461166777e-01f},
+      {5.61245484844e-01f, 5.98112837378e-01f, 4.79875062394e-01f}});
+
+  private final Matrix labels = matrixFactory.create(new float[][]{{0, 1, 0}, {0, 0, 1}, {1, 0, 0}});
+
+  private final Matrix[] expectedBatchActivations = new Matrix[] {
+      matrixFactory.create(new float[][]{
+          {-7.93876278605e-03f, -3.31747899111e-02f, 3.44120437890e-02f, 1.59688640758e-02f, 1.38468652740e-02f},
+          {-1.23871909026e-03f, -2.11530894332e-02f, 7.89375894368e-03f, 7.98690381646e-04f, -3.62337928265e-03f},
+          {-5.40462196656e-03f, -3.56428819858e-03f, -2.77098032534e-03f, 2.72608707532e-02f, 1.27705410570e-03f}}),
+      matrixFactory.create(new float[][]{
+          {4.98015319727e-01f, 4.91707063086e-01f, 5.08602162082e-01f, 5.03992131185e-01f, 5.03461661008e-01f},
+          {4.99690320267e-01f, 4.94711924821e-01f, 5.01973429489e-01f, 5.00199672585e-01f, 4.99094156170e-01f},
+          {4.98648847797e-01f, 4.99108928894e-01f, 4.99307255362e-01f, 5.06814795656e-01f, 5.00319263483e-01f}}),
+      matrixFactory.create(new float[][]{
+          {2.46560502863e-01f, 3.96654087576e-01f, -8.07521889872e-02f},
+          {2.45125553286e-01f, 3.96396002015e-01f, -7.81951521132e-02f},
+          {2.46218328523e-01f, 3.97608068197e-01f, -8.05432640010e-02f}}),
+      expectedBatchOutput};
+
+  private final Matrix[] expectedBatchErrors = new Matrix[] {
+      matrixFactory.create(new float[][]{
+          {-8.30651912736e-03f, -4.80258488777e-02f, 1.07207504661e-02f, 1.48007835060e-02f, -9.54255943309e-02f},
+          {-5.07035192412e-02f, 2.78781517325e-02f, 7.50168509571e-03f, 6.08557822289e-02f, 6.64601224626e-02f},
+          {3.39717583167e-02f, -1.00106875386e-04f, -6.33785444658e-03f, -1.97557316255e-02f, -5.77034221542e-02f}}),
+      matrixFactory.create(new float[][]{
+          {-3.32266000219e-02f, -1.92156256008e-01f, 4.28956985094e-02f, 5.92069083725e-02f, -3.81720674107e-01f},
+          {-2.02814154765e-01f, 1.11525081563e-01f, 3.00072078260e-02f, 2.43423167736e-01f, 2.65841362398e-01f},
+          {1.35888025582e-01f, -4.00428773318e-04f, -2.53514664505e-02f, -7.90376089833e-02f, -2.30813782723e-01f}}),
+      matrixFactory.create(new float[][]{
+          {5.61329743164e-01f, -4.02116496084e-01f, 4.79822915984e-01f},
+          {5.60976372061e-01f, 5.97821453723e-01f, -5.19538833223e-01f},
+          {-4.38754515156e-01f, 5.98112837378e-01f, 4.79875062394e-01f}})};
+
+  /**
+   * Unit test for feedforward of neural network for a batch input.
+   */
+  @Test
+  public void feedForwardTestForBatch() {
+    final Matrix[] batchActivations = neuralNetwork.feedForward(batchInput);
+    assertTrue(expectedBatchOutput.compare(batchActivations[batchActivations.length - 1], TOLERANCE));
+    assertTrue(MatrixUtils.compare(batchActivations, expectedBatchActivations, TOLERANCE));
+  }
+
+  /**
+   * Unit test for backpropagate of neural network for a batch input.
+   */
+  @Test
+  public void backPropagateTestForBatch() {
+    final Matrix[] batchActivations = ArrayUtils.add(expectedBatchActivations, 0, batchInput);
+    final Matrix[] gradients = neuralNetwork.backPropagate(batchActivations, labels);
+    assertTrue(MatrixUtils.compare(expectedBatchErrors, gradients, TOLERANCE));
+  }
+
+  private final LayerParameter[] expectedBatchParams = new LayerParameter[]{
+      LayerParameter.newBuilder()
+          .setWeightParam(matrixFactory.create(new float[][]{
+              {4.64145014168e-03f, 6.73558899806e-03f, -2.89190318578e-03f, -1.16481232727e-02f, 2.39387718430e-02f},
+              {-7.24999073729e-03f, 8.69950140536e-03f, -4.14339451025e-04f, 2.01776909015e-03f, 3.34770362552e-02f},
+              {3.45278565712e-03f, 3.20064693997e-03f, -1.46653662370e-03f, -4.81750970047e-03f, 6.34724142775e-03f},
+              {-1.77590672102e-03f, 2.40225435486e-03f, -3.67275769129e-04f, -1.60488581988e-03f, 1.38594791443e-02f},
+              {2.56467330903e-03f, 1.05311621508e-02f, -2.45393919166e-03f, -5.68093834349e-03f, 2.40228089200e-02f},
+              {2.36981274148e-03f, 1.14383103422e-02f, -2.52281276950e-03f, -4.27949828405e-03f, 2.33507098805e-02f},
+              {1.32143923438e-02f, 7.38994773632e-03f, -4.60051170392e-03f, -1.76606577354e-02f, 1.38018655878e-02f},
+              {4.93842304532e-03f, 9.21118247783e-03f, -2.92447609099e-03f, -8.33124861590e-03f, 2.09370626562e-02f}}))
+          .setBiasParam(matrixFactory.create(new float[]{
+              2.83460933506e-04f, 2.67492680069e-04f, 1.60384729616e-04f, 1.36638863018e-05f, 4.88896313408e-04f}))
+          .build(),
+      emptyLayerParam, // sigmoid activation layer
+      LayerParameter.newBuilder()
+          .setWeightParam(matrixFactory.create(new float[][]{
+              {-2.01150525996e-01f, -3.22383456150e-02f, 1.38103996340e-01f},
+              {-9.70281555556e-02f, 9.45017787010e-02f, -2.08690580267e-01f},
+              {6.45986834694e-02f, -3.79691247050e-03f, 9.64634547967e-03f},
+              {2.46749910214e-01f, 1.08310496669e-01f, -7.54667251949e-02f},
+              {-1.30342513562e-01f, 2.04075111228e-02f, -6.26933879715e-01f}}))
+          .setBiasParam(matrixFactory.create(new float[]{2.97721494666e-01f, 2.97353940683e-01f, 2.98532802849e-01f}))
+          .build(),
+      emptyLayerParam}; // sigmoid activation layer
+
+  /**
+   * Unit test for local neural network parameter provider for a batch input.
+   * @throws InjectionException
+   */
+  @Test
+  public void localNeuralNetParameterProviderBatchTest() throws InjectionException {
+    final Matrix[] batchActivations = ArrayUtils.add(expectedBatchActivations, 0, batchInput);
+    final LocalNeuralNetParameterProvider localNeuralNetParameterProvider = Tang.Factory.getTang()
+        .newInjector(blasConfiguration, neuralNetworkConfiguration).getInstance(LocalNeuralNetParameterProvider.class);
+
+    localNeuralNetParameterProvider.push(batchInput.getRows(),
+        neuralNetwork.generateParameterGradients(batchActivations, expectedBatchErrors));
+    assertTrue(compare(expectedBatchParams, localNeuralNetParameterProvider.pull(), TOLERANCE));
   }
 }

--- a/dolphin-dnn/src/test/java/edu/snu/dolphin/dnn/data/IntAndLayerParameterArrayPairCodecTest.java
+++ b/dolphin-dnn/src/test/java/edu/snu/dolphin/dnn/data/IntAndLayerParameterArrayPairCodecTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (C) 2015 Seoul National University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.snu.dolphin.dnn.data;
+
+import edu.snu.dolphin.dnn.blas.MatrixFactory;
+import edu.snu.dolphin.dnn.blas.jblas.MatrixJBLASFactory;
+import edu.snu.dolphin.dnn.layers.LayerParameter;
+import org.apache.reef.io.network.util.Pair;
+import org.apache.reef.tang.Configuration;
+import org.apache.reef.tang.Injector;
+import org.apache.reef.tang.Tang;
+import org.apache.reef.tang.exceptions.InjectionException;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Random;
+
+import static edu.snu.dolphin.dnn.data.LayerParameterArrayCodecTest.generateRandomLayerParameterArray;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Test class for testing {@link IntAndLayerParameterArrayPairCodec}'s encoding and decoding features.
+ */
+public final class IntAndLayerParameterArrayPairCodecTest {
+
+  private IntAndLayerParameterArrayPairCodec intAndLayerParameterArrayPairCodec;
+  private MatrixFactory matrixFactory;
+  private final Random random = new Random();
+
+  @Before
+  public void setUp() throws InjectionException {
+
+    final Configuration conf = Tang.Factory.getTang().newConfigurationBuilder()
+        .bindImplementation(MatrixFactory.class, MatrixJBLASFactory.class)
+        .build();
+    final Injector injector = Tang.Factory.getTang().newInjector(conf);
+
+    this.intAndLayerParameterArrayPairCodec = injector.getInstance(IntAndLayerParameterArrayPairCodec.class);
+    this.matrixFactory = injector.getInstance(MatrixFactory.class);
+  }
+
+  /**
+   * Checks that a pair of an integer and an random array of layer parameters
+   * does not change after encoding and decoding it, sequentially.
+   */
+  @Test
+  public void testEncodeDecodeIntAndLayerParametersPair() {
+    final Pair<Integer, LayerParameter[]> inputIntAndLayerParameterArrayPair =
+        new Pair<>(random.nextInt(), generateRandomLayerParameterArray(matrixFactory, random, 10));
+    final Pair<Integer, LayerParameter[]> outputIntAndLayerParameterArrayPair =
+        intAndLayerParameterArrayPairCodec.decode(
+            intAndLayerParameterArrayPairCodec.encode(inputIntAndLayerParameterArrayPair));
+
+    assertEquals("Encode-decode result is different from the expected integer",
+        inputIntAndLayerParameterArrayPair.getFirst(), outputIntAndLayerParameterArrayPair.getFirst());
+    assertArrayEquals("Encode-decode result is different from the expected array of layer parameters",
+        inputIntAndLayerParameterArrayPair.getSecond(), inputIntAndLayerParameterArrayPair.getSecond());
+  }
+}

--- a/dolphin-dnn/src/test/java/edu/snu/dolphin/dnn/data/IntAndLayerParameterArrayPairListCodecTest.java
+++ b/dolphin-dnn/src/test/java/edu/snu/dolphin/dnn/data/IntAndLayerParameterArrayPairListCodecTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) 2015 Seoul National University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.snu.dolphin.dnn.data;
+
+import edu.snu.dolphin.dnn.blas.MatrixFactory;
+import edu.snu.dolphin.dnn.blas.jblas.MatrixJBLASFactory;
+import edu.snu.dolphin.dnn.layers.LayerParameter;
+import org.apache.reef.io.network.util.Pair;
+import org.apache.reef.tang.Configuration;
+import org.apache.reef.tang.Injector;
+import org.apache.reef.tang.Tang;
+import org.apache.reef.tang.exceptions.InjectionException;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
+import static edu.snu.dolphin.dnn.data.LayerParameterArrayCodecTest.generateRandomLayerParameterArray;
+import static org.junit.Assert.assertArrayEquals;
+
+/**
+ * Test class for testing {@link IntAndLayerParameterArrayPairListCodec}'s encoding and decoding features.
+ */
+public final class IntAndLayerParameterArrayPairListCodecTest {
+
+  private IntAndLayerParameterArrayPairListCodec intAndLayerParameterArrayPairListCodec;
+  private MatrixFactory matrixFactory;
+  private final Random random = new Random();
+
+  @Before
+  public void setUp() throws InjectionException {
+
+    final Configuration conf = Tang.Factory.getTang().newConfigurationBuilder()
+        .bindImplementation(MatrixFactory.class, MatrixJBLASFactory.class)
+        .build();
+    final Injector injector = Tang.Factory.getTang().newInjector(conf);
+
+    this.intAndLayerParameterArrayPairListCodec = injector.getInstance(IntAndLayerParameterArrayPairListCodec.class);
+    this.matrixFactory = injector.getInstance(MatrixFactory.class);
+  }
+
+  /**
+   * Checks that a random list of pairs of an integer and an array of layer parameters
+   * does not change after encoding and decoding it, sequentially.
+   */
+  @Test
+  public void testEncodeDecodeIntAndLayerParametersPairList() {
+    final List<Pair<Integer, LayerParameter[]>> inputIntAndLayerParameterArrayPairList = new ArrayList<>(5);
+    for (int i = 0; i < inputIntAndLayerParameterArrayPairList.size(); ++i) {
+      inputIntAndLayerParameterArrayPairList.add(
+          new Pair<>(random.nextInt(), generateRandomLayerParameterArray(matrixFactory, random, 10)));
+    }
+    final List<Pair<Integer, LayerParameter[]>> outputIntAndLayerParameterArrayPairList =
+        intAndLayerParameterArrayPairListCodec.decode(
+            intAndLayerParameterArrayPairListCodec.encode(inputIntAndLayerParameterArrayPairList));
+
+    assertArrayEquals(
+        "Encode-decode result is different from the expected list of integer and layer parameter array pairs",
+        inputIntAndLayerParameterArrayPairList.toArray(), outputIntAndLayerParameterArrayPairList.toArray());
+  }
+}


### PR DESCRIPTION
This pull request introduces batch processing for deep neural networks. A batch size that is used for training can be specified in the neural network configuration file. The changes involved in this PR are the followings.
* An input batch is given for training a neural network or inferring outputs.
* The signature of `push` for `ParameterProvider` is changed. The size of batch should be given.
* The return matrix for `generateParameterGradient` is the element-wise sum of parameter gradient matrices for each input instance in a batch.
* The messages that are used for reducing parameter gradients with group communication are changed from a list of layer parameters to a list of pairs of an integer (the size of batch) and a layer parameter (the element-wise sum of parameter gradients for an input batch).

This closes #141.