### PR TITLE
Use batch matrices in which each column represents an input instance.

### DIFF
--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/NeuralNetwork.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/NeuralNetwork.java
@@ -37,6 +37,9 @@ import static edu.snu.dolphin.dnn.util.NeuralNetworkUtils.deserializeLayerConfSe
 
 /**
  * Neural network model.
+ *
+ * The input matrix for the neural network model is a collection of input instances.
+ * Each column of the matrix represents each input instance.
  */
 public final class NeuralNetwork {
 
@@ -103,7 +106,7 @@ public final class NeuralNetwork {
     final Matrix[] errors = backPropagate(activations, label);
     final LayerParameter[] parameterGradients = generateParameterGradients(activations, errors);
 
-    parameterProvider.push(input.getRows(), parameterGradients);
+    parameterProvider.push(input.getColumns(), parameterGradients);
 
     final LayerParameter[] updatedParameters = parameterProvider.pull();
     for (int i = 0; i < layers.length; ++i) {
@@ -120,7 +123,7 @@ public final class NeuralNetwork {
    */
   public void train(final Matrix input, final int[] labels) {
     final Matrix labelMatrix = createOutputMatrix(
-        matrixFactory, labels, getShapeLength(layers[layers.length - 1].getOutputShape())).transpose();
+        matrixFactory, labels, getShapeLength(layers[layers.length - 1].getOutputShape()));
     train(input, labelMatrix);
   }
 

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/NeuralNetwork.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/NeuralNetwork.java
@@ -120,7 +120,7 @@ public final class NeuralNetwork {
    */
   public void train(final Matrix input, final int[] labels) {
     final Matrix labelMatrix = createOutputMatrix(
-        matrixFactory, labels, getShapeLength(layers[layers.length - 1].getOutputShape()));
+        matrixFactory, labels, getShapeLength(layers[layers.length - 1].getOutputShape())).transpose();
     train(input, labelMatrix);
   }
 

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/NeuralNetworkTask.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/NeuralNetworkTask.java
@@ -86,7 +86,7 @@ public final class NeuralNetworkTask implements Task {
       final int[] labels = data.getFirst().getSecond();
       final boolean isValidation = data.getSecond();
 
-      if (input.getRows() != labels.length) {
+      if (input.getColumns() != labels.length) {
         throw new RuntimeException("The number of inputs is not equal to the number of labels");
       }
 

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/blas/Matrix.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/blas/Matrix.java
@@ -38,7 +38,7 @@ public interface Matrix {
   float get(int index);
 
   /**
-   * Returns a row vector in which elements are specified by the given linear indices.
+   * Returns a column vector in which elements are specified by the given linear indices.
    * The modification on the returned vector does not affect this matrix.
    */
   Matrix get(int[] indices);

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/blas/MatrixFactory.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/blas/MatrixFactory.java
@@ -21,9 +21,9 @@ package edu.snu.dolphin.dnn.blas;
 public interface MatrixFactory {
 
   /**
-   * Creates a row vector.
-   * @param length the length of a row vector
-   * @return a generated row vector
+   * Creates a column vector.
+   * @param length the length of a column vector
+   * @return a generated column vector
    */
   Matrix create(int length);
 
@@ -36,9 +36,9 @@ public interface MatrixFactory {
   Matrix create(int rows, int columns);
 
   /**
-   * Creates a row vector with the given values.
-   * @param data elements of a row vector
-   * @return a generated row vector
+   * Creates a column vector with the given values.
+   * @param data elements of a column vector
+   * @return a generated column vector
    */
   Matrix create(float[] data);
 
@@ -60,9 +60,9 @@ public interface MatrixFactory {
   Matrix create(float[] data, int rows, int columns);
 
   /**
-   * Creates a row vector in which all elements are equal to {@code 1}.
-   * @param length the length of a row vector
-   * @return a generated row vector
+   * Creates a column vector in which all elements are equal to {@code 1}.
+   * @param length the length of a column vector
+   * @return a generated column vector
    */
   Matrix ones(int length);
 
@@ -75,9 +75,9 @@ public interface MatrixFactory {
   Matrix ones(int rows, int columns);
 
   /**
-   * Creates a row vector in which all elements are equal to {@code 0}.
-   * @param length the length of a row vector
-   * @return a generated row vector
+   * Creates a column vector in which all elements are equal to {@code 0}.
+   * @param length the length of a column vector
+   * @return a generated column vector
    */
   Matrix zeros(int length);
 
@@ -90,9 +90,9 @@ public interface MatrixFactory {
   Matrix zeros(int rows, int columns);
 
   /**
-   * Creates a row vector with random values uniformly distributed in 0..1.
-   * @param length the length of a row vector
-   * @return a generated row vector
+   * Creates a column vector with random values uniformly distributed in 0..1.
+   * @param length the length of a column vector
+   * @return a generated column vector
    */
   Matrix rand(int length);
 
@@ -114,9 +114,9 @@ public interface MatrixFactory {
   Matrix rand(int rows, int columns, long seed);
 
   /**
-   * Creates a row vector containing normally distributed random values with mean 0.0 and standard deviation 1.0.
-   * @param length the length of a row vector
-   * @return a generated row vector
+   * Creates a column vector containing normally distributed random values with mean 0.0 and standard deviation 1.0.
+   * @param length the length of a column vector
+   * @return a generated column vector
    */
   Matrix randn(int length);
 

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/blas/MatrixUtils.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/blas/MatrixUtils.java
@@ -123,7 +123,7 @@ public final class MatrixUtils {
   }
 
   /**
-   * Creates a column vector in which only element at the specified position is {@code 1}
+   * Creates a column vector in which the only element at the specified position is {@code 1}
    * and other elements are {@code 0}.
    *
    * @param matrixFactory a matrix factory used to create a matrix
@@ -136,7 +136,7 @@ public final class MatrixUtils {
   }
 
   /**
-   * Creates a matrix of which each column is an one-hot vector specified by each element of the given indices array.
+   * Creates a matrix of which each column is a one-hot vector specified by each element of the given indices array.
    * @param matrixFactory a matrix factory used to create a matrix
    * @param indices the array of indices that indicate the one-hot positions
    * @param length the length of each column vector, in other words, the number of rows of the return matrix

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/blas/MatrixUtils.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/blas/MatrixUtils.java
@@ -79,23 +79,23 @@ public final class MatrixUtils {
     final BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream));
     String line;
     final List<float[]> dataList = new ArrayList<>();
-    int numColumns = -1;
+    int numRows = -1;
     final Matrix ret;
     while ((line = reader.readLine()) != null) {
       final String[] data = line.trim().split(delimiter);
-      if (numColumns < 0) {
-        numColumns = data.length;
+      if (numRows < 0) {
+        numRows = data.length;
       } else {
-        if (data.length != numColumns) {
-          throw new RuntimeException("Data has inconsistent number of columns");
+        if (data.length != numRows) {
+          throw new RuntimeException("Data has inconsistent length");
         }
       }
       dataList.add(readSplit(data));
     }
 
-    ret = matrixFactory.create(dataList.size(), numColumns);
+    ret = matrixFactory.create(numRows, dataList.size());
     for (int i = 0; i < dataList.size(); i++) {
-      ret.putRow(i, matrixFactory.create(dataList.get(i)));
+      ret.putColumn(i, matrixFactory.create(dataList.get(i)));
     }
     return ret;
   }
@@ -123,28 +123,29 @@ public final class MatrixUtils {
   }
 
   /**
-   * Creates a row vector in which only element at the specified position is {@code 1} and other elements are {@code 0}.
+   * Creates a column vector in which only element at the specified position is {@code 1}
+   * and other elements are {@code 0}.
    *
    * @param matrixFactory a matrix factory used to create a matrix
    * @param index an index of the element to be set to {@code}
-   * @param length the length of a row vector
-   * @return a generated row vector
+   * @param length the length of a column vector
+   * @return a generated column vector
    */
   public static Matrix createOutputVector(final MatrixFactory matrixFactory, final int index, final int length) {
     return matrixFactory.zeros(length).put(index, 1.0f);
   }
 
   /**
-   * Creates a matrix of which each row is a one-hot vector specified by each element of the given indices array.
+   * Creates a matrix of which each column is an one-hot vector specified by each element of the given indices array.
    * @param matrixFactory a matrix factory used to create a matrix
    * @param indices the array of indices that indicate the one-hot positions
-   * @param length the length of each row vector, in other words, the number of columns of the return matrix
+   * @param length the length of each column vector, in other words, the number of rows of the return matrix
    * @return the generated matrix
    */
   public static Matrix createOutputMatrix(final MatrixFactory matrixFactory, final int[] indices, final int length) {
-    final Matrix ret = matrixFactory.zeros(indices.length, length);
+    final Matrix ret = matrixFactory.zeros(length, indices.length);
     for (int i = 0; i < indices.length; ++i) {
-      ret.put(i, indices[i], 1.0f);
+      ret.put(indices[i], i, 1.0f);
     }
     return ret;
   }

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/blas/function/Softmax.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/blas/function/Softmax.java
@@ -20,6 +20,8 @@ import edu.snu.dolphin.dnn.blas.MatrixFunctions;
 
 /**
  * Softmax function.
+ *
+ * Assumes each column represents each input instance.
  */
 final class Softmax implements Function {
 
@@ -36,12 +38,12 @@ final class Softmax implements Function {
    */
   @Override
   public Matrix applyi(final Matrix m) {
-    // subtract the maximum values of each row
-    m.subiColumnVector(m.rowMaxs());
+    // subtract the maximum values of each column
+    m.subiRowVector(m.columnMaxs());
     // exponentiation
     MatrixFunctions.expi(m);
-    // divide by the sum of each row
-    return m.diviColumnVector(m.rowSums());
+    // divide by the sum of each column
+    return m.diviRowVector(m.columnSums());
   }
 
   /**

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/blas/function/Softmax.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/blas/function/Softmax.java
@@ -21,7 +21,7 @@ import edu.snu.dolphin.dnn.blas.MatrixFunctions;
 /**
  * Softmax function.
  *
- * Assumes each column represents each input instance.
+ * Assumes each column represents a single input instance.
  */
 final class Softmax implements Function {
 

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/blas/jblas/MatrixJBLASFactory.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/blas/jblas/MatrixJBLASFactory.java
@@ -36,7 +36,7 @@ public final class MatrixJBLASFactory implements MatrixFactory {
 
   @Override
   public Matrix create(final int length) {
-    return new MatrixJBLASImpl(new FloatMatrix(1, length));
+    return new MatrixJBLASImpl(new FloatMatrix(length));
   }
 
   @Override
@@ -46,7 +46,7 @@ public final class MatrixJBLASFactory implements MatrixFactory {
 
   @Override
   public Matrix create(final float[] data) {
-    return new MatrixJBLASImpl(new FloatMatrix(1, data.length, data));
+    return new MatrixJBLASImpl(new FloatMatrix(data));
   }
 
   @Override
@@ -61,7 +61,7 @@ public final class MatrixJBLASFactory implements MatrixFactory {
 
   @Override
   public Matrix ones(final int length) {
-    return new MatrixJBLASImpl(FloatMatrix.ones(1, length));
+    return new MatrixJBLASImpl(FloatMatrix.ones(length));
   }
 
   @Override
@@ -71,7 +71,7 @@ public final class MatrixJBLASFactory implements MatrixFactory {
 
   @Override
   public Matrix zeros(final int length) {
-    return new MatrixJBLASImpl(FloatMatrix.zeros(1, length));
+    return new MatrixJBLASImpl(FloatMatrix.zeros(length));
   }
 
   @Override
@@ -81,7 +81,7 @@ public final class MatrixJBLASFactory implements MatrixFactory {
 
   @Override
   public Matrix rand(final int length) {
-    return rand(1, length);
+    return rand(length);
   }
 
   @Override
@@ -104,7 +104,7 @@ public final class MatrixJBLASFactory implements MatrixFactory {
 
   @Override
   public Matrix randn(final int length) {
-    return randn(1, length);
+    return randn(length);
   }
 
   @Override

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/blas/jblas/MatrixJBLASImpl.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/blas/jblas/MatrixJBLASImpl.java
@@ -46,9 +46,7 @@ final class MatrixJBLASImpl implements Matrix {
 
   @Override
   public Matrix get(final int[] indices) {
-    final FloatMatrix innerVector = jblasMatrix.get(indices); // a column vector
-    innerVector.reshape(1, innerVector.getLength()); // convert it to a row vector
-    return new MatrixJBLASImpl(innerVector);
+    return new MatrixJBLASImpl(jblasMatrix.get(indices));
   }
 
   @Override

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/data/NeuralNetworkDataParser.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/data/NeuralNetworkDataParser.java
@@ -87,9 +87,9 @@ public final class NeuralNetworkDataParser implements DataParser<List<Pair<Pair<
       }
       try {
         final Matrix input = readNumpy(matrixFactory, new ByteArrayInputStream(text.getBytes()), delimiter);
-        final Matrix data = input.get(range(0, input.getColumns() - 2));
-        final int label = (int) input.get(input.getColumns() - 2);
-        final boolean isValidation = ((int) input.get(input.getColumns() - 1) == 1);
+        final Matrix data = input.get(range(0, input.getRows() - 2));
+        final int label = (int) input.get(input.getRows() - 2);
+        final boolean isValidation = ((int) input.get(input.getRows() - 1) == 1);
 
         if (isValidation) {
           validationBatchGenerator.push(data, label);
@@ -196,12 +196,12 @@ public final class NeuralNetworkDataParser implements DataParser<List<Pair<Pair<
      */
     private Matrix makeBatch(final List<Matrix> inputs) {
       if (inputs.size() > 0) {
-        final Matrix ret = matrixFactory.create(inputs.size(), inputs.get(0).getLength());
+        final Matrix ret = matrixFactory.create(inputs.get(0).getLength(), inputs.size());
         int i = 0;
         for (final Matrix vector : inputs) {
-          ret.putRow(i++, vector);
+          ret.putColumn(i++, vector);
         }
-        return ret;
+        return ret.transpose();
       } else {
         throw new IllegalArgumentException("At least one input is needed to make batch");
       }

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/data/NeuralNetworkDataParser.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/data/NeuralNetworkDataParser.java
@@ -201,7 +201,7 @@ public final class NeuralNetworkDataParser implements DataParser<List<Pair<Pair<
         for (final Matrix vector : inputs) {
           ret.putColumn(i++, vector);
         }
-        return ret.transpose();
+        return ret;
       } else {
         throw new IllegalArgumentException("At least one input is needed to make batch");
       }

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/layerparam/initializer/FullyConnectedLayerParameterInitializer.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/layerparam/initializer/FullyConnectedLayerParameterInitializer.java
@@ -63,8 +63,8 @@ public final class FullyConnectedLayerParameterInitializer implements LayerParam
   /** {@inheritDoc} */
   @Override
   public LayerParameter generateInitialParameter() {
-    final Matrix weight = matrixFactory.randn(numInput, numOutput, randomSeed);
-    final Matrix bias = matrixFactory.create(1, numOutput).fill(initBias);
+    final Matrix weight = matrixFactory.randn(numOutput, numInput, randomSeed);
+    final Matrix bias = matrixFactory.create(numOutput).fill(initBias);
 
     weight.muli(initWeight); // multiply by standard deviation.
 

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/layerparam/initializer/FullyConnectedLayerParameterInitializer.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/layerparam/initializer/FullyConnectedLayerParameterInitializer.java
@@ -64,7 +64,7 @@ public final class FullyConnectedLayerParameterInitializer implements LayerParam
   @Override
   public LayerParameter generateInitialParameter() {
     final Matrix weight = matrixFactory.randn(numInput, numOutput, randomSeed);
-    final Matrix bias = matrixFactory.create(numOutput).fill(initBias);
+    final Matrix bias = matrixFactory.create(1, numOutput).fill(initBias);
 
     weight.muli(initWeight); // multiply by standard deviation.
 

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/layers/ActivationLayer.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/layers/ActivationLayer.java
@@ -34,9 +34,9 @@ public final class ActivationLayer extends LayerBase {
   private final Function activationFunction;
 
   @Inject
-  public ActivationLayer(@Parameter(LayerIndex.class) final int index,
-                         @Parameter(LayerInputShape.class) final String inputShape,
-                         @Parameter(ActivationFunction.class) final String activationFunction) {
+  private ActivationLayer(@Parameter(LayerIndex.class) final int index,
+                          @Parameter(LayerInputShape.class) final String inputShape,
+                          @Parameter(ActivationFunction.class) final String activationFunction) {
     super(index, inputShape);
     this.activationFunction = FunctionFactory.getSingleInstance(activationFunction);
   }

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/layers/FullyConnectedLayer.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/layers/FullyConnectedLayer.java
@@ -61,8 +61,8 @@ public final class FullyConnectedLayer extends LayerBase {
    */
   @Override
   public Matrix feedForward(final Matrix input) {
-    // (output matrix) = (input matrix) x (weight matrix) + (bias row vector)
-    return input.mmul(getLayerParameter().getWeightParam()).addiRowVector(getLayerParameter().getBiasParam());
+    // (output matrix) = (weight matrix) x (input matrix) + (bias column vector)
+    return getLayerParameter().getWeightParam().mmul(input).addiColumnVector(getLayerParameter().getBiasParam());
   }
 
   /**
@@ -74,16 +74,16 @@ public final class FullyConnectedLayer extends LayerBase {
    */
   @Override
   public Matrix backPropagate(final Matrix input, final Matrix activation, final Matrix nextError) {
-    // ((next error matrix) x (weight matrix of the next layer))
-    return nextError.mmul(getLayerParameter().getWeightParam().transpose());
+    // (error matrix) = (transposed weight matrix) x (next error matrix)
+    return getLayerParameter().getWeightParam().transpose().mmul(nextError);
   }
 
   /** {@inheritDoc} */
   @Override
   public LayerParameter generateParameterGradient(final Matrix input, final Matrix error) {
     return LayerParameter.newBuilder()
-        .setWeightParam(input.transpose().mmul(error))
-        .setBiasParam(error.columnSums())
+        .setWeightParam(error.mmul(input.transpose()))
+        .setBiasParam(error.rowSums())
         .build();
   }
 }

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/layers/FullyConnectedLayer.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/layers/FullyConnectedLayer.java
@@ -34,9 +34,9 @@ public final class FullyConnectedLayer extends LayerBase {
   private final int[] outputShape;
 
   @Inject
-  public FullyConnectedLayer(@Parameter(LayerIndex.class) final int index,
-                             @Parameter(LayerInputShape.class) final String inputShape,
-                             final LayerParameterInitializer layerParameterInitializer) {
+  private FullyConnectedLayer(@Parameter(LayerIndex.class) final int index,
+                              @Parameter(LayerInputShape.class) final String inputShape,
+                              final LayerParameterInitializer layerParameterInitializer) {
     super(index, inputShape);
     this.outputShape = layerParameterInitializer.getOutputShape();
     setLayerParameter(layerParameterInitializer.generateInitialParameter());

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/util/Validator.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/util/Validator.java
@@ -35,8 +35,8 @@ public final class Validator {
     final Matrix[] activations = network.feedForward(input);
     final Matrix outputMatrix = activations[activations.length - 1];
 
-    for (int i = 0; i < outputMatrix.getRows(); ++i) {
-      final Matrix output = outputMatrix.getRow(i);
+    for (int i = 0; i < outputMatrix.getColumns(); ++i) {
+      final Matrix output = outputMatrix.getColumn(i);
       float maxValue = output.get(0);
 
       // Find the index with highest probability.

--- a/dolphin-dnn/src/test/java/edu/snu/dolphin/dnn/NeuralNetworkTest.java
+++ b/dolphin-dnn/src/test/java/edu/snu/dolphin/dnn/NeuralNetworkTest.java
@@ -56,21 +56,19 @@ public final class NeuralNetworkTest {
     }
   }
 
-  private final Matrix input = matrixFactory.create(new float[]{77, 57, 30, 26, 75, 74, 87, 75}).transpose();
+  private final Matrix input = matrixFactory.create(new float[]{77, 57, 30, 26, 75, 74, 87, 75});
   private final Matrix expectedOutput =
-      matrixFactory.create(new float[]{5.61329743164e-01f, 5.97883503916e-01f, 4.79822915984e-01f}).transpose();
-  private final Matrix label = matrixFactory.create(new float[]{0, 1, 0}).transpose();
+      matrixFactory.create(new float[]{5.96001906923e-01f, 5.54388444438e-01f, 4.88766051614e-01f});
+  private final Matrix label = matrixFactory.create(new float[]{0, 1, 0});
   private final int numHiddenUnits = 5;
 
   private final Matrix[] expectedActivations = new Matrix[] {
       matrixFactory.create(new float[]{
-          -7.93876278605e-03f,  -3.31747899111e-02f, 3.44120437890e-02f, 1.59688640758e-02f, 1.38468652740e-02f})
-          .transpose(),
+          1.37635586396e-02f, 2.03896453321e-02f, 8.84165966865e-03f, 2.93623840734e-02f, -7.07257980630e-03f}),
       matrixFactory.create(new float[]{
-          4.98015319727e-01f, 4.91707063086e-01f, 5.08602162082e-01f, 5.03992131185e-01f, 5.03461661008e-01f})
-          .transpose(),
+          5.03440835342e-01f, 5.05097234742e-01f, 5.02210400517e-01f, 5.07340068673e-01f, 4.98231862419e-01f}),
       matrixFactory.create(new float[]{
-          2.46560502863e-01f, 3.96654087576e-01f, -8.07521889872e-02f}).transpose(),
+          3.88833708754e-01f, 2.18417983427e-01f, -4.49433571251e-02f}),
       expectedOutput};
 
   private final Configuration neuralNetworkConfiguration = NeuralNetworkConfigurationBuilder.newConfigurationBuilder()
@@ -109,38 +107,34 @@ public final class NeuralNetworkTest {
 
   private final Matrix[] expectedErrors = new Matrix[] {
       matrixFactory.create(new float[]{
-          -8.30651912736e-03f, -4.80258488777e-02f, 1.07207504661e-02f, 1.48007835060e-02f, -9.54255943309e-02f})
-          .transpose(),
+          -1.10814502938e-02f, 4.75458121280e-02f, 2.79511566348e-02f, -3.76325213356e-02f, -6.66430044053e-02f}),
       matrixFactory.create(new float[]{
-          -3.32266000219e-02f, -1.92156256008e-01f, 4.28956985094e-02f, 5.92069083725e-02f, -3.81720674107e-01f})
-          .transpose(),
-      matrixFactory.create(new float[]{5.61329743164e-01f, -4.02116496084e-01f, 4.79822915984e-01f}).transpose()};
+          -4.43279004290e-02f, 1.90203015780e-01f, 1.11806811634e-01f, -1.50562532537e-01f, -2.66575351211e-01f}),
+      matrixFactory.create(new float[]{5.96001906923e-01f, -4.45611555562e-01f, 4.88766051614e-01f})};
 
   private final LayerParameter[] expectedParams = new LayerParameter[]{
       LayerParameter.newBuilder()
-          .setWeightParam(matrixFactory.create(new float[][]{
-              {6.29601293314e-03f, 3.70347247158e-02f, -8.30645946347e-03f, -1.13498155877e-02f, 7.33580261453e-02f},
-              {4.68675940016e-03f, 2.73855962264e-02f, -6.15892196974e-03f, -8.18972289887e-03f, 5.44971278649e-02f},
-              {2.52483510568e-03f, 1.44771710611e-02f, -3.24509033713e-03f, -4.38972922295e-03f, 2.86505886796e-02f},
-              {2.28363849271e-03f, 1.23827394517e-02f, -2.83174715194e-03f, -3.81162996477e-03f, 2.47702858171e-02f},
-              {6.16528987324e-03f, 3.60245812466e-02f, -7.81562200122e-03f, -1.10868847139e-02f, 7.16255958803e-02f},
-              {6.13136617093e-03f, 3.55017700762e-02f, -7.77507240929e-03f, -1.09673650336e-02f, 7.07364371617e-02f},
-              {7.27458344572e-03f, 4.14693921910e-02f, -9.24880154366e-03f, -1.29832496649e-02f, 8.30297472805e-02f},
-              {6.22864791469e-03f, 3.59129885050e-02f, -7.93995969825e-03f, -1.10342586510e-02f, 7.16121329971e-02f}}))
+          .setWeightParam(matrixFactory.create(new float[]{
+              8.43270993132e-03f, -3.66582318410e-02f, -2.14895112413e-02f, 2.91009849480e-02f, 5.12505139198e-02f,
+              6.30096868417e-03f, -2.70532011080e-02f, -1.59334007127e-02f, 2.15053582413e-02f, 3.79973748771e-02f,
+              3.39385148596e-03f, -1.43677248949e-02f, -8.38015240206e-03f, 1.12523983074e-02f, 1.96798049890e-02f,
+              2.77477892309e-03f, -1.24133927578e-02f, -7.31539492911e-03f, 9.75559034996e-03f, 1.72828291146e-02f,
+              8.53602856872e-03f, -3.55010761603e-02f, -2.08851161142e-02f, 2.83249941530e-02f, 5.00290410160e-02f,
+              8.44699691700e-03f, -3.51333951458e-02f, -2.06472821629e-02f, 2.78617687040e-02f, 4.93010380208e-02f,
+              9.53429374101e-03f, -4.12985275728e-02f, -2.44371877617e-02f, 3.28448326583e-02f, 5.80023242130e-02f,
+              8.27071901140e-03f, -3.56029589638e-02f, -2.08418701192e-02f, 2.82338712143e-02f, 5.00251905529e-02f},
+              numHiddenUnits, input.getLength()))
           .setBiasParam(matrixFactory.create(new float[]{
-              2.83065191274e-04f, 6.80258488777e-04f, 9.27924953390e-05f, 5.19921649397e-05f, 1.15425594331e-03f})
-              .transpose())
+              3.10814502938e-04f, -2.75458121280e-04f, -7.95115663479e-05f, 5.76325213356e-04f, 8.66430044053e-04f}))
           .build(),
       emptyLayerParam, // sigmoid activation layer
       LayerParameter.newBuilder()
-          .setWeightParam(matrixFactory.create(new float[][]{
-              {-2.02809097974e-01f, -2.89133648763e-02f, 1.36443203991e-01f},
-              {-9.86731028695e-02f, 9.78008450420e-02f, -2.10321836138e-01f},
-              {6.29037997313e-02f, -4.37688459799e-04f, 7.94878703128e-03f},
-              {2.45057981449e-01f, 1.11668795437e-01f, -7.71344562636e-02f},
-              {-1.32025024617e-01f, 2.37492346105e-02f, -6.28608389523e-01f}}))
-          .setBiasParam(matrixFactory.create(new float[]{2.94386702568e-01f, 3.04021164961e-01f, 2.95201770840e-01f})
-              .transpose())
+          .setWeightParam(matrixFactory.create(new float[]{
+              -2.03014106838e-01f, -9.36696143375e-02f, 6.32980870484e-02f, 2.44876650034e-01f, -1.26948172924e-01f,
+              -3.33847104410e-02f, 9.28304262651e-02f, -2.44954075032e-04f, 1.07187525993e-01f, 1.87009757363e-02f,
+              1.41093561592e-01f, -2.10442218992e-01f, 7.41970535523e-03f, -7.24960077710e-02f, -6.28627853302e-01f},
+              expectedOutput.getLength(), numHiddenUnits))
+          .setBiasParam(matrixFactory.create(new float[]{2.94039980931e-01f, 3.04456115556e-01f, 2.95112339484e-01f}))
           .build(),
       emptyLayerParam}; // sigmoid activation layer
 
@@ -205,51 +199,62 @@ public final class NeuralNetworkTest {
     final LocalNeuralNetParameterProvider localNeuralNetParameterProvider = Tang.Factory.getTang()
         .newInjector(blasConfiguration, neuralNetworkConfiguration).getInstance(LocalNeuralNetParameterProvider.class);
 
-    localNeuralNetParameterProvider.push(input.getRows(),
+    localNeuralNetParameterProvider.push(input.getColumns(),
         neuralNetwork.generateParameterGradients(activations, expectedErrors));
     assertTrue(compare(expectedParams, localNeuralNetParameterProvider.pull(), TOLERANCE));
   }
 
-  private final Matrix batchInput = matrixFactory.create(new float[][]{
-      {77, 57, 30, 26, 75, 74, 87, 75},
-      {61, 5, 18, 18, 16, 4, 67, 29},
-      {68, 85, 4, 50, 19, 3, 5, 18}});
+  private static final int numBatch = 3;
 
-  private final Matrix expectedBatchOutput = matrixFactory.create(new float[][]{
-      {5.61329743164e-01f, 5.97883503916e-01f, 4.79822915984e-01f},
-      {5.60976372061e-01f, 5.97821453723e-01f, 4.80461166777e-01f},
-      {5.61245484844e-01f, 5.98112837378e-01f, 4.79875062394e-01f}});
+  private final Matrix batchInput = matrixFactory.create(new float[]{
+      77, 57, 30, 26, 75, 74, 87, 75,
+      61, 5, 18, 18, 16, 4, 67, 29,
+      68, 85, 4, 50, 19, 3, 5, 18}, input.getLength(), numBatch);
 
-  private final Matrix labels = matrixFactory.create(new float[][]{{0, 1, 0}, {0, 0, 1}, {1, 0, 0}});
+  private final Matrix expectedBatchOutput = matrixFactory.create(new float[]{
+      5.96001906923e-01f, 5.54388444438e-01f, 4.88766051614e-01f,
+      5.95962765220e-01f, 5.54549180394e-01f, 4.88787332887e-01f,
+      5.95960592285e-01f, 5.54529568429e-01f, 4.88781434177e-01f}, expectedOutput.getLength(), numBatch);
+
+  private final Matrix labels = matrixFactory.create(new float[]{
+      0, 1, 0,
+      0, 0, 1,
+      1, 0, 0}, expectedOutput.getLength(), numBatch);
 
   private final Matrix[] expectedBatchActivations = new Matrix[] {
-      matrixFactory.create(new float[][]{
-          {-7.93876278605e-03f, -3.31747899111e-02f, 3.44120437890e-02f, 1.59688640758e-02f, 1.38468652740e-02f},
-          {-1.23871909026e-03f, -2.11530894332e-02f, 7.89375894368e-03f, 7.98690381646e-04f, -3.62337928265e-03f},
-          {-5.40462196656e-03f, -3.56428819858e-03f, -2.77098032534e-03f, 2.72608707532e-02f, 1.27705410570e-03f}}),
-      matrixFactory.create(new float[][]{
-          {4.98015319727e-01f, 4.91707063086e-01f, 5.08602162082e-01f, 5.03992131185e-01f, 5.03461661008e-01f},
-          {4.99690320267e-01f, 4.94711924821e-01f, 5.01973429489e-01f, 5.00199672585e-01f, 4.99094156170e-01f},
-          {4.98648847797e-01f, 4.99108928894e-01f, 4.99307255362e-01f, 5.06814795656e-01f, 5.00319263483e-01f}}),
-      matrixFactory.create(new float[][]{
-          {2.46560502863e-01f, 3.96654087576e-01f, -8.07521889872e-02f},
-          {2.45125553286e-01f, 3.96396002015e-01f, -7.81951521132e-02f},
-          {2.46218328523e-01f, 3.97608068197e-01f, -8.05432640010e-02f}}),
+      matrixFactory.create(new float[]{
+          1.37635586396e-02f, 2.03896453321e-02f, 8.84165966865e-03f, 2.93623840734e-02f, -7.07257980630e-03f,
+          -1.03681771740e-02f, 3.53007655740e-03f, -1.66967848856e-03f, 1.57861485705e-02f, -6.65068837926e-03f,
+          -9.20206232816e-03f, 2.52719653249e-03f, 3.13138561007e-03f, 1.43411668226e-02f, -5.00741667077e-03f},
+          numHiddenUnits, numBatch),
+      matrixFactory.create(new float[]{
+          5.03440835342e-01f, 5.05097234742e-01f, 5.02210400517e-01f, 5.07340068673e-01f, 4.98231862419e-01f,
+          4.97407978926e-01f, 5.00882518223e-01f, 4.99582580475e-01f, 5.03946455187e-01f, 4.98337334034e-01f,
+          4.97699500651e-01f, 5.00631798797e-01f, 5.00782845763e-01f, 5.03585230258e-01f, 4.98748148448e-01f},
+          numHiddenUnits, numBatch),
+      matrixFactory.create(new float[]{
+          3.88833708754e-01f, 2.18417983427e-01f, -4.49433571251e-02f,
+          3.88671151640e-01f, 2.19068648969e-01f, -4.48581891244e-02f,
+          3.88662127499e-01f, 2.18989256483e-01f, -4.48817958414e-02f},
+          expectedOutput.getLength(), numBatch),
       expectedBatchOutput};
 
   private final Matrix[] expectedBatchErrors = new Matrix[] {
-      matrixFactory.create(new float[][]{
-          {-8.30651912736e-03f, -4.80258488777e-02f, 1.07207504661e-02f, 1.48007835060e-02f, -9.54255943309e-02f},
-          {-5.07035192412e-02f, 2.78781517325e-02f, 7.50168509571e-03f, 6.08557822289e-02f, 6.64601224626e-02f},
-          {3.39717583167e-02f, -1.00106875386e-04f, -6.33785444658e-03f, -1.97557316255e-02f, -5.77034221542e-02f}}),
-      matrixFactory.create(new float[][]{
-          {-3.32266000219e-02f, -1.92156256008e-01f, 4.28956985094e-02f, 5.92069083725e-02f, -3.81720674107e-01f},
-          {-2.02814154765e-01f, 1.11525081563e-01f, 3.00072078260e-02f, 2.43423167736e-01f, 2.65841362398e-01f},
-          {1.35888025582e-01f, -4.00428773318e-04f, -2.53514664505e-02f, -7.90376089833e-02f, -2.30813782723e-01f}}),
-      matrixFactory.create(new float[][]{
-          {5.61329743164e-01f, -4.02116496084e-01f, 4.79822915984e-01f},
-          {5.60976372061e-01f, 5.97821453723e-01f, -5.19538833223e-01f},
-          {-4.38754515156e-01f, 5.98112837378e-01f, 4.79875062394e-01f}})};
+      matrixFactory.create(new float[]{
+          -1.10814502938e-02f, 4.75458121280e-02f, 2.79511566348e-02f, -3.76325213356e-02f, -6.66430044053e-02f,
+          -5.15000730878e-02f, 2.29721560018e-02f, -8.00065487467e-05f, 4.90593973619e-02f, 7.12180587144e-02f,
+          1.49417896767e-02f, -4.67279048839e-02f, 3.37442108292e-03f, -8.35931344072e-03f, -8.79247789398e-02f},
+          numHiddenUnits, numBatch),
+      matrixFactory.create(new float[]{
+          -4.43279004290e-02f, 1.90203015780e-01f, 1.11806811634e-01f, -1.50562532537e-01f, -2.66575351211e-01f,
+          -2.06005828612e-01f, 9.18889102737e-02f, -3.20026418031e-04f, 1.96249815425e-01f, 2.84875384962e-01f,
+          5.97684239558e-02f, -1.86911917974e-01f, 1.34977174198e-02f, -3.34389730445e-02f, -3.51701320409e-01f},
+          numHiddenUnits, numBatch),
+      matrixFactory.create(new float[]{
+          5.96001906923e-01f, -4.45611555562e-01f, 4.88766051614e-01f,
+          5.95962765220e-01f, 5.54549180394e-01f, -5.11212667113e-01f,
+          -4.04039407715e-01f, 5.54529568429e-01f, 4.88781434177e-01f},
+          expectedOutput.getLength(), numBatch)};
 
   /**
    * Unit test for feedforward of neural network for a batch input.
@@ -273,29 +278,27 @@ public final class NeuralNetworkTest {
 
   private final LayerParameter[] expectedBatchParams = new LayerParameter[]{
       LayerParameter.newBuilder()
-          .setWeightParam(matrixFactory.create(new float[][]{
-              {4.64145014168e-03f, 6.73558899806e-03f, -2.89190318578e-03f, -1.16481232727e-02f, 2.39387718430e-02f},
-              {-7.24999073729e-03f, 8.69950140536e-03f, -4.14339451025e-04f, 2.01776909015e-03f, 3.34770362552e-02f},
-              {3.45278565712e-03f, 3.20064693997e-03f, -1.46653662370e-03f, -4.81750970047e-03f, 6.34724142775e-03f},
-              {-1.77590672102e-03f, 2.40225435486e-03f, -3.67275769129e-04f, -1.60488581988e-03f, 1.38594791443e-02f},
-              {2.56467330903e-03f, 1.05311621508e-02f, -2.45393919166e-03f, -5.68093834349e-03f, 2.40228089200e-02f},
-              {2.36981274148e-03f, 1.14383103422e-02f, -2.52281276950e-03f, -4.27949828405e-03f, 2.33507098805e-02f},
-              {1.32143923438e-02f, 7.38994773632e-03f, -4.60051170392e-03f, -1.76606577354e-02f, 1.38018655878e-02f},
-              {4.93842304532e-03f, 9.21118247783e-03f, -2.92447609099e-03f, -8.33124861590e-03f, 2.09370626562e-02f}}))
+          .setWeightParam(matrixFactory.create(new float[]{
+              9.82910798162e-03f, -6.33072822863e-03f, -7.88985161601e-03f, 1.70232424537e-03f, 2.24890496128e-02f,
+              -1.28515495108e-03f, 3.87091128434e-03f, -6.26671372245e-03f, 8.75581565258e-03f, 3.63980862575e-02f,
+              4.06834195010e-03f, -5.61385309760e-03f, -2.83011296328e-03f, 8.93787711127e-04f, 3.25045097098e-03f,
+              1.45370031131e-03f, 2.23753613154e-03f, -3.02813089998e-03f, 1.68227505019e-03f, 1.61124213181e-02f,
+              4.79566064030e-03f, -9.99391777382e-03f, -7.11898411617e-03f, 7.42165547717e-03f, 1.84778116814e-02f,
+              3.51739784978e-03f, -1.15164775272e-02f, -6.89072234663e-03f, 8.72585934798e-03f, 1.63534961874e-02f,
+              1.43597057322e-02f, -1.80736062976e-02f, -8.26388913572e-03f, 2.00693430198e-04f, 4.90942819402e-03f,
+              6.81182688237e-03f, -1.12470203536e-02f, -7.06102310040e-03f, 5.17676094132e-03f, 1.50947627443e-02f},
+              numHiddenUnits, input.getLength()))
           .setBiasParam(matrixFactory.create(new float[]{
-              2.83460933506e-04f, 2.67492680069e-04f, 1.60384729616e-04f, 1.36638863018e-05f, 4.88896313408e-04f})
-              .transpose())
+              3.58799112350e-04f, 1.20699789180e-04f, 9.58480961035e-05f, 1.89774791381e-04f, 4.77832415436e-04f}))
           .build(),
       emptyLayerParam, // sigmoid activation layer
       LayerParameter.newBuilder()
-          .setWeightParam(matrixFactory.create(new float[][]{
-              {-2.01150525996e-01f, -3.22383456150e-02f, 1.38103996340e-01f},
-              {-9.70281555556e-02f, 9.45017787010e-02f, -2.08690580267e-01f},
-              {6.45986834694e-02f, -3.79691247050e-03f, 9.64634547967e-03f},
-              {2.46749910214e-01f, 1.08310496669e-01f, -7.54667251949e-02f},
-              {-1.30342513562e-01f, 2.04075111228e-02f, -6.26933879715e-01f}}))
-          .setBiasParam(matrixFactory.create(new float[]{2.97721494666e-01f, 2.97353940683e-01f, 2.98532802849e-01f})
-              .transpose())
+          .setWeightParam(matrixFactory.create(new float[]{
+              -2.01331583596e-01f, -9.70046289504e-02f, 6.49752355899e-02f, 2.46562801617e-01f, -1.30299951105e-01f,
+              -3.17010213689e-02f, 9.45078932686e-02f, -3.58603247992e-03f, 1.08859347243e-01f, 2.03939299096e-02f,
+              1.37723997630e-01f, -2.08750812643e-01f, 9.08109765882e-03f, -7.58192041248e-02f, -6.26967802760e-01f},
+              expectedOutput.getLength(), numHiddenUnits))
+          .setBiasParam(matrixFactory.create(new float[]{2.97373582452e-01f, 2.97788442689e-01f, 2.98445550604e-01f}))
           .build(),
       emptyLayerParam}; // sigmoid activation layer
 
@@ -309,7 +312,7 @@ public final class NeuralNetworkTest {
     final LocalNeuralNetParameterProvider localNeuralNetParameterProvider = Tang.Factory.getTang()
         .newInjector(blasConfiguration, neuralNetworkConfiguration).getInstance(LocalNeuralNetParameterProvider.class);
 
-    localNeuralNetParameterProvider.push(batchInput.getRows(),
+    localNeuralNetParameterProvider.push(batchInput.getColumns(),
         neuralNetwork.generateParameterGradients(batchActivations, expectedBatchErrors));
     assertTrue(compare(expectedBatchParams, localNeuralNetParameterProvider.pull(), TOLERANCE));
   }

--- a/dolphin-dnn/src/test/java/edu/snu/dolphin/dnn/NeuralNetworkTest.java
+++ b/dolphin-dnn/src/test/java/edu/snu/dolphin/dnn/NeuralNetworkTest.java
@@ -56,19 +56,21 @@ public final class NeuralNetworkTest {
     }
   }
 
-  private final Matrix input = matrixFactory.create(new float[]{77, 57, 30, 26, 75, 74, 87, 75});
+  private final Matrix input = matrixFactory.create(new float[]{77, 57, 30, 26, 75, 74, 87, 75}).transpose();
   private final Matrix expectedOutput =
-      matrixFactory.create(new float[]{5.61329743164e-01f, 5.97883503916e-01f, 4.79822915984e-01f});
-  private final Matrix label = matrixFactory.create(new float[]{0, 1, 0});
+      matrixFactory.create(new float[]{5.61329743164e-01f, 5.97883503916e-01f, 4.79822915984e-01f}).transpose();
+  private final Matrix label = matrixFactory.create(new float[]{0, 1, 0}).transpose();
   private final int numHiddenUnits = 5;
 
   private final Matrix[] expectedActivations = new Matrix[] {
       matrixFactory.create(new float[]{
-          -7.93876278605e-03f,  -3.31747899111e-02f, 3.44120437890e-02f, 1.59688640758e-02f, 1.38468652740e-02f}),
+          -7.93876278605e-03f,  -3.31747899111e-02f, 3.44120437890e-02f, 1.59688640758e-02f, 1.38468652740e-02f})
+          .transpose(),
       matrixFactory.create(new float[]{
-          4.98015319727e-01f, 4.91707063086e-01f, 5.08602162082e-01f, 5.03992131185e-01f, 5.03461661008e-01f}),
+          4.98015319727e-01f, 4.91707063086e-01f, 5.08602162082e-01f, 5.03992131185e-01f, 5.03461661008e-01f})
+          .transpose(),
       matrixFactory.create(new float[]{
-          2.46560502863e-01f, 3.96654087576e-01f, -8.07521889872e-02f}),
+          2.46560502863e-01f, 3.96654087576e-01f, -8.07521889872e-02f}).transpose(),
       expectedOutput};
 
   private final Configuration neuralNetworkConfiguration = NeuralNetworkConfigurationBuilder.newConfigurationBuilder()
@@ -107,10 +109,12 @@ public final class NeuralNetworkTest {
 
   private final Matrix[] expectedErrors = new Matrix[] {
       matrixFactory.create(new float[]{
-          -8.30651912736e-03f, -4.80258488777e-02f, 1.07207504661e-02f, 1.48007835060e-02f, -9.54255943309e-02f}),
+          -8.30651912736e-03f, -4.80258488777e-02f, 1.07207504661e-02f, 1.48007835060e-02f, -9.54255943309e-02f})
+          .transpose(),
       matrixFactory.create(new float[]{
-          -3.32266000219e-02f, -1.92156256008e-01f, 4.28956985094e-02f, 5.92069083725e-02f, -3.81720674107e-01f}),
-      matrixFactory.create(new float[]{5.61329743164e-01f, -4.02116496084e-01f, 4.79822915984e-01f})};
+          -3.32266000219e-02f, -1.92156256008e-01f, 4.28956985094e-02f, 5.92069083725e-02f, -3.81720674107e-01f})
+          .transpose(),
+      matrixFactory.create(new float[]{5.61329743164e-01f, -4.02116496084e-01f, 4.79822915984e-01f}).transpose()};
 
   private final LayerParameter[] expectedParams = new LayerParameter[]{
       LayerParameter.newBuilder()
@@ -124,7 +128,8 @@ public final class NeuralNetworkTest {
               {7.27458344572e-03f, 4.14693921910e-02f, -9.24880154366e-03f, -1.29832496649e-02f, 8.30297472805e-02f},
               {6.22864791469e-03f, 3.59129885050e-02f, -7.93995969825e-03f, -1.10342586510e-02f, 7.16121329971e-02f}}))
           .setBiasParam(matrixFactory.create(new float[]{
-              2.83065191274e-04f, 6.80258488777e-04f, 9.27924953390e-05f, 5.19921649397e-05f, 1.15425594331e-03f}))
+              2.83065191274e-04f, 6.80258488777e-04f, 9.27924953390e-05f, 5.19921649397e-05f, 1.15425594331e-03f})
+              .transpose())
           .build(),
       emptyLayerParam, // sigmoid activation layer
       LayerParameter.newBuilder()
@@ -134,7 +139,8 @@ public final class NeuralNetworkTest {
               {6.29037997313e-02f, -4.37688459799e-04f, 7.94878703128e-03f},
               {2.45057981449e-01f, 1.11668795437e-01f, -7.71344562636e-02f},
               {-1.32025024617e-01f, 2.37492346105e-02f, -6.28608389523e-01f}}))
-          .setBiasParam(matrixFactory.create(new float[]{2.94386702568e-01f, 3.04021164961e-01f, 2.95201770840e-01f}))
+          .setBiasParam(matrixFactory.create(new float[]{2.94386702568e-01f, 3.04021164961e-01f, 2.95201770840e-01f})
+              .transpose())
           .build(),
       emptyLayerParam}; // sigmoid activation layer
 
@@ -277,7 +283,8 @@ public final class NeuralNetworkTest {
               {1.32143923438e-02f, 7.38994773632e-03f, -4.60051170392e-03f, -1.76606577354e-02f, 1.38018655878e-02f},
               {4.93842304532e-03f, 9.21118247783e-03f, -2.92447609099e-03f, -8.33124861590e-03f, 2.09370626562e-02f}}))
           .setBiasParam(matrixFactory.create(new float[]{
-              2.83460933506e-04f, 2.67492680069e-04f, 1.60384729616e-04f, 1.36638863018e-05f, 4.88896313408e-04f}))
+              2.83460933506e-04f, 2.67492680069e-04f, 1.60384729616e-04f, 1.36638863018e-05f, 4.88896313408e-04f})
+              .transpose())
           .build(),
       emptyLayerParam, // sigmoid activation layer
       LayerParameter.newBuilder()
@@ -287,7 +294,8 @@ public final class NeuralNetworkTest {
               {6.45986834694e-02f, -3.79691247050e-03f, 9.64634547967e-03f},
               {2.46749910214e-01f, 1.08310496669e-01f, -7.54667251949e-02f},
               {-1.30342513562e-01f, 2.04075111228e-02f, -6.26933879715e-01f}}))
-          .setBiasParam(matrixFactory.create(new float[]{2.97721494666e-01f, 2.97353940683e-01f, 2.98532802849e-01f}))
+          .setBiasParam(matrixFactory.create(new float[]{2.97721494666e-01f, 2.97353940683e-01f, 2.98532802849e-01f})
+              .transpose())
           .build(),
       emptyLayerParam}; // sigmoid activation layer
 

--- a/dolphin-dnn/src/test/java/edu/snu/dolphin/dnn/NeuralNetworkTest.java
+++ b/dolphin-dnn/src/test/java/edu/snu/dolphin/dnn/NeuralNetworkTest.java
@@ -204,7 +204,7 @@ public final class NeuralNetworkTest {
     assertTrue(compare(expectedParams, localNeuralNetParameterProvider.pull(), TOLERANCE));
   }
 
-  private static final int numBatch = 3;
+  private final int numBatch = 3;
 
   private final Matrix batchInput = matrixFactory.create(new float[]{
       77, 57, 30, 26, 75, 74, 87, 75,

--- a/dolphin-dnn/src/test/java/edu/snu/dolphin/dnn/blas/function/AbsoluteTest.java
+++ b/dolphin-dnn/src/test/java/edu/snu/dolphin/dnn/blas/function/AbsoluteTest.java
@@ -44,10 +44,19 @@ public final class AbsoluteTest {
         .build();
     final MatrixFactory matrixFactory = Tang.Factory.getTang().newInjector(conf).getInstance(MatrixFactory.class);
 
-    this.input = matrixFactory.create(new float[][]{{1.0f, -2.0f, 3.0f}, {-4.0f, 5.0f, -6.0f}});
-    this.expectedOutput = matrixFactory.create(new float[][]{{1.0f, 2.0f, 3.0f}, {4.0f, 5.0f, 6.0f}});
-    this.expectedDerivative = matrixFactory.create(new float[][]{
-        {1.0f, -1.0f, 1.0f}, {-1.0f, 1.0f, -1.0f}});
+    final int numInput = 3;
+    final int numBatch = 2;
+    this.input = matrixFactory.create(new float[]{
+        1.0f, -2.0f, 3.0f,
+        -4.0f, 5.0f, -6.0f},
+        numInput, numBatch);
+    this.expectedOutput = matrixFactory.create(new float[]{
+        1.0f, 2.0f, 3.0f,
+        4.0f, 5.0f, 6.0f},
+        numInput, numBatch);
+    this.expectedDerivative = matrixFactory.create(new float[]{
+        1.0f, -1.0f, 1.0f,
+        -1.0f, 1.0f, -1.0f}, numInput, numBatch);
   }
 
   @Test

--- a/dolphin-dnn/src/test/java/edu/snu/dolphin/dnn/blas/function/IdentityTest.java
+++ b/dolphin-dnn/src/test/java/edu/snu/dolphin/dnn/blas/function/IdentityTest.java
@@ -44,7 +44,12 @@ public final class IdentityTest {
         .build();
     final MatrixFactory matrixFactory = Tang.Factory.getTang().newInjector(conf).getInstance(MatrixFactory.class);
 
-    this.input = matrixFactory.create(new float[][]{{1.0f, 2.0f, 3.0f}, {4.0f, 5.0f, 6.0f}});
+    final int numInput = 3;
+    final int numBatch = 2;
+    this.input = matrixFactory.create(new float[]{
+        1.0f, 2.0f, 3.0f,
+        4.0f, 5.0f, 6.0f},
+        numInput, numBatch);
     this.expectedOutput = input.dup();
     this.expectedDerivative = matrixFactory.ones(input.getRows(), input.getColumns());
   }

--- a/dolphin-dnn/src/test/java/edu/snu/dolphin/dnn/blas/function/PowerTest.java
+++ b/dolphin-dnn/src/test/java/edu/snu/dolphin/dnn/blas/function/PowerTest.java
@@ -44,10 +44,20 @@ public final class PowerTest {
         .build();
     final MatrixFactory matrixFactory = Tang.Factory.getTang().newInjector(conf).getInstance(MatrixFactory.class);
 
-    this.input = matrixFactory.create(new float[][]{{1.0f, -2.0f, 3.0f}, {-4.0f, 5.0f, -6.0f}});
-    this.expectedOutput = matrixFactory.create(new float[][]{{1.0f, 4.0f, 9.0f}, {16.0f, 25.0f, 36.0f}});
-    this.expectedDerivative = matrixFactory.create(new float[][]{
-        {2.0f, -4.0f, 6.0f}, {-8.0f, 10.0f, -12.0f}});
+    final int numInput = 3;
+    final int numBatch = 2;
+    this.input = matrixFactory.create(new float[]{
+        1.0f, -2.0f, 3.0f,
+        -4.0f, 5.0f, -6.0f},
+        numInput, numBatch);
+    this.expectedOutput = matrixFactory.create(new float[]{
+        1.0f, 4.0f, 9.0f,
+        16.0f, 25.0f, 36.0f},
+        numInput, numBatch);
+    this.expectedDerivative = matrixFactory.create(new float[]{
+        2.0f, -4.0f, 6.0f,
+        -8.0f, 10.0f, -12.0f},
+        numInput, numBatch);
   }
 
   @Test

--- a/dolphin-dnn/src/test/java/edu/snu/dolphin/dnn/blas/function/ReLUTest.java
+++ b/dolphin-dnn/src/test/java/edu/snu/dolphin/dnn/blas/function/ReLUTest.java
@@ -44,11 +44,20 @@ public final class ReLUTest {
         .build();
     final MatrixFactory matrixFactory = Tang.Factory.getTang().newInjector(conf).getInstance(MatrixFactory.class);
 
-    this.input = matrixFactory.create(new float[][]{{1.0f, -2.0f, 3.0f}, {-4.0f, 5.0f, -6.0f}});
-    this.expectedOutput = matrixFactory.create(new float[][]{
-        {1.0f, 0.0f, 3.0f}, {0.0f, 5.0f, 0.0f}});
-    this.expectedDerivative = matrixFactory.create(new float[][]{
-        {1.0f, 0.0f, 1.0f}, {0.0f, 1.0f, 0.0f}});
+    final int numInput = 3;
+    final int numBatch = 2;
+    this.input = matrixFactory.create(new float[]{
+        1.0f, -2.0f, 3.0f,
+        -4.0f, 5.0f, -6.0f},
+        numInput, numBatch);
+    this.expectedOutput = matrixFactory.create(new float[]{
+        1.0f, 0.0f, 3.0f,
+        0.0f, 5.0f, 0.0f},
+        numInput, numBatch);
+    this.expectedDerivative = matrixFactory.create(new float[]{
+        1.0f, 0.0f, 1.0f,
+        0.0f, 1.0f, 0.0f},
+        numInput, numBatch);
   }
 
   @Test

--- a/dolphin-dnn/src/test/java/edu/snu/dolphin/dnn/blas/function/SigmoidTest.java
+++ b/dolphin-dnn/src/test/java/edu/snu/dolphin/dnn/blas/function/SigmoidTest.java
@@ -44,13 +44,20 @@ public final class SigmoidTest {
         .build();
     final MatrixFactory matrixFactory = Tang.Factory.getTang().newInjector(conf).getInstance(MatrixFactory.class);
 
-    this.input = matrixFactory.create(new float[][]{{1.0f, 2.0f, 3.0f}, {4.0f, 5.0f, 6.0f}});
-    this.expectedOutput = matrixFactory.create(new float[][]{
-        {7.310585786e-01f, 8.807970780e-01f, 9.525741268e-01f},
-        {9.820137900e-01f, 9.933071491e-01f, 9.975273768e-01f}});
-    this.expectedDerivative = matrixFactory.create(new float[][]{
-        {1.966119332e-01f, 1.049935854e-01f, 4.517665973e-02f},
-        {1.766270621e-02f, 6.648056671e-03f, 2.466509291e-03f}});
+    final int numInput = 3;
+    final int numBatch = 2;
+    this.input = matrixFactory.create(new float[]{
+        1.0f, 2.0f, 3.0f,
+        4.0f, 5.0f, 6.0f},
+        numInput, numBatch);
+    this.expectedOutput = matrixFactory.create(new float[]{
+        7.310585786e-01f, 8.807970780e-01f, 9.525741268e-01f,
+        9.820137900e-01f, 9.933071491e-01f, 9.975273768e-01f},
+        numInput, numBatch);
+    this.expectedDerivative = matrixFactory.create(new float[]{
+        1.966119332e-01f, 1.049935854e-01f, 4.517665973e-02f,
+        1.766270621e-02f, 6.648056671e-03f, 2.466509291e-03f},
+        numInput, numBatch);
   }
 
   @Test

--- a/dolphin-dnn/src/test/java/edu/snu/dolphin/dnn/blas/function/SoftmaxTest.java
+++ b/dolphin-dnn/src/test/java/edu/snu/dolphin/dnn/blas/function/SoftmaxTest.java
@@ -44,13 +44,20 @@ public final class SoftmaxTest {
         .build();
     final MatrixFactory matrixFactory = Tang.Factory.getTang().newInjector(conf).getInstance(MatrixFactory.class);
 
-    this.input = matrixFactory.create(new float[][]{{1.0f, -2.0f, 3.0f}, {-4.0f, 5.0f, -6.0f}});
-    this.expectedOutput = matrixFactory.create(new float[][]{
-        {1.184996545e-01f, 5.899750402e-03f, 8.756005951e-01f},
-        {1.233925154e-04f, 9.998599081e-01f, 1.669936102e-05f}});
-    this.expectedDerivative = matrixFactory.create(new float[][]{
-        {1.044574864e-01f, 5.864943347e-03f, 1.089241930e-01f},
-        {1.233772897e-04f, 1.400722507e-04f, 1.669908215e-05f}});
+    final int numInput = 3;
+    final int numBatch = 2;
+    this.input = matrixFactory.create(new float[]{
+        1.0f, -2.0f, 3.0f,
+        -4.0f, 5.0f, -6.0f},
+        numInput, numBatch);
+    this.expectedOutput = matrixFactory.create(new float[]{
+        1.184996545e-01f, 5.899750402e-03f, 8.756005951e-01f,
+        1.233925154e-04f, 9.998599081e-01f, 1.669936102e-05f},
+        numInput, numBatch);
+    this.expectedDerivative = matrixFactory.create(new float[]{
+        1.044574864e-01f, 5.864943347e-03f, 1.089241930e-01f,
+        1.233772897e-04f, 1.400722507e-04f, 1.669908215e-05f},
+        numInput, numBatch);
   }
 
   @Test

--- a/dolphin-dnn/src/test/java/edu/snu/dolphin/dnn/blas/function/TanhTest.java
+++ b/dolphin-dnn/src/test/java/edu/snu/dolphin/dnn/blas/function/TanhTest.java
@@ -44,13 +44,20 @@ public final class TanhTest {
         .build();
     final MatrixFactory matrixFactory = Tang.Factory.getTang().newInjector(conf).getInstance(MatrixFactory.class);
 
-    this.input = matrixFactory.create(new float[][]{{1.0f, 2.0f, 3.0f}, {4.0f, 5.0f, 6.0f}});
-    this.expectedOutput = matrixFactory.create(new float[][]{
-        {7.615941560e-01f, 9.640275801e-01f, 9.950547537e-01f},
-        {9.993292997e-01f, 9.999092043e-01f, 9.999877117e-01f}});
-    this.expectedDerivative = matrixFactory.create(new float[][]{
-        {4.199743416e-01f, 7.065082485e-02f, 9.866037165e-03f},
-        {1.340950683e-03f, 1.815832309e-04f, 2.457654741e-05f}});
+    final int numInput = 3;
+    final int numBatch = 2;
+    this.input = matrixFactory.create(new float[]{
+        1.0f, 2.0f, 3.0f,
+        4.0f, 5.0f, 6.0f},
+        numInput, numBatch);
+    this.expectedOutput = matrixFactory.create(new float[]{
+        7.615941560e-01f, 9.640275801e-01f, 9.950547537e-01f,
+        9.993292997e-01f, 9.999092043e-01f, 9.999877117e-01f},
+        numInput, numBatch);
+    this.expectedDerivative = matrixFactory.create(new float[]{
+        4.199743416e-01f, 7.065082485e-02f, 9.866037165e-03f,
+        1.340950683e-03f, 1.815832309e-04f, 2.457654741e-05f},
+        numInput, numBatch);
   }
 
   @Test


### PR DESCRIPTION
For batch processing, `dolphin-dnn` handles matrices in which each **row** represents an input instance. However, many linear algebra libraries such as [netlib-java](https://github.com/fommil/netlib-java), [jblas](http://jblas.org), and [cuBLAS](https://developer.nvidia.com/cublas) use column-major storage for the compatibility with Fortran environment.
In this circumstance, retrieving each input instance from batch matrices requires the access of not contiguous memory (sequential access), which is inefficient.
This pull request changes the batch matrix format that each **column** represents an input instance, not each **row**. This PR also include the change that `MatrixFactory` creates column vectors when it generates vectors.

This closes #155 