### PR TITLE
pooling layer base implementation

### DIFF
--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/NeuralNetworkDriverParameters.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/NeuralNetworkDriverParameters.java
@@ -26,7 +26,6 @@ import edu.snu.dolphin.dnn.layerparam.provider.GroupCommParameterProvider;
 import edu.snu.dolphin.dnn.layerparam.provider.LocalNeuralNetParameterProvider;
 import edu.snu.dolphin.dnn.layerparam.provider.ParameterProvider;
 import edu.snu.dolphin.dnn.layerparam.provider.ParameterServerParameterProvider;
-import edu.snu.dolphin.dnn.conf.NeuralNetworkConfigurationBuilder;
 import edu.snu.dolphin.dnn.proto.NeuralNetworkProtos.*;
 import edu.snu.dolphin.bsp.parameters.OnLocal;
 import org.apache.hadoop.fs.FileSystem;

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/NeuralNetworkDriverParameters.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/NeuralNetworkDriverParameters.java
@@ -20,15 +20,13 @@ import edu.snu.dolphin.bsp.examples.ml.parameters.MaxIterations;
 import edu.snu.dolphin.dnn.NeuralNetworkParameterUpdater.LogPeriod;
 import edu.snu.dolphin.dnn.blas.MatrixFactory;
 import edu.snu.dolphin.dnn.blas.jblas.MatrixJBLASFactory;
-import edu.snu.dolphin.dnn.conf.ActivationLayerConfigurationBuilder;
-import edu.snu.dolphin.dnn.conf.ActivationWithLossLayerConfigurationBuilder;
-import edu.snu.dolphin.dnn.conf.FullyConnectedLayerConfigurationBuilder;
-import edu.snu.dolphin.dnn.conf.NeuralNetworkConfigurationBuilder;
+import edu.snu.dolphin.dnn.conf.*;
 import edu.snu.dolphin.dnn.conf.NeuralNetworkConfigurationParameters.BatchSize;
 import edu.snu.dolphin.dnn.layerparam.provider.GroupCommParameterProvider;
 import edu.snu.dolphin.dnn.layerparam.provider.LocalNeuralNetParameterProvider;
 import edu.snu.dolphin.dnn.layerparam.provider.ParameterProvider;
 import edu.snu.dolphin.dnn.layerparam.provider.ParameterServerParameterProvider;
+import edu.snu.dolphin.dnn.conf.NeuralNetworkConfigurationBuilder;
 import edu.snu.dolphin.dnn.proto.NeuralNetworkProtos.*;
 import edu.snu.dolphin.bsp.parameters.OnLocal;
 import org.apache.hadoop.fs.FileSystem;
@@ -160,6 +158,9 @@ public final class NeuralNetworkDriverParameters {
           .fromProtoConfiguration(layerConf).build();
     case "activationwithloss":
       return ActivationWithLossLayerConfigurationBuilder.newConfigurationBuilder()
+          .fromProtoConfiguration(layerConf).build();
+    case "pooling":
+      return PoolingLayerConfigurationBuilder.newConfigurationBuilder()
           .fromProtoConfiguration(layerConf).build();
     default:
       throw new IllegalArgumentException("Illegal layer type: " + layerConf.getType());

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/conf/ActivationLayerConfigurationBuilder.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/conf/ActivationLayerConfigurationBuilder.java
@@ -26,7 +26,7 @@ import org.apache.reef.util.Builder;
  * Configuration builder for activation layer.
  *
  * The configuration that this builder generates is used to create an activation layer instance.
- * The generate configuration need to bind the parameter for a layer input shape, to inject layer instance.
+ * The generated configuration needs to bind the parameter for a layer input shape, to inject a layer instance.
  */
 public final class ActivationLayerConfigurationBuilder implements Builder<Configuration> {
 

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/conf/ActivationWithLossLayerConfigurationBuilder.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/conf/ActivationWithLossLayerConfigurationBuilder.java
@@ -29,7 +29,7 @@ import org.apache.reef.util.Builder;
  * Configuration builder for activation with loss layer.
  *
  * The configuration that this builder generates is used to create an activation with loss layer instance.
- * The generate configuration need to bind the parameter for a layer input shape, to inject layer instance.
+ * The generated configuration needs to bind the parameter for a layer input shape, to inject a layer instance.
  */
 public final class ActivationWithLossLayerConfigurationBuilder implements Builder<Configuration> {
 

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/conf/FullyConnectedLayerConfigurationBuilder.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/conf/FullyConnectedLayerConfigurationBuilder.java
@@ -28,8 +28,8 @@ import org.apache.reef.util.Builder;
  * Configuration builder for fully connected layer.
  *
  * The configuration that this builder generates is used to create a fully connected layer instance.
- * The generate configuration need to bind the implementation for matrix factory and
- * the parameter for a layer input shape, to inject layer instance.
+ * The generated configuration needs to bind the implementation for matrix factory and
+ * the parameter for a layer input shape, to inject a layer instance.
  */
 public final class FullyConnectedLayerConfigurationBuilder implements Builder<Configuration> {
 

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/conf/LayerConfigurationParameters.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/conf/LayerConfigurationParameters.java
@@ -64,4 +64,23 @@ public final class LayerConfigurationParameters {
   @NamedParameter(doc = "loss function of loss layer", short_name = "lossFunc")
   public static final class LossFunction implements Name<String> {
   }
+
+  /**
+   * For pooling layers.
+   */
+  @NamedParameter(doc = "pooling type of pooling layer", short_name = "poolingTyp")
+  public static final class PoolingType implements Name<String> {
+  }
+
+  @NamedParameter(doc = "stride of pooling / convolutional layer", short_name = "stride")
+  public static final class Stride implements Name<Integer> {
+  }
+
+  @NamedParameter(doc = "kernel height of pooling / convolutional layer", short_name = "height")
+  public static final class KernelHeight implements Name<Integer> {
+  }
+
+  @NamedParameter(doc = "kernal width of pooling / convolutional layer", short_name = "width")
+  public static final class KernelWidth implements Name<Integer> {
+  }
 }

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/conf/LayerConfigurationParameters.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/conf/LayerConfigurationParameters.java
@@ -72,15 +72,19 @@ public final class LayerConfigurationParameters {
   public static final class PoolingType implements Name<String> {
   }
 
-  @NamedParameter(doc = "stride of pooling / convolutional layer", short_name = "stride")
-  public static final class Stride implements Name<Integer> {
+  @NamedParameter(doc = "stride height of pooling / convolutional layer", short_name = "strideH")
+  public static final class StrideHeight implements Name<Integer> {
   }
 
-  @NamedParameter(doc = "kernel height of pooling / convolutional layer", short_name = "height")
+  @NamedParameter(doc = "stride width of pooling / convolutional layer", short_name = "strideW")
+  public static final class StrideWidth implements Name<Integer> {
+  }
+
+  @NamedParameter(doc = "kernel height of pooling / convolutional layer", short_name = "kernelH")
   public static final class KernelHeight implements Name<Integer> {
   }
 
-  @NamedParameter(doc = "kernal width of pooling / convolutional layer", short_name = "width")
+  @NamedParameter(doc = "kernel width of pooling / convolutional layer", short_name = "kernelW")
   public static final class KernelWidth implements Name<Integer> {
   }
 }

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/conf/LayerConfigurationParameters.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/conf/LayerConfigurationParameters.java
@@ -68,7 +68,7 @@ public final class LayerConfigurationParameters {
   /**
    * For pooling layers.
    */
-  @NamedParameter(doc = "pooling type of pooling layer", short_name = "poolingTyp")
+  @NamedParameter(doc = "pooling type of pooling layer")
   public static final class PoolingType implements Name<String> {
   }
 

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/conf/PoolingLayerConfigurationBuilder.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/conf/PoolingLayerConfigurationBuilder.java
@@ -28,7 +28,7 @@ import org.apache.reef.util.Builder;
  * Configuration builder for Pooling layer.
  *
  * The configuration that this builder generates is used to create a pooling layer instance.
- * The generate configuration need to bind the parameter for a layer input shape, to inject layer instance.
+ * The generated configuration needs to bind the parameter for a layer input shape, to inject a layer instance.
  */
 public final class PoolingLayerConfigurationBuilder implements Builder<Configuration> {
 

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/conf/PoolingLayerConfigurationBuilder.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/conf/PoolingLayerConfigurationBuilder.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (C) 2016 Seoul National University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.snu.dolphin.dnn.conf;
+
+import edu.snu.dolphin.dnn.layerparam.initializer.LayerParameterInitializer;
+import edu.snu.dolphin.dnn.layerparam.initializer.PoolingLayerParameterInitializer;
+import edu.snu.dolphin.dnn.layers.PoolingLayer;
+import edu.snu.dolphin.dnn.layers.LayerBase;
+import edu.snu.dolphin.dnn.proto.NeuralNetworkProtos;
+import org.apache.reef.tang.Configuration;
+import org.apache.reef.tang.Tang;
+import org.apache.reef.util.Builder;
+
+/**
+ * Configuration builder for Pooling layer.
+ *
+ * The configuration that this builder generates is used to create a pooling layer instance.
+ * The generate configuration need to bind to bind the parameter for a layer input shape, to inject layer instance.
+ */
+public final class PoolingLayerConfigurationBuilder implements Builder<Configuration> {
+
+  public static PoolingLayerConfigurationBuilder newConfigurationBuilder() {
+    return new PoolingLayerConfigurationBuilder();
+  }
+
+  private String poolingType;
+  private int strideHeight;
+  private int strideWidth;
+  private int kernelHeight;
+  private int kernelWidth;
+
+  public synchronized PoolingLayerConfigurationBuilder setPoolingType(final String poolingType) {
+    this.poolingType = poolingType;
+    return this;
+  }
+
+  public synchronized PoolingLayerConfigurationBuilder setStrideHeight(final int strideHeight) {
+    this.strideHeight = strideHeight;
+    return this;
+  }
+
+  public synchronized PoolingLayerConfigurationBuilder setStrideWidth(final int strideWidth) {
+    this.strideWidth = strideWidth;
+    return this;
+  }
+
+  public synchronized PoolingLayerConfigurationBuilder setKernelHeight(final int kernelHeight) {
+    this.kernelHeight = kernelHeight;
+    return this;
+  }
+
+  public synchronized PoolingLayerConfigurationBuilder setKernelWidth(final int kernelWidth) {
+    this.kernelWidth = kernelWidth;
+    return this;
+  }
+
+  public synchronized PoolingLayerConfigurationBuilder fromProtoConfiguration(
+      final NeuralNetworkProtos.LayerConfiguration protoConf) {
+    poolingType = protoConf.getPoolingParam().getPoolingType();
+    strideHeight = protoConf.getPoolingParam().getStrideHeight();
+    strideWidth = protoConf.getPoolingParam().getStrideWidth();
+    kernelHeight = protoConf.getPoolingParam().getKernelHeight();
+    kernelWidth = protoConf.getPoolingParam().getKernelWidth();
+    return this;
+  }
+
+  @Override
+  public synchronized Configuration build() {
+    return Tang.Factory.getTang().newConfigurationBuilder()
+        .bindNamedParameter(LayerConfigurationParameters.PoolingType.class, String.valueOf(poolingType))
+        .bindNamedParameter(LayerConfigurationParameters.StrideHeight.class, String.valueOf(strideHeight))
+        .bindNamedParameter(LayerConfigurationParameters.StrideWidth.class, String.valueOf(strideWidth))
+        .bindNamedParameter(LayerConfigurationParameters.KernelHeight.class, String.valueOf(kernelHeight))
+        .bindNamedParameter(LayerConfigurationParameters.KernelWidth.class, String.valueOf(kernelWidth))
+        .bindImplementation(LayerBase.class, PoolingLayer.class)
+        .bindImplementation(LayerParameterInitializer.class, PoolingLayerParameterInitializer.class)
+        .build();
+  }
+}

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/conf/PoolingLayerConfigurationBuilder.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/conf/PoolingLayerConfigurationBuilder.java
@@ -28,7 +28,7 @@ import org.apache.reef.util.Builder;
  * Configuration builder for Pooling layer.
  *
  * The configuration that this builder generates is used to create a pooling layer instance.
- * The generate configuration need to bind to bind the parameter for a layer input shape, to inject layer instance.
+ * The generate configuration need to bind the parameter for a layer input shape, to inject layer instance.
  */
 public final class PoolingLayerConfigurationBuilder implements Builder<Configuration> {
 
@@ -36,9 +36,9 @@ public final class PoolingLayerConfigurationBuilder implements Builder<Configura
     return new PoolingLayerConfigurationBuilder();
   }
 
-  private String poolingType;
-  private int strideHeight;
-  private int strideWidth;
+  private String poolingType = "MAX";
+  private int strideHeight = 1;
+  private int strideWidth = 1;
   private int kernelHeight;
   private int kernelWidth;
 
@@ -69,9 +69,15 @@ public final class PoolingLayerConfigurationBuilder implements Builder<Configura
 
   public synchronized PoolingLayerConfigurationBuilder fromProtoConfiguration(
       final NeuralNetworkProtos.LayerConfiguration protoConf) {
-    poolingType = protoConf.getPoolingParam().getPoolingType();
-    strideHeight = protoConf.getPoolingParam().getStrideHeight();
-    strideWidth = protoConf.getPoolingParam().getStrideWidth();
+    if (protoConf.getPoolingParam().hasPoolingType()) {
+      poolingType = protoConf.getPoolingParam().getPoolingType();
+    }
+    if (protoConf.getPoolingParam().hasStrideHeight()) {
+      strideHeight = protoConf.getPoolingParam().getStrideHeight();
+    }
+    if (protoConf.getPoolingParam().hasStrideWidth()) {
+      strideWidth = protoConf.getPoolingParam().getStrideWidth();
+    }
     kernelHeight = protoConf.getPoolingParam().getKernelHeight();
     kernelWidth = protoConf.getPoolingParam().getKernelWidth();
     return this;
@@ -80,7 +86,7 @@ public final class PoolingLayerConfigurationBuilder implements Builder<Configura
   @Override
   public synchronized Configuration build() {
     return Tang.Factory.getTang().newConfigurationBuilder()
-        .bindNamedParameter(LayerConfigurationParameters.PoolingType.class, String.valueOf(poolingType))
+        .bindNamedParameter(LayerConfigurationParameters.PoolingType.class, poolingType)
         .bindNamedParameter(LayerConfigurationParameters.StrideHeight.class, String.valueOf(strideHeight))
         .bindNamedParameter(LayerConfigurationParameters.StrideWidth.class, String.valueOf(strideWidth))
         .bindNamedParameter(LayerConfigurationParameters.KernelHeight.class, String.valueOf(kernelHeight))

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/conf/PoolingLayerConfigurationBuilder.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/conf/PoolingLayerConfigurationBuilder.java
@@ -36,9 +36,9 @@ public final class PoolingLayerConfigurationBuilder implements Builder<Configura
     return new PoolingLayerConfigurationBuilder();
   }
 
-  private String poolingType = "MAX";
-  private int strideHeight = 1;
-  private int strideWidth = 1;
+  private String poolingType;
+  private int strideHeight;
+  private int strideWidth;
   private int kernelHeight;
   private int kernelWidth;
 
@@ -69,15 +69,9 @@ public final class PoolingLayerConfigurationBuilder implements Builder<Configura
 
   public synchronized PoolingLayerConfigurationBuilder fromProtoConfiguration(
       final NeuralNetworkProtos.LayerConfiguration protoConf) {
-    if (protoConf.getPoolingParam().hasPoolingType()) {
-      poolingType = protoConf.getPoolingParam().getPoolingType();
-    }
-    if (protoConf.getPoolingParam().hasStrideHeight()) {
-      strideHeight = protoConf.getPoolingParam().getStrideHeight();
-    }
-    if (protoConf.getPoolingParam().hasStrideWidth()) {
-      strideWidth = protoConf.getPoolingParam().getStrideWidth();
-    }
+    poolingType = protoConf.getPoolingParam().getPoolingType();
+    strideHeight = protoConf.getPoolingParam().getStrideHeight();
+    strideWidth = protoConf.getPoolingParam().getStrideWidth();
     kernelHeight = protoConf.getPoolingParam().getKernelHeight();
     kernelWidth = protoConf.getPoolingParam().getKernelWidth();
     return this;

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/layerparam/initializer/PoolingLayerParameterInitializer.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/layerparam/initializer/PoolingLayerParameterInitializer.java
@@ -27,12 +27,13 @@ import static edu.snu.dolphin.dnn.util.NeuralNetworkUtils.shapeFromString;
 /**
  * Pooling Layer parameter initializer.
  *
- * This initializer is for pooling layer which do not have layer parameter.
+ * This initializer is for pooling layers which do not have layer parameters.
  */
 public final class PoolingLayerParameterInitializer implements LayerParameterInitializer {
 
   private final int index;
   private final int[] inputShape;
+  private final int[] outputShape;
   private final int strideHeight;
   private final int strideWidth;
   private final int kernelHeight;
@@ -40,7 +41,7 @@ public final class PoolingLayerParameterInitializer implements LayerParameterIni
   private final LayerParameter emptyLayerParam;
 
   @Inject
-  public PoolingLayerParameterInitializer(
+  private PoolingLayerParameterInitializer(
       final MatrixFactory matrixFactory,
       @Parameter(LayerConfigurationParameters.LayerIndex.class) final int index,
       @Parameter(LayerConfigurationParameters.LayerInputShape.class) final String inputShape,
@@ -54,6 +55,7 @@ public final class PoolingLayerParameterInitializer implements LayerParameterIni
     this.strideWidth = strideWidth;
     this.kernelHeight = kernelHeight;
     this.kernelWidth = kernelWidth;
+    this.outputShape = computeOutputShape();
     this.emptyLayerParam = LayerParameter.newEmptyInstance(matrixFactory);
   }
 
@@ -75,24 +77,32 @@ public final class PoolingLayerParameterInitializer implements LayerParameterIni
    * This function computes output shape.
    * input shape: row * col
    * output shape: row' * col'
-   * row = (row − kernelHeight) / stride + 1
-   * col = (col − kernelWidth) / stride + 1
+   * row' = (row − kernelHeight) / stride + 1
+   * col' = (col − kernelWidth) / stride + 1
+   * @return shape of output
    */
-  @Override
-  public int[] getOutputShape() {
+  private int[] computeOutputShape() {
     final int[] computedShape;
     switch (inputShape.length) {
-    case 1 :
+    case 1:
       computedShape = new int[1];
       computedShape[0] = (inputShape[0] - kernelHeight) / strideHeight + 1;
       return computedShape;
-    case 2 :
+    case 2:
       computedShape = new int[2];
       computedShape[0] = (inputShape[0] - kernelHeight) / strideHeight + 1;
       computedShape[1] = (inputShape[1] - kernelWidth) / strideWidth + 1;
       return computedShape;
-    default :
+    default:
       throw new IllegalArgumentException("Unsupported input dimension: " + Integer.toString(inputShape.length));
     }
+  }
+
+  /**
+   * @return shape of output
+   */
+  @Override
+  public int[] getOutputShape() {
+    return outputShape;
   }
 }

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/layerparam/initializer/PoolingLayerParameterInitializer.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/layerparam/initializer/PoolingLayerParameterInitializer.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (C) 2016 Seoul National University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.snu.dolphin.dnn.layerparam.initializer;
+
+import edu.snu.dolphin.dnn.blas.MatrixFactory;
+import edu.snu.dolphin.dnn.conf.LayerConfigurationParameters;
+import edu.snu.dolphin.dnn.layers.LayerParameter;
+import org.apache.reef.tang.annotations.Parameter;
+
+import javax.inject.Inject;
+
+import static edu.snu.dolphin.dnn.util.NeuralNetworkUtils.shapeFromString;
+
+/**
+ * Pooling Layer parameter initializer.
+ *
+ * This initializer is for pooling layer which do not have layer parameter.
+ */
+public final class PoolingLayerParameterInitializer implements LayerParameterInitializer {
+
+  private final int index;
+  private final int[] inputShape;
+  private final int strideHeight;
+  private final int strideWidth;
+  private final int kernelHeight;
+  private final int kernelWidth;
+  private final LayerParameter emptyLayerParam;
+
+  @Inject
+  public PoolingLayerParameterInitializer(
+      final MatrixFactory matrixFactory,
+      @Parameter(LayerConfigurationParameters.LayerIndex.class) final int index,
+      @Parameter(LayerConfigurationParameters.LayerInputShape.class) final String inputShape,
+      @Parameter(LayerConfigurationParameters.StrideHeight.class) final int strideHeight,
+      @Parameter(LayerConfigurationParameters.StrideWidth.class) final int strideWidth,
+      @Parameter(LayerConfigurationParameters.KernelHeight.class) final int kernelHeight,
+      @Parameter(LayerConfigurationParameters.KernelWidth.class) final int kernelWidth) {
+    this.index = index;
+    this.inputShape = shapeFromString(inputShape);
+    this.strideHeight = strideHeight;
+    this.strideWidth = strideWidth;
+    this.kernelHeight = kernelHeight;
+    this.kernelWidth = kernelWidth;
+    this.emptyLayerParam = LayerParameter.newEmptyInstance(matrixFactory);
+  }
+
+  /**
+   * @return the initial parameter of the layer.
+   */
+  public LayerParameter generateInitialParameter() {
+    return emptyLayerParam;
+  }
+
+  /**
+   * @return the index of the layer.
+   */
+  public int getIndex() {
+    return index;
+  }
+
+  /**
+   * This function computes output shape.
+   * input shape: row * col
+   * output shape: row' * col'
+   * row = (row − kernelHeight) / stride + 1
+   * col = (col − kernelWidth) / stride + 1
+   */
+  @Override
+  public int[] getOutputShape() {
+    final int[] computedShape;
+    switch (inputShape.length) {
+    case 1 :
+      computedShape = new int[1];
+      computedShape[0] = (inputShape[0] - kernelHeight) / strideHeight + 1;
+      return computedShape;
+    case 2 :
+      computedShape = new int[2];
+      computedShape[0] = (inputShape[0] - kernelHeight) / strideHeight + 1;
+      computedShape[1] = (inputShape[1] - kernelWidth) / strideWidth + 1;
+      return computedShape;
+    default :
+      throw new IllegalArgumentException("Unsupported input dimension: " + Integer.toString(inputShape.length));
+    }
+  }
+}

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/layers/LayerParameter.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/layers/LayerParameter.java
@@ -24,10 +24,6 @@ import edu.snu.dolphin.dnn.blas.MatrixFactory;
 public final class LayerParameter {
   private final Matrix weightParam;
   private final Matrix biasParam;
-  private final String poolingType;
-  private final int stride;
-  private final int kernalHeight;
-  private final int kernalWidth;
 
   /**
    * Generates a new instance of a layer parameter.
@@ -35,7 +31,7 @@ public final class LayerParameter {
    * @return the generated empty layer parameter
    */
   public static LayerParameter newEmptyInstance(final MatrixFactory matrixFactory) {
-    return new LayerParameter(matrixFactory.create(0), matrixFactory.create(0), null, 0, 0, 0);
+    return new LayerParameter(matrixFactory.create(0), matrixFactory.create(0));
   }
 
   /**
@@ -59,29 +55,9 @@ public final class LayerParameter {
     return biasParam;
   }
 
-  public String getPoolingType() {
-    return poolingType;
-  }
-
-  public int getStride() {
-    return stride;
-  }
-
-  public int getKernalHeight() {
-    return kernalHeight;
-  }
-
-  public int getKernalWidth() {
-    return kernalWidth;
-  }
-
   public static final class Builder implements org.apache.reef.util.Builder<LayerParameter> {
     private Matrix weightParam;
     private Matrix biasParam;
-    private String poolingType;
-    private int stride;
-    private int kernalHeight;
-    private int kernalWidth;
 
     public Builder setWeightParam(final Matrix weightParam) {
       this.weightParam = weightParam;
@@ -93,52 +69,21 @@ public final class LayerParameter {
       return this;
     }
 
-    public Builder setPoolingType(final String poolingType) {
-      this.poolingType = poolingType;
-      return this;
-    }
-
-    public Builder setStride(final int stride) {
-      this.stride = stride;
-      return this;
-    }
-
-    public Builder setKernalHeight(final int kernalHeight) {
-      this.kernalHeight = kernalHeight;
-      return this;
-    }
-
-    public Builder setKernalWidth(final int kernalWidth) {
-      this.kernalWidth = kernalWidth;
-      return this;
-    }
-
     @Override
     public LayerParameter build() {
-      return new LayerParameter(this.weightParam, this.biasParam,
-          this.poolingType, this.stride, this.kernalHeight, this.kernalWidth);
+      return new LayerParameter(this.weightParam, this.biasParam);
     }
   }
 
   private LayerParameter(final Matrix weightParam,
-                         final Matrix biasParam,
-                         final String poolingType,
-                         final int stride,
-                         final int kernalHeight,
-                         final int kernalWidth) {
+                         final Matrix biasParam) {
     this.weightParam = weightParam;
     this.biasParam = biasParam;
-    this.poolingType = poolingType;
-    this.stride = stride;
-    this.kernalHeight = kernalHeight;
-    this.kernalWidth = kernalWidth;
   }
 
   @Override
   public String toString() {
-    return "weight: " + weightParam.toString() + ", bias: " + biasParam.toString()
-        + ", pooling type: " + poolingType + ", stride: " + Integer.toString(stride)
-        + ", kernal height: " + Integer.toString(kernalHeight) + ", kernal width: " + Integer.toString(kernalWidth);
+    return "weight: " + weightParam.toString() + ", bias: " + biasParam.toString();
   }
 
   @Override
@@ -148,21 +93,13 @@ public final class LayerParameter {
     }
 
     final LayerParameter other = (LayerParameter)obj;
-    return weightParam.equals(other.weightParam) && biasParam.equals(other.biasParam)
-        && poolingType.equals(other.poolingType) && this.stride == other.stride
-        && this.kernalHeight == other.kernalHeight && this.kernalWidth == other.kernalWidth;
+    return weightParam.equals(other.weightParam) && biasParam.equals(other.biasParam);
   }
 
   @Override
   public int hashCode() {
     final int weightParamHashCode = weightParam == null ? 0 : weightParam.hashCode();
     final int biasParamHashCode = biasParam == null ? 0 : biasParam.hashCode();
-    final int poolingTypeHashCode = poolingType == null ? 0 : poolingType.hashCode();
-    final int strideHashCode = stride;
-    final int kernalHeightHashCode = kernalHeight;
-    final int kernalWidthHashCode = kernalWidth;
-    return strideHashCode * (int) Math.pow(31, 5) + kernalHeightHashCode * (int) Math.pow(31, 4) +
-        kernalWidthHashCode * (int) Math.pow(31, 3) + poolingTypeHashCode * (int) Math.pow(31, 2) +
-        weightParamHashCode * 31 + biasParamHashCode;
+    return weightParamHashCode * 31 + biasParamHashCode;
   }
 }

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/layers/LayerParameter.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/layers/LayerParameter.java
@@ -24,6 +24,10 @@ import edu.snu.dolphin.dnn.blas.MatrixFactory;
 public final class LayerParameter {
   private final Matrix weightParam;
   private final Matrix biasParam;
+  private final String poolingType;
+  private final int stride;
+  private final int kernalHeight;
+  private final int kernalWidth;
 
   /**
    * Generates a new instance of a layer parameter.
@@ -31,7 +35,7 @@ public final class LayerParameter {
    * @return the generated empty layer parameter
    */
   public static LayerParameter newEmptyInstance(final MatrixFactory matrixFactory) {
-    return new LayerParameter(matrixFactory.create(0), matrixFactory.create(0));
+    return new LayerParameter(matrixFactory.create(0), matrixFactory.create(0), null, 0, 0, 0);
   }
 
   /**
@@ -55,9 +59,29 @@ public final class LayerParameter {
     return biasParam;
   }
 
+  public String getPoolingType() {
+    return poolingType;
+  }
+
+  public int getStride() {
+    return stride;
+  }
+
+  public int getKernalHeight() {
+    return kernalHeight;
+  }
+
+  public int getKernalWidth() {
+    return kernalWidth;
+  }
+
   public static final class Builder implements org.apache.reef.util.Builder<LayerParameter> {
     private Matrix weightParam;
     private Matrix biasParam;
+    private String poolingType;
+    private int stride;
+    private int kernalHeight;
+    private int kernalWidth;
 
     public Builder setWeightParam(final Matrix weightParam) {
       this.weightParam = weightParam;
@@ -69,21 +93,52 @@ public final class LayerParameter {
       return this;
     }
 
+    public Builder setPoolingType(final String poolingType) {
+      this.poolingType = poolingType;
+      return this;
+    }
+
+    public Builder setStride(final int stride) {
+      this.stride = stride;
+      return this;
+    }
+
+    public Builder setKernalHeight(final int kernalHeight) {
+      this.kernalHeight = kernalHeight;
+      return this;
+    }
+
+    public Builder setKernalWidth(final int kernalWidth) {
+      this.kernalWidth = kernalWidth;
+      return this;
+    }
+
     @Override
     public LayerParameter build() {
-      return new LayerParameter(this.weightParam, this.biasParam);
+      return new LayerParameter(this.weightParam, this.biasParam,
+          this.poolingType, this.stride, this.kernalHeight, this.kernalWidth);
     }
   }
 
   private LayerParameter(final Matrix weightParam,
-                         final Matrix biasParam) {
+                         final Matrix biasParam,
+                         final String poolingType,
+                         final int stride,
+                         final int kernalHeight,
+                         final int kernalWidth) {
     this.weightParam = weightParam;
     this.biasParam = biasParam;
+    this.poolingType = poolingType;
+    this.stride = stride;
+    this.kernalHeight = kernalHeight;
+    this.kernalWidth = kernalWidth;
   }
 
   @Override
   public String toString() {
-    return "weight: " + weightParam.toString() + ", bias: " + biasParam.toString();
+    return "weight: " + weightParam.toString() + ", bias: " + biasParam.toString()
+        + ", pooling type: " + poolingType + ", stride: " + Integer.toString(stride)
+        + ", kernal height: " + Integer.toString(kernalHeight) + ", kernal width: " + Integer.toString(kernalWidth);
   }
 
   @Override
@@ -93,13 +148,21 @@ public final class LayerParameter {
     }
 
     final LayerParameter other = (LayerParameter)obj;
-    return weightParam.equals(other.weightParam) && biasParam.equals(other.biasParam);
+    return weightParam.equals(other.weightParam) && biasParam.equals(other.biasParam)
+        && poolingType.equals(other.poolingType) && this.stride == other.stride
+        && this.kernalHeight == other.kernalHeight && this.kernalWidth == other.kernalWidth;
   }
 
   @Override
   public int hashCode() {
     final int weightParamHashCode = weightParam == null ? 0 : weightParam.hashCode();
     final int biasParamHashCode = biasParam == null ? 0 : biasParam.hashCode();
-    return weightParamHashCode * 31 + biasParamHashCode;
+    final int poolingTypeHashCode = poolingType == null ? 0 : poolingType.hashCode();
+    final int strideHashCode = stride;
+    final int kernalHeightHashCode = kernalHeight;
+    final int kernalWidthHashCode = kernalWidth;
+    return strideHashCode * (int) Math.pow(31, 5) + kernalHeightHashCode * (int) Math.pow(31, 4) +
+        kernalWidthHashCode * (int) Math.pow(31, 3) + poolingTypeHashCode * (int) Math.pow(31, 2) +
+        weightParamHashCode * 31 + biasParamHashCode;
   }
 }

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/layers/PoolingLayer.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/layers/PoolingLayer.java
@@ -17,6 +17,7 @@ package edu.snu.dolphin.dnn.layers;
 
 import edu.snu.dolphin.dnn.blas.Matrix;
 import edu.snu.dolphin.dnn.conf.LayerConfigurationParameters.*;
+import edu.snu.dolphin.dnn.layerparam.initializer.LayerParameterInitializer;
 import org.apache.reef.tang.annotations.Parameter;
 
 import javax.inject.Inject;
@@ -53,52 +54,20 @@ public final class PoolingLayer extends LayerBase {
                        @Parameter(StrideHeight.class) final int strideHeight,
                        @Parameter(StrideWidth.class) final int strideWidth,
                        @Parameter(KernelHeight.class) final int kernelHeight,
-                       @Parameter(KernelWidth.class) final int kernelWidth) {
+                       @Parameter(KernelWidth.class) final int kernelWidth,
+                       final LayerParameterInitializer layerParameterInitializer) {
     super(index, inputShape);
     this.strideHeight = strideHeight;
     this.strideWidth = strideWidth;
     this.kernelHeight = kernelHeight;
     this.kernelWidth = kernelWidth;
-    this.outputShape = computeOutputShape();
-
-    try {
-      this.poolingType = PoolType.valueOf(poolingType);
-    } catch (final IllegalArgumentException illegalArgumentException) {
-      throw new IllegalArgumentException("Illegal pooling type: " + illegalArgumentException);
-    } catch (final NullPointerException nullPointerException) {
-      throw new NullPointerException("Null pointer exception while matching pooling type: " + nullPointerException);
-    }
+    this.outputShape = layerParameterInitializer.getOutputShape();
+    this.poolingType = PoolType.valueOf(poolingType);
   }
 
   @Override
   public int[] getOutputShape() {
     return outputShape;
-  }
-
-  /**
-   * This function computes output shape.
-   * input shape: row * col
-   * output shape: row' * col'
-   * row' = (row − kernelHeight) / stride + 1
-   * col' = (col − kernelWidth) / stride + 1
-   * @return shape of output
-   */
-  private int[] computeOutputShape() {
-    final int[] inputShape = getInputShape();
-    final int[] computedShape;
-    switch (inputShape.length) {
-    case 1:
-      computedShape = new int[1];
-      computedShape[0] = (inputShape[0] - kernelHeight) / strideHeight + 1;
-      return computedShape;
-    case 2:
-      computedShape = new int[2];
-      computedShape[0] = (inputShape[0] - kernelHeight) / strideHeight + 1;
-      computedShape[1] = (inputShape[1] - kernelWidth) / strideWidth + 1;
-      return computedShape;
-    default:
-      throw new IllegalArgumentException("Unsupported input dimension: " + Integer.toString(inputShape.length));
-    }
   }
 
   /** {@inheritDoc} */

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/layers/PoolingLayer.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/layers/PoolingLayer.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright (C) 2015 Seoul National University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.snu.dolphin.dnn.layers;
+
+import edu.snu.dolphin.dnn.blas.Matrix;
+import edu.snu.dolphin.dnn.blas.function.Function;
+import edu.snu.dolphin.dnn.conf.LayerConfigurationParameters;
+import edu.snu.dolphin.dnn.layerparam.initializer.LayerParameterInitializer;
+import org.apache.reef.tang.annotations.Parameter;
+
+import javax.inject.Inject;
+
+/**
+ * Pooling layer.
+ *
+ * This layer is not learnable.
+ * This layer resizes input matrix spatially, using max pooling or average pooling.
+ * In a forward pass,
+ * max pooling picks maximum value in certain range ( kernalHeight * kernalWidth) and these values make up output.
+ * average pooling get average of values in certain range (kernalHeight * kernalWidth) and these values make up output.
+ * In a backward pass,
+ * each value of error matrix is the sum of elements in next error matrix
+ * on which had an impact in feedforward step.
+ */
+
+public abstract class PoolingLayer extends LayerBase {
+
+  private final int[] outputShape;
+  private Matrix trackMatrix;
+  private Function poolingFunctions;
+
+  @Inject
+  public PoolingLayer(@Parameter(LayerConfigurationParameters.LayerIndex.class) final int index,
+                      @Parameter(LayerConfigurationParameters.LayerInputShape.class) final String inputShape,
+                      final LayerParameterInitializer layerParameterInitializer) {
+    super(index, inputShape);
+    this.outputShape = getOutputShape();
+    setLayerParameter(layerParameterInitializer.generateInitialParameter());
+  }
+
+  /**
+   * This function computes output size.
+   * input size: row * col
+   * output size: row' * col'
+   * row = (row − kernal_height) / stride + 1
+   * col = (col − kernal_width) / stride + 1
+   */
+
+  @Override
+  public int[] getOutputShape() {
+    final int[] inputShape = getInputShape();
+    int[] computedShape;
+    switch (inputShape.length) {
+    case 1:
+      computedShape = new int[1];
+      computedShape[0] = (inputShape[0] - getLayerParameter().getKernalHeight()) / getLayerParameter().getStride() + 1;
+      return computedShape;
+    case 2:
+      computedShape = new int[2];
+      computedShape[0] = (inputShape[0] - getLayerParameter().getKernalHeight()) / getLayerParameter().getStride() + 1;
+      computedShape[1] = (inputShape[1] - getLayerParameter().getKernalWidth()) / getLayerParameter().getStride() + 1;
+      return computedShape;
+    default:
+      throw new IllegalArgumentException("Unsupported input dimension: " + Integer.toString(inputShape.length));
+    }
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public boolean isLearnable() {
+    return false;
+  }
+
+  public abstract Matrix feedForwardMaxPooling(final Matrix input);
+
+  public abstract Matrix feedForwardAveragePooling(final Matrix input);
+
+  /**
+   * Computes output values for this pooling layer.
+   * available pooling type: max, average
+   * @param input input values for this layer.
+   * @return output values for this layer.
+   */
+
+  @Override
+  public  Matrix feedForward(final Matrix input) {
+    switch (getLayerParameter().getPoolingType().toLowerCase()) {
+    case "max" :
+      return feedForwardMaxPooling(input);
+    case "average" :
+      return feedForwardAveragePooling(input);
+    default:
+      throw new IllegalArgumentException("Illegal pooling type: " + getLayerParameter().getPoolingType());
+    }
+  }
+
+  public abstract Matrix backPropagateMaxPooling(final Matrix input, final Matrix nextError);
+
+  public abstract Matrix backPropagateAveragePooling(final Matrix input, final Matrix nextError);
+
+  /**
+   * Computes errors for this pooling layer.
+   * available pooling type: max, average
+   * @param input the input values for this layer.
+   * @param activation the output values.
+   * @param nextError the errors of the next layer - the one closer to the output layer.
+   * @return errors for this layer with the specified input value.
+   */
+
+  @Override
+  public Matrix backPropagate(final Matrix input, final Matrix activation, final Matrix nextError) {
+    switch (getLayerParameter().getPoolingType().toLowerCase()) {
+    case "max" :
+      return backPropagateMaxPooling(input, nextError);
+    case "average" :
+      return backPropagateAveragePooling(input, nextError);
+    default:
+      throw new IllegalArgumentException("Illegal pooling type: " + getLayerParameter().getPoolingType());
+    }
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public LayerParameter generateParameterGradient(final Matrix input, final Matrix error) {
+    throw new RuntimeException("This layer doesn't have parameter gradient");
+  }
+}

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/layers/PoolingLayer.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/layers/PoolingLayer.java
@@ -47,8 +47,13 @@ public abstract class PoolingLayer extends LayerBase {
                       @Parameter(LayerConfigurationParameters.LayerInputShape.class) final String inputShape,
                       final LayerParameterInitializer layerParameterInitializer) {
     super(index, inputShape);
-    this.outputShape = getOutputShape();
+    this.outputShape = setOutputShape();
     setLayerParameter(layerParameterInitializer.generateInitialParameter());
+  }
+
+  @Override
+  public int[] getOutputShape() {
+    return outputShape;
   }
 
   /**
@@ -59,8 +64,7 @@ public abstract class PoolingLayer extends LayerBase {
    * col = (col − kernal_width) / stride + 1
    */
 
-  @Override
-  public int[] getOutputShape() {
+  public int[] setOutputShape() {
     final int[] inputShape = getInputShape();
     int[] computedShape;
     switch (inputShape.length) {

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/layers/PoolingLayer.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/layers/PoolingLayer.java
@@ -32,7 +32,7 @@ import javax.inject.Inject;
  * Average pooling gets the average of values in certain range (kernelHeight * kernelWidth)
  * and these values make up output.
  * In a backward pass,
- * each value of error matrix is the sum of elements in next error matrix on which had an impact in feedforward step.
+ * error of each input pixel comes from errors of output pixels affected by the input pixel in feedforward step.
  */
 public final class PoolingLayer extends LayerBase {
 
@@ -40,11 +40,11 @@ public final class PoolingLayer extends LayerBase {
     AVERAGE, MAX
   }
   private final int[] outputShape;
-  private PoolType poolingType;
-  private int strideHeight;
-  private int strideWidth;
-  private int kernelHeight;
-  private int kernelWidth;
+  private final PoolType poolingType;
+  private final int strideHeight;
+  private final int strideWidth;
+  private final int kernelHeight;
+  private final int kernelWidth;
 
   @Inject
   private PoolingLayer(@Parameter(LayerIndex.class) final int index,

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/layers/PoolingLayer.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/layers/PoolingLayer.java
@@ -42,7 +42,8 @@ public final class PoolingLayer extends LayerBase {
   }
   private final int[] outputShape;
   private PType poolingType;
-  private int stride;
+  private int strideHeight;
+  private int strideWidth;
   private int kernelHeight;
   private int kernelWidth;
   private Matrix trackMatrix;
@@ -52,13 +53,15 @@ public final class PoolingLayer extends LayerBase {
   private PoolingLayer(@Parameter(LayerIndex.class) final int index,
                        @Parameter(LayerInputShape.class) final String inputShape,
                        @Parameter(PoolingType.class) final String poolingType,
-                       @Parameter(Stride.class) final int stride,
+                       @Parameter(StrideHeight.class) final int strideHeight,
+                       @Parameter(StrideWidth.class) final int strideWidth,
                        @Parameter(KernelHeight.class) final int kernelHeight,
                        @Parameter(KernelWidth.class) final int kernelWidth,
                        final LayerParameterInitializer layerParameterInitializer) {
     super(index, inputShape);
     this.outputShape = setOutputShape();
-    this.stride = stride;
+    this.strideHeight = strideHeight;
+    this.strideWidth = strideWidth;
     this.kernelHeight = kernelHeight;
     this.kernelWidth = kernelWidth;
 
@@ -89,12 +92,12 @@ public final class PoolingLayer extends LayerBase {
     switch (inputShape.length) {
     case 1 :
       computedShape = new int[1];
-      computedShape[0] = (inputShape[0] - kernelHeight) / stride + 1;
+      computedShape[0] = (inputShape[0] - kernelHeight) / strideHeight + 1;
       return computedShape;
     case 2 :
       computedShape = new int[2];
-      computedShape[0] = (inputShape[0] - kernelHeight) / stride + 1;
-      computedShape[1] = (inputShape[1] - kernelWidth) / stride + 1;
+      computedShape[0] = (inputShape[0] - kernelHeight) / strideHeight + 1;
+      computedShape[1] = (inputShape[1] - kernelWidth) / strideWidth + 1;
       return computedShape;
     default :
       throw new IllegalArgumentException("Unsupported input dimension: " + Integer.toString(inputShape.length));

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/layers/PoolingLayer.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/layers/PoolingLayer.java
@@ -55,11 +55,11 @@ public final class PoolingLayer extends LayerBase {
                        @Parameter(KernelHeight.class) final int kernelHeight,
                        @Parameter(KernelWidth.class) final int kernelWidth) {
     super(index, inputShape);
-    this.outputShape = computeOutputShape();
     this.strideHeight = strideHeight;
     this.strideWidth = strideWidth;
     this.kernelHeight = kernelHeight;
     this.kernelWidth = kernelWidth;
+    this.outputShape = computeOutputShape();
 
     try {
       this.poolingType = PoolType.valueOf(poolingType);
@@ -87,16 +87,16 @@ public final class PoolingLayer extends LayerBase {
     final int[] inputShape = getInputShape();
     final int[] computedShape;
     switch (inputShape.length) {
-    case 1 :
+    case 1:
       computedShape = new int[1];
       computedShape[0] = (inputShape[0] - kernelHeight) / strideHeight + 1;
       return computedShape;
-    case 2 :
+    case 2:
       computedShape = new int[2];
       computedShape[0] = (inputShape[0] - kernelHeight) / strideHeight + 1;
       computedShape[1] = (inputShape[1] - kernelWidth) / strideWidth + 1;
       return computedShape;
-    default :
+    default:
       throw new IllegalArgumentException("Unsupported input dimension: " + Integer.toString(inputShape.length));
     }
   }
@@ -124,11 +124,11 @@ public final class PoolingLayer extends LayerBase {
   @Override
   public Matrix feedForward(final Matrix input) {
     switch (poolingType) {
-    case MAX :
+    case MAX:
       return feedForwardMaxPooling(input);
-    case AVERAGE :
+    case AVERAGE:
       return feedForwardAveragePooling(input);
-    default :
+    default:
       throw new IllegalArgumentException("Illegal pooling type: " + poolingType);
     }
   }
@@ -152,11 +152,11 @@ public final class PoolingLayer extends LayerBase {
   @Override
   public Matrix backPropagate(final Matrix input, final Matrix activation, final Matrix nextError) {
     switch (poolingType) {
-    case MAX :
+    case MAX:
       return backPropagateMaxPooling(input, nextError);
-    case AVERAGE :
+    case AVERAGE:
       return backPropagateAveragePooling(input, nextError);
-    default :
+    default:
       throw new IllegalArgumentException("Illegal pooling type: " + poolingType);
     }
   }

--- a/dolphin-dnn/src/main/proto/neural_network.proto
+++ b/dolphin-dnn/src/main/proto/neural_network.proto
@@ -45,6 +45,7 @@ message LayerConfiguration {
   optional FullyConnectedLayerConfiguration fully_connected_param = 2;
   optional ActivationLayerConfiguration activation_param = 3;
   optional ActivationWithLossLayerConfiguration activation_with_loss_param = 4;
+  optional PoolingLayerConfiguration pooling_param = 5;
 }
 
 message ParameterProviderConfiguration {

--- a/dolphin-dnn/src/main/proto/neural_network.proto
+++ b/dolphin-dnn/src/main/proto/neural_network.proto
@@ -24,9 +24,9 @@ message FullyConnectedLayerConfiguration {
 }
 
 message PoolingLayerConfiguration {
-  optional string pooling_type = 1;
-  optional uint32 stride_height = 2;
-  optional uint32 stride_width = 3;
+  optional string pooling_type = 1 [default = "MAX"];
+  optional uint32 stride_height = 2 [default = 1];
+  optional uint32 stride_width = 3 [default = 1];
   required uint32 kernel_height = 4;
   required uint32 kernel_width = 5;
 }

--- a/dolphin-dnn/src/main/proto/neural_network.proto
+++ b/dolphin-dnn/src/main/proto/neural_network.proto
@@ -24,9 +24,9 @@ message FullyConnectedLayerConfiguration {
 }
 
 message PoolingLayerConfiguration {
-  required string pooling_type = 1;
-  required uint32 stride_height = 2;
-  required uint32 stride_width = 3;
+  optional string pooling_type = 1;
+  optional uint32 stride_height = 2;
+  optional uint32 stride_width = 3;
   required uint32 kernel_height = 4;
   required uint32 kernel_width = 5;
 }

--- a/dolphin-dnn/src/main/proto/neural_network.proto
+++ b/dolphin-dnn/src/main/proto/neural_network.proto
@@ -23,6 +23,14 @@ message FullyConnectedLayerConfiguration {
   required uint32 num_output = 4;
 }
 
+message PoolingLayerConfiguration {
+  required string pooling_type = 1;
+  required uint32 stride_height = 2;
+  required uint32 stride_width = 3;
+  required uint32 kernel_height = 4;
+  required uint32 kernel_width = 5;
+}
+
 message ActivationLayerConfiguration {
   required string activation_function = 1;
 }


### PR DESCRIPTION
As a first step for implementing CNN,  this PR introduce new layer class `PoolingLayer`.  This layer extends `LayerBase`, and include implementation for `isLearnable()`, `getOutputShape()` and `generateParameterGradient()`. This PR include some modifications in `LayerParameter`, which enable `poolingLayer`  to make use of its new parameters. Also, `PoolingLayerConfigurationBuilder` class and `PoolingLayerParameterInitializer` class are added  for configuration of pooling layer. `neural_network.proto` is modified to take inputs for pooling layer. Concrete implementation for `feedForward()` and `backPropagate()` will be made in later PRs. 