### PR TITLE
Remove required numInput and numOutput options for layer configuration

### DIFF
--- a/dolphin-dnn/README.md
+++ b/dolphin-dnn/README.md
@@ -81,12 +81,12 @@ parameter_provider {
 
 **More types of layers such as convolutional layer and subsampling layer will be supported.**
 
-##### Activation Layers
+##### Activation Layer
 * Layer type: `Activation`
 * Parameters (`ActivationLayerConfiguration activation_param`)
 	* `activation_function`: the activation function to produce output values for this layer.
 
-##### Activation with Loss Layers
+##### Activation with Loss Layer
 * Layer type: `ActivationWithLoss`
 * Parameters (`ActivationWithLossLayerConfiguration activation_with_loss_param`)
 	* `activation_function`: the activation function to produce output values for this layer.
@@ -101,7 +101,7 @@ The following activation functions are supported.
 * Absolute: `abs`
 * Softmax: `softmax`
 
-##### Loss functions
+##### Loss Functions
 The following loss functions are supported.
 * CrossEntropy: `crossEntropy`
 
@@ -166,7 +166,7 @@ layer {
   type: "ActivationWithLoss"
   activation_with_loss_param {
     activation_function: "softmax"
-    loss_function: "crossentropy"
+    loss_function: "crossEntropy"
   }
 }
 

--- a/dolphin-dnn/README.md
+++ b/dolphin-dnn/README.md
@@ -164,8 +164,6 @@ layer {
 }
 layer {
   type: "ActivationWithLoss"
-  num_input: 10
-  num_output: 10
   activation_with_loss_param {
     activation_function: "softmax"
     loss_function: "crossentropy"

--- a/dolphin-dnn/README.md
+++ b/dolphin-dnn/README.md
@@ -76,19 +76,34 @@ parameter_provider {
 * Parameters (`FullyConnectedLayerConfiguration fully_connected_param`)
 	* `init_weight`: the standard deviation that is used to initialize the weights in this layer from a Gaussian distribution with mean 0.
 	* `init_bias`: constant value with which the biases of this layer are initialized.
-	* `activation_function`: the activation function to produce a output value for this layer.
+	* `random_seed`: the seed for generating random inital parameters.
+	* `num_output`: the number of outputs for this layer.
 
 **More types of layers such as convolutional layer and subsampling layer will be supported.**
 
-##### Activation function
-The following functions are supported.
+##### Activation Layers
+* Layer type: `Activation`
+* Parameters (`ActivationLayerConfiguration activation_param`)
+	* `activation_function`: the activation function to produce output values for this layer.
 
+##### Activation with Loss Layers
+* Layer type: `ActivationWithLoss`
+* Parameters (`ActivationWithLossLayerConfiguration activation_with_loss_param`)
+	* `activation_function`: the activation function to produce output values for this layer.
+	* `loss_function`: the loss function that is used to compute loss and calculate the loss gradient for backpropagation.
+
+##### Activation Functions
+The following activation functions are supported.
 * Sigmoid: `sigmoid`
 * ReLU: `relu`
 * TanhH: `tanh`
 * Power: `pow` (squared value)
 * Absolute: `abs`
 * Softmax: `softmax`
+
+##### Loss functions
+The following loss functions are supported.
+* CrossEntropy: `crossEntropy`
 
 ## How to run
 A script for training a neural network model is included with the source code, in `bin/run_neuralnetwork.sh`. `test/resources/data/neuralnet` is a sample subset of the [MNIST](http://yann.lecun.com/exdb/mnist) dataset, composed of 1,000 training images and 100 test images. `test/resources/configuration/neuralnet` is an example of a protocol buffer definition file; it defines a neural network model that uses two fully connected layers and a local parameter provider.
@@ -127,24 +142,36 @@ parameter_provider {
 }
 layer {
   type: "FullyConnected"
-  num_input: 784
-  num_output: 50
   fully_connected_param {
     init_weight: 1e-4
     init_bias: 2e-4
-    activation_function: "sigmoid"
+    num_output: 50
+  }
+}
+layer {
+  type: "Activation"
+  activation_param {
+    activation_function: "relu"
   }
 }
 layer {
   type: "FullyConnected"
-  num_input: 50
-  num_output: 10
   fully_connected_param {
     init_weight: 1e-2
     init_bias: 2e-2
-    activation_function: "sigmoid"
+    num_output: 10
   }
 }
+layer {
+  type: "ActivationWithLoss"
+  num_input: 10
+  num_output: 10
+  activation_with_loss_param {
+    activation_function: "softmax"
+    loss_function: "crossentropy"
+  }
+}
+
 ```
 This model comprises two fully connected layers with 50 and 10 features, respectively, and a local parameter provider. `input_shape` specifies the shape of input data. For the MNIST dataset, each data object is a 28 * 28 image and thus `input_shape` is configured as the following.
 

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/NeuralNetworkDriverParameters.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/NeuralNetworkDriverParameters.java
@@ -61,7 +61,7 @@ public final class NeuralNetworkDriverParameters {
   private final int batchSize;
 
   @NamedParameter(doc = "neural network configuration file path", short_name = "conf")
-  public static class ConfigurationPath implements Name<String> {
+  public static final class ConfigurationPath implements Name<String> {
   }
 
   @NamedParameter(doc = "delimiter that is used in input file", short_name = "delim", default_value = ",")
@@ -201,7 +201,8 @@ public final class NeuralNetworkDriverParameters {
         NeuralNetworkConfigurationBuilder.newConfigurationBuilder();
 
     neuralNetConfBuilder.setStepsize(neuralNetConf.getStepsize())
-        .setParameterProviderClass(getParameterProviderClass(neuralNetConf.getParameterProvider().getType()));
+        .setParameterProviderClass(getParameterProviderClass(neuralNetConf.getParameterProvider().getType()))
+        .setInputShape(neuralNetConf.getInputShape().getDimList());
 
     // Adds the configuration of each layer.
     for (final LayerConfiguration layerConf : neuralNetConf.getLayerList()) {

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/conf/ActivationLayerConfigurationBuilder.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/conf/ActivationLayerConfigurationBuilder.java
@@ -26,7 +26,7 @@ import org.apache.reef.util.Builder;
  * Configuration builder for activation layer.
  *
  * The configuration that this builder generates is used to create an activation layer instance.
- * The generate configuration need to bind the implementation for matrix factory, in order to inject layer instance.
+ * The generate configuration need to bind the parameter for a layer input shape, to inject layer instance.
  */
 public final class ActivationLayerConfigurationBuilder implements Builder<Configuration> {
 

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/conf/ActivationLayerConfigurationBuilder.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/conf/ActivationLayerConfigurationBuilder.java
@@ -26,6 +26,7 @@ import org.apache.reef.util.Builder;
  * Configuration builder for activation layer.
  *
  * The configuration that this builder generates is used to create an activation layer instance.
+ * The generate configuration need to bind the implementation for matrix factory, in order to inject layer instance.
  */
 public final class ActivationLayerConfigurationBuilder implements Builder<Configuration> {
 
@@ -33,19 +34,7 @@ public final class ActivationLayerConfigurationBuilder implements Builder<Config
     return new ActivationLayerConfigurationBuilder();
   }
 
-  private int numInput;
-  private int numOutput;
   private String activationFunction;
-
-  public synchronized ActivationLayerConfigurationBuilder setNumInput(final int numInput) {
-    this.numInput = numInput;
-    return this;
-  }
-
-  public synchronized ActivationLayerConfigurationBuilder setNumOutput(final int numOutput) {
-    this.numOutput = numOutput;
-    return this;
-  }
 
   public synchronized ActivationLayerConfigurationBuilder setActivationFunction(final String activationFunction) {
     this.activationFunction = activationFunction;
@@ -54,8 +43,6 @@ public final class ActivationLayerConfigurationBuilder implements Builder<Config
 
   public synchronized ActivationLayerConfigurationBuilder fromProtoConfiguration(
       final NeuralNetworkProtos.LayerConfiguration protoConf) {
-    numInput = protoConf.getNumInput();
-    numOutput = protoConf.getNumOutput();
     activationFunction = protoConf.getActivationParam().getActivationFunction();
     return this;
   }
@@ -63,8 +50,6 @@ public final class ActivationLayerConfigurationBuilder implements Builder<Config
   @Override
   public synchronized Configuration build() {
     return Tang.Factory.getTang().newConfigurationBuilder()
-        .bindNamedParameter(LayerConfigurationParameters.NumberOfInput.class, String.valueOf(numInput))
-        .bindNamedParameter(LayerConfigurationParameters.NumberOfOutput.class, String.valueOf(numOutput))
         .bindNamedParameter(LayerConfigurationParameters.ActivationFunction.class, String.valueOf(activationFunction))
         .bindImplementation(LayerBase.class, ActivationLayer.class)
         .build();

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/conf/ActivationWithLossLayerConfigurationBuilder.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/conf/ActivationWithLossLayerConfigurationBuilder.java
@@ -29,6 +29,7 @@ import org.apache.reef.util.Builder;
  * Configuration builder for activation with loss layer.
  *
  * The configuration that this builder generates is used to create an activation with loss layer instance.
+ * The generate configuration need to bind the implementation for matrix factory, in order to inject layer instance.
  */
 public final class ActivationWithLossLayerConfigurationBuilder implements Builder<Configuration> {
 
@@ -36,22 +37,10 @@ public final class ActivationWithLossLayerConfigurationBuilder implements Builde
     return new ActivationWithLossLayerConfigurationBuilder();
   }
 
-  private int numInput;
-  private int numOutput;
   private String activationFunction;
   private String lossFunction;
 
   private ConfigurationSerializer configurationSerializer = new AvroConfigurationSerializer();
-
-  public synchronized ActivationWithLossLayerConfigurationBuilder setNumInput(final int numInput) {
-    this.numInput = numInput;
-    return this;
-  }
-
-  public synchronized ActivationWithLossLayerConfigurationBuilder setNumOutput(final int numOutput) {
-    this.numOutput = numOutput;
-    return this;
-  }
 
   public synchronized ActivationWithLossLayerConfigurationBuilder setActivationFunction(
       final String activationFunction) {
@@ -66,8 +55,6 @@ public final class ActivationWithLossLayerConfigurationBuilder implements Builde
 
   public synchronized ActivationWithLossLayerConfigurationBuilder fromProtoConfiguration(
       final NeuralNetworkProtos.LayerConfiguration protoConf) {
-    numInput = protoConf.getNumInput();
-    numOutput = protoConf.getNumOutput();
     activationFunction = protoConf.getActivationWithLossParam().getActivationFunction();
     lossFunction = protoConf.getActivationWithLossParam().getLossFunction();
     return this;
@@ -76,13 +63,10 @@ public final class ActivationWithLossLayerConfigurationBuilder implements Builde
   @Override
   public synchronized Configuration build() {
     final Configuration layerConf = ActivationLayerConfigurationBuilder.newConfigurationBuilder()
-        .setNumInput(numInput)
-        .setNumOutput(numOutput)
         .setActivationFunction(activationFunction)
         .build();
 
     return Tang.Factory.getTang().newConfigurationBuilder()
-        .bindNamedParameter(LayerConfigurationParameters.NumberOfOutput.class, String.valueOf(numOutput))
         .bindNamedParameter(LayerConfigurationParameters.LossFunction.class, lossFunction)
         .bindNamedParameter(SerializedLayerConfiguartion.class, configurationSerializer.toString(layerConf))
         .bindImplementation(LayerBase.class, ActivationWithLossLayer.class)

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/conf/ActivationWithLossLayerConfigurationBuilder.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/conf/ActivationWithLossLayerConfigurationBuilder.java
@@ -29,7 +29,7 @@ import org.apache.reef.util.Builder;
  * Configuration builder for activation with loss layer.
  *
  * The configuration that this builder generates is used to create an activation with loss layer instance.
- * The generate configuration need to bind the implementation for matrix factory, in order to inject layer instance.
+ * The generate configuration need to bind the parameter for a layer input shape, to inject layer instance.
  */
 public final class ActivationWithLossLayerConfigurationBuilder implements Builder<Configuration> {
 

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/conf/FullyConnectedLayerConfigurationBuilder.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/conf/FullyConnectedLayerConfigurationBuilder.java
@@ -29,7 +29,7 @@ import org.apache.reef.util.Builder;
  *
  * The configuration that this builder generates is used to create a fully connected layer instance.
  * The generate configuration need to bind the implementation for matrix factory and
- * the parameter for layer input shape, to inject layer instance.
+ * the parameter for a layer input shape, to inject layer instance.
  */
 public final class FullyConnectedLayerConfigurationBuilder implements Builder<Configuration> {
 

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/conf/FullyConnectedLayerConfigurationBuilder.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/conf/FullyConnectedLayerConfigurationBuilder.java
@@ -28,6 +28,8 @@ import org.apache.reef.util.Builder;
  * Configuration builder for fully connected layer.
  *
  * The configuration that this builder generates is used to create a fully connected layer instance.
+ * The generate configuration need to bind the implementation for matrix factory and
+ * the parameter for layer input shape, to inject layer instance.
  */
 public final class FullyConnectedLayerConfigurationBuilder implements Builder<Configuration> {
 
@@ -35,16 +37,10 @@ public final class FullyConnectedLayerConfigurationBuilder implements Builder<Co
     return new FullyConnectedLayerConfigurationBuilder();
   }
 
-  private int numInput;
   private int numOutput;
   private long randomSeed = System.currentTimeMillis();
   private float initWeight;
   private float initBias;
-
-  public synchronized FullyConnectedLayerConfigurationBuilder setNumInput(final int numInput) {
-    this.numInput = numInput;
-    return this;
-  }
 
   public synchronized FullyConnectedLayerConfigurationBuilder setNumOutput(final int numOutput) {
     this.numOutput = numOutput;
@@ -68,9 +64,7 @@ public final class FullyConnectedLayerConfigurationBuilder implements Builder<Co
 
   public synchronized FullyConnectedLayerConfigurationBuilder fromProtoConfiguration(
       final NeuralNetworkProtos.LayerConfiguration protoConf) {
-    numInput = protoConf.getNumInput();
-    numOutput = protoConf.getNumOutput();
-
+    numOutput = protoConf.getFullyConnectedParam().getNumOutput();
     if (protoConf.getFullyConnectedParam().hasRandomSeed()) {
       randomSeed = protoConf.getFullyConnectedParam().getRandomSeed();
     }
@@ -82,7 +76,6 @@ public final class FullyConnectedLayerConfigurationBuilder implements Builder<Co
   @Override
   public synchronized Configuration build() {
     return Tang.Factory.getTang().newConfigurationBuilder()
-        .bindNamedParameter(LayerConfigurationParameters.NumberOfInput.class, String.valueOf(numInput))
         .bindNamedParameter(LayerConfigurationParameters.NumberOfOutput.class, String.valueOf(numOutput))
         .bindNamedParameter(LayerConfigurationParameters.RandomSeed.class, String.valueOf(randomSeed))
         .bindNamedParameter(LayerConfigurationParameters.InitialWeight.class, String.valueOf(initWeight))

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/conf/LayerConfigurationParameters.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/conf/LayerConfigurationParameters.java
@@ -50,7 +50,6 @@ public final class LayerConfigurationParameters {
   /**
    * For fully connected layers.
    */
-
   @NamedParameter(doc = "number of layer output nodes", short_name = "numOutput")
   public static final class NumberOfOutput implements Name<Integer> {
   }
@@ -58,7 +57,6 @@ public final class LayerConfigurationParameters {
   /**
    * For activation layers.
    */
-
   @NamedParameter(doc = "activation function of layer node", short_name = "activationFunc")
   public static final class ActivationFunction implements Name<String> {
   }

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/conf/LayerConfigurationParameters.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/conf/LayerConfigurationParameters.java
@@ -43,13 +43,21 @@ public final class LayerConfigurationParameters {
   public static final class LayerIndex implements Name<Integer> {
   }
 
-  @NamedParameter(doc = "number of layer input nodes", short_name = "numInput")
-  public static final class NumberOfInput implements Name<Integer> {
+  @NamedParameter(doc = "the shape of input data for layer")
+  public static final class LayerInputShape implements Name<String> {
   }
+
+  /**
+   * For fully connected layers.
+   */
 
   @NamedParameter(doc = "number of layer output nodes", short_name = "numOutput")
   public static final class NumberOfOutput implements Name<Integer> {
   }
+
+  /**
+   * For activation layers.
+   */
 
   @NamedParameter(doc = "activation function of layer node", short_name = "activationFunc")
   public static final class ActivationFunction implements Name<String> {

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/conf/NeuralNetworkConfigurationBuilder.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/conf/NeuralNetworkConfigurationBuilder.java
@@ -37,7 +37,7 @@ import static edu.snu.dolphin.dnn.util.NeuralNetworkUtils.shapeToString;
  */
 public final class NeuralNetworkConfigurationBuilder implements Builder<Configuration> {
 
-  private ArrayList<Configuration> layerConfigurations = new ArrayList<>();
+  private List<Configuration> layerConfigurations = new ArrayList<>();
   private ConfigurationSerializer configurationSerializer = new AvroConfigurationSerializer();
   private Class<? extends ParameterProvider> parameterProviderClass;
   private float stepsize = 1e-2f;

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/conf/NeuralNetworkConfigurationBuilder.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/conf/NeuralNetworkConfigurationBuilder.java
@@ -16,8 +16,8 @@
 package edu.snu.dolphin.dnn.conf;
 
 import edu.snu.dolphin.dnn.layerparam.provider.ParameterProvider;
+import edu.snu.dolphin.dnn.conf.NeuralNetworkConfigurationParameters.*;
 import org.apache.reef.tang.Configuration;
-import org.apache.reef.tang.Configurations;
 import org.apache.reef.tang.JavaConfigurationBuilder;
 import org.apache.reef.tang.Tang;
 import org.apache.reef.tang.formats.AvroConfigurationSerializer;
@@ -25,7 +25,9 @@ import org.apache.reef.tang.formats.ConfigurationSerializer;
 import org.apache.reef.util.Builder;
 
 import java.util.ArrayList;
-import java.util.Collection;
+import java.util.List;
+
+import static edu.snu.dolphin.dnn.util.NeuralNetworkUtils.shapeToString;
 
 /**
  * Configuration builder for neural network.
@@ -35,25 +37,18 @@ import java.util.Collection;
  */
 public final class NeuralNetworkConfigurationBuilder implements Builder<Configuration> {
 
-  private Collection<String> layerConfigurations = new ArrayList<>();
-  private int index = 0;
+  private ArrayList<Configuration> layerConfigurations = new ArrayList<>();
   private ConfigurationSerializer configurationSerializer = new AvroConfigurationSerializer();
   private Class<? extends ParameterProvider> parameterProviderClass;
   private float stepsize = 1e-2f;
+  private String inputShape;
 
   public static NeuralNetworkConfigurationBuilder newConfigurationBuilder() {
     return new NeuralNetworkConfigurationBuilder();
   }
 
   public synchronized NeuralNetworkConfigurationBuilder addLayerConfiguration(final Configuration layerConfiguration) {
-
-    final Configuration finalLayerConfiguration = Configurations.merge(layerConfiguration,
-        Tang.Factory.getTang().newConfigurationBuilder()
-            .bindNamedParameter(LayerConfigurationParameters.LayerIndex.class, String.valueOf(index))
-            .build());
-
-    layerConfigurations.add(configurationSerializer.toString(finalLayerConfiguration));
-    ++index;
+    layerConfigurations.add(layerConfiguration);
     return this;
   }
 
@@ -68,16 +63,33 @@ public final class NeuralNetworkConfigurationBuilder implements Builder<Configur
     return this;
   }
 
+  public synchronized NeuralNetworkConfigurationBuilder setInputShape(final List<Integer> inputShapeList) {
+    this.inputShape = shapeToString(inputShapeList);
+    return this;
+  }
+
+  public synchronized NeuralNetworkConfigurationBuilder setInputShape(final int... inputShape) {
+    this.inputShape = shapeToString(inputShape);
+    return this;
+  }
+
   @Override
   public synchronized Configuration build() {
     final JavaConfigurationBuilder jb = Tang.Factory.getTang().newConfigurationBuilder();
 
-    for (final String layerConfiguration : layerConfigurations) {
-      jb.bindSetEntry(NeuralNetworkConfigurationParameters.SerializedLayerConfigurationSet.class, layerConfiguration);
+    for (int i = 0; i < layerConfigurations.size(); ++i) {
+      final Configuration finalLayerConfiguration =
+          Tang.Factory.getTang().newConfigurationBuilder(layerConfigurations.get(i))
+              .bindNamedParameter(LayerConfigurationParameters.LayerIndex.class, String.valueOf(i))
+              .build();
+
+      jb.bindSetEntry(SerializedLayerConfigurationSet.class,
+          configurationSerializer.toString(finalLayerConfiguration));
     }
 
     jb.bindImplementation(ParameterProvider.class, parameterProviderClass);
-    jb.bindNamedParameter(NeuralNetworkConfigurationParameters.Stepsize.class, String.valueOf(stepsize));
+    jb.bindNamedParameter(Stepsize.class, String.valueOf(stepsize));
+    jb.bindNamedParameter(InputShape.class, inputShape);
 
     return jb.build();
   }

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/conf/NeuralNetworkConfigurationParameters.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/conf/NeuralNetworkConfigurationParameters.java
@@ -43,4 +43,8 @@ public final class NeuralNetworkConfigurationParameters {
   @NamedParameter(doc = "step size")
   public static final class Stepsize implements Name<Float> {
   }
+
+  @NamedParameter(doc = "the shape of input data")
+  public static final class InputShape implements Name<String> {
+  }
 }

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/layerparam/initializer/DefaultLayerParameterInitializer.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/layerparam/initializer/DefaultLayerParameterInitializer.java
@@ -22,21 +22,27 @@ import org.apache.reef.tang.annotations.Parameter;
 
 import javax.inject.Inject;
 
+import static edu.snu.dolphin.dnn.util.NeuralNetworkUtils.shapeFromString;
+
 /**
  * Default parameter initializer.
  *
  * This initializer is for layers which do not have layer parameters (i.e. not learnable layer).
+ * This initializer is used for layers whose output shape is equal to input shape.
  */
 public final class DefaultLayerParameterInitializer implements LayerParameterInitializer {
 
   private final int index;
+  private final int[] inputShape;
   private final LayerParameter emptyLayerParam;
 
   @Inject
   public DefaultLayerParameterInitializer(
       final MatrixFactory matrixFactory,
-      @Parameter(LayerConfigurationParameters.LayerIndex.class) final int index) {
+      @Parameter(LayerConfigurationParameters.LayerIndex.class) final int index,
+      @Parameter(LayerConfigurationParameters.LayerInputShape.class) final String inputShape) {
     this.index = index;
+    this.inputShape = shapeFromString(inputShape);
     this.emptyLayerParam = LayerParameter.newEmptyInstance(matrixFactory);
   }
 
@@ -53,4 +59,10 @@ public final class DefaultLayerParameterInitializer implements LayerParameterIni
   public int getIndex() {
     return index;
   }
+
+  @Override
+  public int[] getOutputShape() {
+    return inputShape;
+  }
+
 }

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/layerparam/initializer/FullyConnectedLayerParameterInitializer.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/layerparam/initializer/FullyConnectedLayerParameterInitializer.java
@@ -23,6 +23,9 @@ import org.apache.reef.tang.annotations.Parameter;
 
 import javax.inject.Inject;
 
+import static edu.snu.dolphin.dnn.util.NeuralNetworkUtils.getShapeLength;
+import static edu.snu.dolphin.dnn.util.NeuralNetworkUtils.shapeFromString;
+
 /**
  * Parameter Initializer of fully connected layer.
  *
@@ -43,7 +46,7 @@ public final class FullyConnectedLayerParameterInitializer implements LayerParam
   public FullyConnectedLayerParameterInitializer(
       final MatrixFactory matrixFactory,
       @Parameter(LayerConfigurationParameters.LayerIndex.class) final int index,
-      @Parameter(LayerConfigurationParameters.NumberOfInput.class) final int numInput,
+      @Parameter(LayerConfigurationParameters.LayerInputShape.class) final String inputShape,
       @Parameter(LayerConfigurationParameters.NumberOfOutput.class) final int numOutput,
       @Parameter(LayerConfigurationParameters.RandomSeed.class) final long randomSeed,
       @Parameter(LayerConfigurationParameters.InitialWeight.class) final float initWeight,
@@ -51,7 +54,7 @@ public final class FullyConnectedLayerParameterInitializer implements LayerParam
     this.matrixFactory = matrixFactory;
     this.index = index;
     this.randomSeed = randomSeed;
-    this.numInput = numInput;
+    this.numInput = getShapeLength(shapeFromString(inputShape));
     this.numOutput = numOutput;
     this.initWeight = initWeight;
     this.initBias = initBias;
@@ -75,5 +78,10 @@ public final class FullyConnectedLayerParameterInitializer implements LayerParam
   @Override
   public int getIndex() {
     return this.index;
+  }
+
+  @Override
+  public int[] getOutputShape() {
+    return new int[]{numOutput};
   }
 }

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/layerparam/initializer/LayerParameterInitializer.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/layerparam/initializer/LayerParameterInitializer.java
@@ -35,4 +35,9 @@ public interface LayerParameterInitializer {
    * @return the index of the layer.
    */
   int getIndex();
+
+  /**
+   * @return the shape of output.
+   */
+  int[] getOutputShape();
 }

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/layers/ActivationLayer.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/layers/ActivationLayer.java
@@ -18,9 +18,7 @@ package edu.snu.dolphin.dnn.layers;
 import edu.snu.dolphin.dnn.blas.Matrix;
 import edu.snu.dolphin.dnn.blas.function.Function;
 import edu.snu.dolphin.dnn.blas.function.FunctionFactory;
-import edu.snu.dolphin.dnn.conf.LayerConfigurationParameters.ActivationFunction;
-import edu.snu.dolphin.dnn.conf.LayerConfigurationParameters.LayerIndex;
-import edu.snu.dolphin.dnn.conf.LayerConfigurationParameters.NumberOfOutput;
+import edu.snu.dolphin.dnn.conf.LayerConfigurationParameters.*;
 import org.apache.reef.tang.annotations.Parameter;
 
 import javax.inject.Inject;
@@ -37,10 +35,15 @@ public final class ActivationLayer extends LayerBase {
 
   @Inject
   public ActivationLayer(@Parameter(LayerIndex.class) final int index,
-                         @Parameter(ActivationFunction.class) final String activationFunction,
-                         @Parameter(NumberOfOutput.class) final int numOutput) {
-    super(index, numOutput);
+                         @Parameter(LayerInputShape.class) final String inputShape,
+                         @Parameter(ActivationFunction.class) final String activationFunction) {
+    super(index, inputShape);
     this.activationFunction = FunctionFactory.getSingleInstance(activationFunction);
+  }
+
+  @Override
+  public int[] getOutputShape() {
+    return getInputShape();
   }
 
   /** {@inheritDoc} */

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/layers/FullyConnectedLayer.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/layers/FullyConnectedLayer.java
@@ -16,8 +16,7 @@
 package edu.snu.dolphin.dnn.layers;
 
 import edu.snu.dolphin.dnn.blas.Matrix;
-import edu.snu.dolphin.dnn.conf.LayerConfigurationParameters.LayerIndex;
-import edu.snu.dolphin.dnn.conf.LayerConfigurationParameters.NumberOfOutput;
+import edu.snu.dolphin.dnn.conf.LayerConfigurationParameters.*;
 import edu.snu.dolphin.dnn.layerparam.initializer.LayerParameterInitializer;
 import org.apache.reef.tang.annotations.Parameter;
 
@@ -32,12 +31,21 @@ import javax.inject.Inject;
  */
 public final class FullyConnectedLayer extends LayerBase {
 
+  private final int[] outputShape;
+
   @Inject
   public FullyConnectedLayer(@Parameter(LayerIndex.class) final int index,
-                             @Parameter(NumberOfOutput.class) final int numOutput,
+                             @Parameter(LayerInputShape.class) final String inputShape,
                              final LayerParameterInitializer layerParameterInitializer) {
-    super(index, numOutput);
+    super(index, inputShape);
+    this.outputShape = layerParameterInitializer.getOutputShape();
     setLayerParameter(layerParameterInitializer.generateInitialParameter());
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public int[] getOutputShape() {
+    return outputShape;
   }
 
   /** {@inheritDoc} */

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/layers/LayerBase.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/layers/LayerBase.java
@@ -17,18 +17,25 @@ package edu.snu.dolphin.dnn.layers;
 
 import edu.snu.dolphin.dnn.blas.Matrix;
 
+import static edu.snu.dolphin.dnn.util.NeuralNetworkUtils.shapeFromString;
+
 /**
  * Abstract class for the layer of a neural network.
  */
 public abstract class LayerBase {
 
   private final int index;
-  private final int numOutput;
   private LayerParameter layerParameter;
+  private final int[] inputShape;
 
-  protected LayerBase(final int index, final int numOutput) {
+  protected LayerBase(final int index, final int[] inputShape) {
     this.index = index;
-    this.numOutput = numOutput;
+    this.inputShape = inputShape;
+  }
+
+  protected LayerBase(final int index, final String inputShapeString) {
+    this.index = index;
+    this.inputShape = shapeFromString(inputShapeString);
   }
 
   /**
@@ -39,11 +46,16 @@ public abstract class LayerBase {
   }
 
   /**
-   * @return the number of layer output nodes.
+   * @return the shape of inputs.
    */
-  public final int getNumOutput() {
-    return this.numOutput;
+  public final int[] getInputShape() {
+    return this.inputShape;
   }
+
+  /**
+   * @return the shape of outputs.
+   */
+  public abstract int[] getOutputShape();
 
   /**
    * Replaces the parameter of the layer.

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/layers/LayerBase.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/layers/LayerBase.java
@@ -28,11 +28,6 @@ public abstract class LayerBase {
   private LayerParameter layerParameter;
   private final int[] inputShape;
 
-  protected LayerBase(final int index, final int[] inputShape) {
-    this.index = index;
-    this.inputShape = inputShape;
-  }
-
   protected LayerBase(final int index, final String inputShapeString) {
     this.index = index;
     this.inputShape = shapeFromString(inputShapeString);

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/util/NeuralNetworkUtils.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/util/NeuralNetworkUtils.java
@@ -1,0 +1,258 @@
+/*
+ * Copyright (C) 2015 Seoul National University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.snu.dolphin.dnn.util;
+
+import edu.snu.dolphin.dnn.blas.MatrixFactory;
+import edu.snu.dolphin.dnn.conf.LayerConfigurationParameters;
+import edu.snu.dolphin.dnn.layerparam.initializer.LayerParameterInitializer;
+import edu.snu.dolphin.dnn.layers.LayerBase;
+import edu.snu.dolphin.dnn.layers.LayerParameter;
+import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.ArrayUtils;
+import org.apache.reef.tang.Configuration;
+import org.apache.reef.tang.Injector;
+import org.apache.reef.tang.Tang;
+import org.apache.reef.tang.exceptions.InjectionException;
+import org.apache.reef.tang.formats.ConfigurationSerializer;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Utility class for neural network.
+ */
+public final class NeuralNetworkUtils {
+
+  private NeuralNetworkUtils() {
+  }
+
+  /**
+   * Delimiter that is used for distinguishing dimensions of shapes.
+   */
+  private static final String SHAPE_DELIMITER = ",";
+
+  /**
+   * Converts a list of integer for a shape to a string.
+   * @param dimensionList a list of integers for a shape.
+   * @return a string for a shape.
+   */
+  public static String shapeToString(final List<Integer> dimensionList) {
+    return StringUtils.join(dimensionList, SHAPE_DELIMITER);
+  }
+
+  /**
+   * Converts an array of {@code int} for a shape to a string.
+   * @param dimensions an array of {@code int}s for a shape.
+   * @return a string for a shape.
+   */
+  public static String shapeToString(final int[] dimensions) {
+    return shapeToString(Arrays.asList(ArrayUtils.toObject(dimensions)));
+  }
+
+  /**
+   * Converts a string for a shape to an array of integers.
+   * @param shapeString a string for a shape.
+   * @return an array of integers for a shape.
+   */
+  public static int[] shapeFromString(final String shapeString) {
+    final String[] inputShapeStrings = shapeString.split(SHAPE_DELIMITER);
+    final int[] inputShape = new int[inputShapeStrings.length];
+    for (int i = 0; i < inputShapeStrings.length; ++i) {
+      inputShape[i] = Integer.parseInt(inputShapeStrings[i]);
+    }
+    return inputShape;
+  }
+
+  public static int getShapeLength(final int[] shape) {
+    if (shape.length < 1) {
+      throw new IllegalArgumentException("the shape must have one or more dimensions");
+    }
+
+    int length = shape[0];
+    for (int i = 1; i < shape.length; ++i) {
+      length *= shape[i];
+    }
+
+    if (length > 0) {
+      return length;
+    } else {
+      throw new IllegalArgumentException("the length of the shape must be positive: " + length);
+    }
+  }
+
+  /**
+   * De-serializes a set of serialized layer configurations to an array of layer configurations.
+   * @param configurationSerializer a configuration serializer to deserialize the specified configuration set.
+   * @param serializedLayerConfSet a set of serialized layer configurations.
+   * @return an array of layer configurations.
+   */
+  public static Configuration[] deserializeLayerConfSetToArray(
+      final ConfigurationSerializer configurationSerializer,
+      final Set<String> serializedLayerConfSet) {
+    final Configuration[] layerConfigurations = new Configuration[serializedLayerConfSet.size()];
+    for (final String serializedLayerConfiguration : serializedLayerConfSet) {
+      try {
+        final Configuration layerConfiguration = configurationSerializer.fromString(serializedLayerConfiguration);
+        final int index = Tang.Factory.getTang().newInjector(layerConfiguration)
+            .getNamedInstance(LayerConfigurationParameters.LayerIndex.class);
+        layerConfigurations[index] = layerConfiguration;
+      } catch (final IOException exception) {
+        throw new RuntimeException("IOException while de-serializing layer configuration", exception);
+      } catch (final InjectionException exception) {
+        throw new RuntimeException("InjectionException", exception);
+      }
+    }
+    return layerConfigurations;
+  }
+
+  /**
+   * Returns initial layer parameters from the specified set of configurations and the input shape.
+   * @param layerInitializerConfs an array of configurations for injecting layer initializers
+   * @param inputShape an input shape for the neural network.
+   * @param matrixFactoryClass a matrix factory class for instantiate matrices
+   * @return an array of initial layer parameters
+   */
+  public static LayerParameter[] getInitialLayerParameters(final Configuration[] layerInitializerConfs,
+                                                           final String inputShape,
+                                                           final Class<? extends MatrixFactory> matrixFactoryClass) {
+    final LayerParameter[] layerParameters = new LayerParameter[layerInitializerConfs.length];
+
+    String currentInputShape = inputShape;
+    for (int i = 0; i < layerInitializerConfs.length; ++i) {
+      try {
+        // bind an input shape for the layer and the matrix factory.
+        final Configuration finalInitializerConf =
+            Tang.Factory.getTang().newConfigurationBuilder(layerInitializerConfs[i])
+                .bindNamedParameter(LayerConfigurationParameters.LayerInputShape.class, currentInputShape)
+                .bindImplementation(MatrixFactory.class, matrixFactoryClass)
+                .build();
+        final LayerParameterInitializer layerParameterInitializer =
+            Tang.Factory.getTang().newInjector(finalInitializerConf).getInstance(LayerParameterInitializer.class);
+
+        layerParameters[i] = layerParameterInitializer.generateInitialParameter();
+        currentInputShape = shapeToString(layerParameterInitializer.getOutputShape());
+
+      } catch (final InjectionException e) {
+        throw new RuntimeException("InjectionException while injecting LayerParameterInitializer", e);
+      }
+    }
+    return layerParameters;
+  }
+
+  /**
+   * Returns initial layer parameters using the specified injector and the specified array of configurations.
+   * This assumes that the specified injector has all parameters that are needed to inject layer parameter initializer
+   * instances except the configuration for each layer.
+   * @param injector an injector used for injecting layer parameter initializer instances
+   * @param layerInitializerConfs an array of configurations for injecting layer parameter initializer instances
+   * @param inputShape an input shape for the neural network.
+   * @return an array of initial layer parameters
+   */
+  public static LayerParameter[] getInitialLayerParameters(final Injector injector,
+                                                           final Configuration[] layerInitializerConfs,
+                                                           final String inputShape) {
+    final LayerParameter[] layerParameters = new LayerParameter[layerInitializerConfs.length];
+
+    String currentInputShape = inputShape;
+    for (int i = 0; i < layerInitializerConfs.length; ++i) {
+      try {
+        // bind an input shape for the layer.
+        final Configuration finalInitializerConf =
+            Tang.Factory.getTang().newConfigurationBuilder(layerInitializerConfs[i])
+                .bindNamedParameter(LayerConfigurationParameters.LayerInputShape.class, currentInputShape)
+                .build();
+        final LayerParameterInitializer layerParameterInitializer =
+            injector.forkInjector(finalInitializerConf).getInstance(LayerParameterInitializer.class);
+        final int index = layerParameterInitializer.getIndex();
+
+        layerParameters[index] = layerParameterInitializer.generateInitialParameter();
+        currentInputShape = shapeToString(layerParameterInitializer.getOutputShape());
+
+      } catch (final InjectionException exception) {
+        throw new RuntimeException("InjectionException during injecting LayerParameterInitializer", exception);
+      }
+    }
+    return layerParameters;
+  }
+
+  /**
+   * Returns layer instances from the specified array of configurations for layer instances.
+   * @param layerConfs an array of configurations for layer instances
+   * @param inputShape an input shape for the neural network
+   * @param matrixFactoryClass a class for {@link MatrixFactory}
+   * @return an array of layer instances
+   */
+  public static LayerBase[] getLayerInstances(final Configuration[] layerConfs,
+                                              final String inputShape,
+                                              final Class<? extends MatrixFactory> matrixFactoryClass) {
+    final LayerBase[] layers = new LayerBase[layerConfs.length];
+
+    String currentInputShape = inputShape;
+    for (int i = 0; i < layerConfs.length; ++i) {
+      try {
+        // bind an input shape for the layer and the matrix factory.
+        final Configuration finalLayerConf = Tang.Factory.getTang().newConfigurationBuilder(layerConfs[i])
+            .bindNamedParameter(LayerConfigurationParameters.LayerInputShape.class, currentInputShape)
+            .bindImplementation(MatrixFactory.class, matrixFactoryClass)
+            .build();
+        final Injector injector = Tang.Factory.getTang().newInjector(finalLayerConf);
+        final LayerBase layer = injector.getInstance(LayerBase.class);
+
+        layers[i] = layer;
+        currentInputShape = shapeToString(layer.getOutputShape());
+
+      } catch (final InjectionException exception) {
+        throw new RuntimeException("InjectionException while injecting LayerBase", exception);
+      }
+    }
+    return layers;
+  }
+
+  /**
+   * Returns layer instances using the specified injector and the specified array of configurations.
+   * This assumes that the specified injector has all parameters that are needed to inject layer instances
+   * except the configuration for each layer.
+   * @param injector an injector used for injecting layer instances
+   * @param layerConfs an array of configurations for injecting layer instances
+   * @param inputShape an input shape for the neural network.
+   * @return an array of layer instances.
+   */
+  public static LayerBase[] getLayerInstances(final Injector injector,
+                                              final Configuration[] layerConfs,
+                                              final String inputShape) {
+    final LayerBase[] layers = new LayerBase[layerConfs.length];
+
+    String currentInputShape = inputShape;
+    for (int i = 0; i < layerConfs.length; ++i) {
+      try {
+        // bind an input shape for the layer.
+        final Configuration finalLayerConf = Tang.Factory.getTang().newConfigurationBuilder(layerConfs[i])
+            .bindNamedParameter(LayerConfigurationParameters.LayerInputShape.class, currentInputShape)
+            .build();
+        final LayerBase layer = injector.forkInjector(finalLayerConf).getInstance(LayerBase.class);
+
+        layers[layer.getIndex()] = layer;
+        currentInputShape = shapeToString(layer.getOutputShape());
+
+      } catch (final InjectionException exception) {
+        throw new RuntimeException("InjectionException while injecting LayerBase", exception);
+      }
+    }
+    return layers;
+  }
+}

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/util/NeuralNetworkUtils.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/util/NeuralNetworkUtils.java
@@ -47,7 +47,7 @@ public final class NeuralNetworkUtils {
   private static final String SHAPE_DELIMITER = ",";
 
   /**
-   * Converts a list of integer for a shape to a string.
+   * Converts a list of integers for a shape to a string.
    * @param dimensionList a list of integers for a shape.
    * @return a string for a shape.
    */
@@ -56,7 +56,7 @@ public final class NeuralNetworkUtils {
   }
 
   /**
-   * Converts an array of {@code int} for a shape to a string.
+   * Converts an array of {@code int}s for a shape to a string.
    * @param dimensions an array of {@code int}s for a shape.
    * @return a string for a shape.
    */

--- a/dolphin-dnn/src/main/proto/neural_network.proto
+++ b/dolphin-dnn/src/main/proto/neural_network.proto
@@ -20,6 +20,7 @@ message FullyConnectedLayerConfiguration {
   required float init_bias = 1;
   required float init_weight = 2;
   optional uint32 random_seed = 3;
+  required uint32 num_output = 4;
 }
 
 message ActivationLayerConfiguration {
@@ -33,11 +34,9 @@ message ActivationWithLossLayerConfiguration {
 
 message LayerConfiguration {
   required string type = 1;
-  required uint32 num_input = 2;
-  required uint32 num_output = 3;
-  optional FullyConnectedLayerConfiguration fully_connected_param = 4;
-  optional ActivationLayerConfiguration activation_param = 5;
-  optional ActivationWithLossLayerConfiguration activation_with_loss_param = 6;
+  optional FullyConnectedLayerConfiguration fully_connected_param = 2;
+  optional ActivationLayerConfiguration activation_param = 3;
+  optional ActivationWithLossLayerConfiguration activation_with_loss_param = 4;
 }
 
 message ParameterProviderConfiguration {

--- a/dolphin-dnn/src/test/java/edu/snu/dolphin/dnn/NeuralNetworkTest.java
+++ b/dolphin-dnn/src/test/java/edu/snu/dolphin/dnn/NeuralNetworkTest.java
@@ -72,11 +72,11 @@ public final class NeuralNetworkTest {
       expectedOutput};
 
   private final Configuration neuralNetworkConfiguration = NeuralNetworkConfigurationBuilder.newConfigurationBuilder()
+      .setInputShape(input.getLength())
       .setStepsize(1e-2f)
       .setParameterProviderClass(LocalNeuralNetParameterProvider.class)
       .addLayerConfiguration(
           FullyConnectedLayerConfigurationBuilder.newConfigurationBuilder()
-              .setNumInput(input.getLength())
               .setNumOutput(numHiddenUnits)
               .setInitWeight(0.0001f)
               .setInitBias(0.0002f)
@@ -84,21 +84,16 @@ public final class NeuralNetworkTest {
               .build())
       .addLayerConfiguration(
           ActivationLayerConfigurationBuilder.newConfigurationBuilder()
-              .setNumInput(numHiddenUnits)
-              .setNumOutput(numHiddenUnits)
               .setActivationFunction("sigmoid")
               .build())
       .addLayerConfiguration(
           FullyConnectedLayerConfigurationBuilder.newConfigurationBuilder()
-              .setNumInput(numHiddenUnits)
               .setNumOutput(expectedOutput.getLength())
               .setInitWeight(0.2f)
               .setInitBias(0.3f)
               .setRandomSeed(10)
               .build())
       .addLayerConfiguration(ActivationWithLossLayerConfigurationBuilder.newConfigurationBuilder()
-          .setNumInput(expectedOutput.getLength())
-          .setNumOutput(expectedOutput.getLength())
           .setActivationFunction("sigmoid")
           .setLossFunction("crossentropy")
           .build())

--- a/dolphin-dnn/src/test/java/edu/snu/dolphin/dnn/layers/ActivationLayerTest.java
+++ b/dolphin-dnn/src/test/java/edu/snu/dolphin/dnn/layers/ActivationLayerTest.java
@@ -19,13 +19,14 @@ import edu.snu.dolphin.dnn.blas.Matrix;
 import edu.snu.dolphin.dnn.blas.MatrixFactory;
 import edu.snu.dolphin.dnn.blas.jblas.MatrixJBLASFactory;
 import edu.snu.dolphin.dnn.conf.ActivationLayerConfigurationBuilder;
-import edu.snu.dolphin.dnn.conf.LayerConfigurationParameters;
+import edu.snu.dolphin.dnn.conf.LayerConfigurationParameters.*;
 import org.apache.reef.tang.Configuration;
 import org.apache.reef.tang.Tang;
 import org.apache.reef.tang.exceptions.InjectionException;
 import org.junit.Before;
 import org.junit.Test;
 
+import static edu.snu.dolphin.dnn.util.NeuralNetworkUtils.shapeToString;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -65,15 +66,16 @@ public final class ActivationLayerTest {
   @Before
   public void setup() throws InjectionException {
     final Configuration layerConf = Tang.Factory.getTang().newConfigurationBuilder()
-        .bindNamedParameter(LayerConfigurationParameters.LayerIndex.class, String.valueOf(0))
+        .bindNamedParameter(LayerIndex.class, String.valueOf(0))
+        .bindNamedParameter(LayerInputShape.class, shapeToString(new int[]{input.getLength()}))
         .build();
 
-    final ActivationLayerConfigurationBuilder builder = ActivationLayerConfigurationBuilder.newConfigurationBuilder()
-        .setNumInput(input.getLength())
-        .setNumOutput(expectedSigmoidActivation.getLength());
+    final Configuration sigmoidActivationLayerConf = ActivationLayerConfigurationBuilder.newConfigurationBuilder()
+        .setActivationFunction("sigmoid")
+        .build();
 
     this.sigmoidActivationLayer =
-        Tang.Factory.getTang().newInjector(layerConf, builder.setActivationFunction("sigmoid").build())
+        Tang.Factory.getTang().newInjector(layerConf, sigmoidActivationLayerConf)
         .getInstance(LayerBase.class);
   }
 

--- a/dolphin-dnn/src/test/resources/configuration/neuralnet
+++ b/dolphin-dnn/src/test/resources/configuration/neuralnet
@@ -47,10 +47,8 @@ layer {
 }
 layer {
   type: "ActivationWithLoss"
-  num_input: 10
-  num_output: 10
   activation_with_loss_param {
     activation_function: "softmax"
-    loss_function: "crossentropy"
+    loss_function: "crossEntropy"
   }
 }

--- a/dolphin-dnn/src/test/resources/configuration/neuralnet
+++ b/dolphin-dnn/src/test/resources/configuration/neuralnet
@@ -25,28 +25,24 @@ parameter_provider {
 }
 layer {
   type: "FullyConnected"
-  num_input: 784
-  num_output: 50
   fully_connected_param {
     init_weight: 1e-4
     init_bias: 2e-4
+    num_output: 50
   }
 }
 layer {
   type: "Activation"
-  num_input: 50
-  num_output: 50
   activation_param {
     activation_function: "relu"
   }
 }
 layer {
   type: "FullyConnected"
-  num_input: 50
-  num_output: 10
   fully_connected_param {
     init_weight: 1e-2
     init_bias: 2e-2
+    num_output: 10
   }
 }
 layer {

--- a/dolphin-dnn/src/test/resources/configuration/neuralnet_groupcomm
+++ b/dolphin-dnn/src/test/resources/configuration/neuralnet_groupcomm
@@ -49,6 +49,6 @@ layer {
   type: "ActivationWithLoss"
   activation_with_loss_param {
     activation_function: "softmax"
-    loss_function: "crossentropy"
+    loss_function: "crossEntropy"
   }
 }

--- a/dolphin-dnn/src/test/resources/configuration/neuralnet_groupcomm
+++ b/dolphin-dnn/src/test/resources/configuration/neuralnet_groupcomm
@@ -25,34 +25,28 @@ parameter_provider {
 }
 layer {
   type: "FullyConnected"
-  num_input: 784
-  num_output: 50
   fully_connected_param {
     init_weight: 1e-4
     init_bias: 2e-4
+    num_output: 50
   }
 }
 layer {
   type: "Activation"
-  num_input: 50
-  num_output: 50
   activation_param {
     activation_function: "relu"
   }
 }
 layer {
   type: "FullyConnected"
-  num_input: 50
-  num_output: 10
   fully_connected_param {
     init_weight: 1e-2
     init_bias: 2e-2
+    num_output: 10
   }
 }
 layer {
   type: "ActivationWithLoss"
-  num_input: 10
-  num_output: 10
   activation_with_loss_param {
     activation_function: "softmax"
     loss_function: "crossentropy"

--- a/dolphin-dnn/src/test/resources/configuration/neuralnet_ps
+++ b/dolphin-dnn/src/test/resources/configuration/neuralnet_ps
@@ -49,6 +49,6 @@ layer {
   type: "ActivationWithLoss"
   activation_with_loss_param {
     activation_function: "softmax"
-    loss_function: "crossentropy"
+    loss_function: "crossEntropy"
   }
 }

--- a/dolphin-dnn/src/test/resources/configuration/neuralnet_ps
+++ b/dolphin-dnn/src/test/resources/configuration/neuralnet_ps
@@ -25,34 +25,28 @@ parameter_provider {
 }
 layer {
   type: "FullyConnected"
-  num_input: 784
-  num_output: 50
   fully_connected_param {
     init_weight: 1e-4
     init_bias: 2e-4
+    num_output: 50
   }
 }
 layer {
   type: "Activation"
-  num_input: 50
-  num_output: 50
   activation_param {
     activation_function: "relu"
   }
 }
 layer {
   type: "FullyConnected"
-  num_input: 50
-  num_output: 10
   fully_connected_param {
     init_weight: 1e-2
     init_bias: 2e-2
+    num_output: 10
   }
 }
 layer {
   type: "ActivationWithLoss"
-  num_input: 10
-  num_output: 10
   activation_with_loss_param {
     activation_function: "softmax"
     loss_function: "crossentropy"


### PR DESCRIPTION
This pull request removes `num_input` and `num_output` options for layer configurations. The `num_input` and `num_output` not only are meaningful only with 1-dimensional inputs, but also input and output shapes of layers can be inferred by other options for layers, such as kernel size for convolutional layers and the number of outputs for fully connected layers.

Moreover, the codes for instantiating layers and generating layer parameters are repeatedly used at several points. This PR introduces the utility class for neural network, `NeuralNetworkUtils`, for neural network related operations including generating layer instances and layer parameters.

In addition, this pull request brings back the support for arbitrary dimensional inputs that was lost in #148.
While input data had its dimension information with ND4J library, each layer has its input shape with which layers can process spatial operations on input data.

This closes #146.