### PR TITLE
Convolutional layer base implementation

### DIFF
--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/NeuralNetworkDriverParameters.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/NeuralNetworkDriverParameters.java
@@ -161,6 +161,9 @@ public final class NeuralNetworkDriverParameters {
     case "pooling":
       return PoolingLayerConfigurationBuilder.newConfigurationBuilder()
           .fromProtoConfiguration(layerConf).build();
+    case "convolutional":
+      return PoolingLayerConfigurationBuilder.newConfigurationBuilder()
+          .fromProtoConfiguration(layerConf).build();
     default:
       throw new IllegalArgumentException("Illegal layer type: " + layerConf.getType());
     }

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/NeuralNetworkDriverParameters.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/NeuralNetworkDriverParameters.java
@@ -162,7 +162,7 @@ public final class NeuralNetworkDriverParameters {
       return PoolingLayerConfigurationBuilder.newConfigurationBuilder()
           .fromProtoConfiguration(layerConf).build();
     case "convolutional":
-      return PoolingLayerConfigurationBuilder.newConfigurationBuilder()
+      return ConvolutionalLayerConfigurationBuilder.newConfigurationBuilder()
           .fromProtoConfiguration(layerConf).build();
     default:
       throw new IllegalArgumentException("Illegal layer type: " + layerConf.getType());

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/conf/ConvolutionalLayerConfigurationBuilder.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/conf/ConvolutionalLayerConfigurationBuilder.java
@@ -15,6 +15,7 @@
  */
 package edu.snu.dolphin.dnn.conf;
 
+import edu.snu.dolphin.dnn.layerparam.initializer.ConvolutionalLayerParameterInitializer;
 import edu.snu.dolphin.dnn.layerparam.initializer.LayerParameterInitializer;
 import edu.snu.dolphin.dnn.layers.ConvolutionalLayer;
 import edu.snu.dolphin.dnn.layers.LayerBase;
@@ -94,14 +95,14 @@ public final class ConvolutionalLayerConfigurationBuilder implements Builder<Con
 
   public synchronized ConvolutionalLayerConfigurationBuilder fromProtoConfiguration(
       final NeuralNetworkProtos.LayerConfiguration protoConf) {
-    paddingHeight = protoConf.getConvolutionalParam().getPaddingHeight;
-    paddingWidth = protoConf.getConvolutionalParam().getPaddingWidth;
+    paddingHeight = protoConf.getConvolutionalParam().getPaddingHeight();
+    paddingWidth = protoConf.getConvolutionalParam().getPaddingWidth();
     strideHeight = protoConf.getConvolutionalParam().getStrideHeight();
     strideWidth = protoConf.getConvolutionalParam().getStrideWidth();
     kernelHeight = protoConf.getConvolutionalParam().getKernelHeight();
     kernelWidth = protoConf.getConvolutionalParam().getKernelWidth();
     if (protoConf.getConvolutionalParam().hasRandomSeed()) {
-        randomSeed = protoConf.getConvolutionalParam().getRandomSeed();
+      randomSeed = protoConf.getConvolutionalParam().getRandomSeed();
     }
     initWeight = protoConf.getConvolutionalParam().getInitWeight();
     initBias = protoConf.getConvolutionalParam().getInitBias();

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/conf/ConvolutionalLayerConfigurationBuilder.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/conf/ConvolutionalLayerConfigurationBuilder.java
@@ -27,7 +27,7 @@ import org.apache.reef.util.Builder;
 /**
  * Configuration builder for Convolutional layer.
  *
- * The configuration that this builder generates is used to create convolutional layer instance.
+ * The configuration that this builder generates is used to create a convolutional layer instance.
  * The generated configuration needs to bind the implementation for matrix factory and
  * the parameter for a layer input shape, to inject a layer instance.
  */
@@ -37,10 +37,10 @@ public final class ConvolutionalLayerConfigurationBuilder implements Builder<Con
     return new ConvolutionalLayerConfigurationBuilder();
   }
 
-  private int paddingHeight;
-  private int paddingWidth;
-  private int strideHeight;
-  private int strideWidth;
+  private int paddingHeight = 0;
+  private int paddingWidth = 0;
+  private int strideHeight = 1;
+  private int strideWidth = 1;
   private int kernelHeight;
   private int kernelWidth;
   private long randomSeed = System.currentTimeMillis();

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/conf/ConvolutionalLayerConfigurationBuilder.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/conf/ConvolutionalLayerConfigurationBuilder.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright (C) 2016 Seoul National University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.snu.dolphin.dnn.conf;
+
+import edu.snu.dolphin.dnn.layerparam.initializer.LayerParameterInitializer;
+import edu.snu.dolphin.dnn.layers.ConvolutionalLayer;
+import edu.snu.dolphin.dnn.layers.LayerBase;
+import edu.snu.dolphin.dnn.proto.NeuralNetworkProtos;
+import org.apache.reef.tang.Configuration;
+import org.apache.reef.tang.Tang;
+import org.apache.reef.util.Builder;
+
+/**
+ * Configuration builder for Convolutional layer.
+ *
+ * The configuration that this builder generates is used to create convolutional layer instance.
+ * The generated configuration needs to bind the implementation for matrix factory and
+ * the parameter for a layer input shape, to inject a layer instance.
+ */
+public final class ConvolutionalLayerConfigurationBuilder implements Builder<Configuration> {
+
+  public static ConvolutionalLayerConfigurationBuilder newConfigurationBuilder() {
+    return new ConvolutionalLayerConfigurationBuilder();
+  }
+
+  private int paddingHeight;
+  private int paddingWidth;
+  private int strideHeight;
+  private int strideWidth;
+  private int kernelHeight;
+  private int kernelWidth;
+  private long randomSeed = System.currentTimeMillis();
+  private float initWeight;
+  private float initBias;
+
+  public synchronized ConvolutionalLayerConfigurationBuilder setPaddingHeight(final int paddingHeight) {
+    this.paddingHeight = paddingHeight;
+    return this;
+  }
+
+  public synchronized ConvolutionalLayerConfigurationBuilder setPaddingWidth(final int paddingWidth) {
+    this.paddingWidth = paddingWidth;
+    return this;
+  }
+
+  public synchronized ConvolutionalLayerConfigurationBuilder setStrideHeight(final int strideHeight) {
+    this.strideHeight = strideHeight;
+    return this;
+  }
+
+  public synchronized ConvolutionalLayerConfigurationBuilder setStrideWidth(final int strideWidth) {
+    this.strideWidth = strideWidth;
+    return this;
+  }
+
+  public synchronized ConvolutionalLayerConfigurationBuilder setKernelHeight(final int kernelHeight) {
+    this.kernelHeight = kernelHeight;
+    return this;
+  }
+
+  public synchronized ConvolutionalLayerConfigurationBuilder setKernelWidth(final int kernelWidth) {
+    this.kernelWidth = kernelWidth;
+    return this;
+  }
+
+  public synchronized ConvolutionalLayerConfigurationBuilder setRandomSeed(final long randomSeed) {
+    this.randomSeed = randomSeed;
+    return this;
+  }
+
+  public synchronized ConvolutionalLayerConfigurationBuilder setInitWeight(final float initWeight) {
+    this.initWeight = initWeight;
+    return this;
+  }
+
+  public synchronized ConvolutionalLayerConfigurationBuilder setInitBias(final float initBias) {
+    this.initBias = initBias;
+    return this;
+  }
+
+
+  public synchronized ConvolutionalLayerConfigurationBuilder fromProtoConfiguration(
+      final NeuralNetworkProtos.LayerConfiguration protoConf) {
+    paddingHeight = protoConf.getConvolutionalParam().getPaddingHeight;
+    paddingWidth = protoConf.getConvolutionalParam().getPaddingWidth;
+    strideHeight = protoConf.getConvolutionalParam().getStrideHeight();
+    strideWidth = protoConf.getConvolutionalParam().getStrideWidth();
+    kernelHeight = protoConf.getConvolutionalParam().getKernelHeight();
+    kernelWidth = protoConf.getConvolutionalParam().getKernelWidth();
+    if (protoConf.getConvolutionalParam().hasRandomSeed()) {
+        randomSeed = protoConf.getConvolutionalParam().getRandomSeed();
+    }
+    initWeight = protoConf.getConvolutionalParam().getInitWeight();
+    initBias = protoConf.getConvolutionalParam().getInitBias();
+    return this;
+  }
+
+  @Override
+  public synchronized Configuration build() {
+    return Tang.Factory.getTang().newConfigurationBuilder()
+        .bindNamedParameter(LayerConfigurationParameters.PaddingHeight.class, String.valueOf(paddingHeight))
+        .bindNamedParameter(LayerConfigurationParameters.PaddingWidth.class, String.valueOf(paddingWidth))
+        .bindNamedParameter(LayerConfigurationParameters.StrideHeight.class, String.valueOf(strideHeight))
+        .bindNamedParameter(LayerConfigurationParameters.StrideWidth.class, String.valueOf(strideWidth))
+        .bindNamedParameter(LayerConfigurationParameters.KernelHeight.class, String.valueOf(kernelHeight))
+        .bindNamedParameter(LayerConfigurationParameters.KernelWidth.class, String.valueOf(kernelWidth))
+        .bindNamedParameter(LayerConfigurationParameters.RandomSeed.class, String.valueOf(randomSeed))
+        .bindNamedParameter(LayerConfigurationParameters.InitialWeight.class, String.valueOf(initWeight))
+        .bindNamedParameter(LayerConfigurationParameters.InitialBias.class, String.valueOf(initBias))
+        .bindImplementation(LayerBase.class, ConvolutionalLayer.class)
+        .bindImplementation(LayerParameterInitializer.class, ConvolutionalLayerParameterInitializer.class)
+        .build();
+  }
+}

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/conf/LayerConfigurationParameters.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/conf/LayerConfigurationParameters.java
@@ -72,27 +72,27 @@ public final class LayerConfigurationParameters {
   public static final class PoolingType implements Name<String> {
   }
 
-  @NamedParameter(doc = "padding height of pooling / convolutional layer", short_name = "paddingH")
+  @NamedParameter(doc = "padding height of pooling / convolutional layer")
   public static final class PaddingHeight implements Name<Integer> {
   }
 
-  @NamedParameter(doc = "padding width of pooling / convolutional layer", short_name = "paddingW")
+  @NamedParameter(doc = "padding width of pooling / convolutional layer")
   public static final class PaddingWidth implements Name<Integer> {
   }
 
-  @NamedParameter(doc = "stride height of pooling / convolutional layer", short_name = "strideH")
+  @NamedParameter(doc = "stride height of pooling / convolutional layer")
   public static final class StrideHeight implements Name<Integer> {
   }
 
-  @NamedParameter(doc = "stride width of pooling / convolutional layer", short_name = "strideW")
+  @NamedParameter(doc = "stride width of pooling / convolutional layer")
   public static final class StrideWidth implements Name<Integer> {
   }
 
-  @NamedParameter(doc = "kernel height of pooling / convolutional layer", short_name = "kernelH")
+  @NamedParameter(doc = "kernel height of pooling / convolutional layer")
   public static final class KernelHeight implements Name<Integer> {
   }
 
-  @NamedParameter(doc = "kernel width of pooling / convolutional layer", short_name = "kernelW")
+  @NamedParameter(doc = "kernel width of pooling / convolutional layer")
   public static final class KernelWidth implements Name<Integer> {
   }
 }

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/conf/LayerConfigurationParameters.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/conf/LayerConfigurationParameters.java
@@ -66,10 +66,18 @@ public final class LayerConfigurationParameters {
   }
 
   /**
-   * For pooling layers.
+   * For pooling / convolutional layers.
    */
   @NamedParameter(doc = "pooling type of pooling layer")
   public static final class PoolingType implements Name<String> {
+  }
+
+  @NamedParameter(doc = "padding height of pooling / convolutional layer", short_name = "paddingH")
+  public static final class PaddingHeight implements Name<Integer> {
+  }
+
+  @NamedParameter(doc = "padding width of pooling / convolutional layer", short_name = "paddingW")
+  public static final class PaddingWidth implements Name<Integer> {
   }
 
   @NamedParameter(doc = "stride height of pooling / convolutional layer", short_name = "strideH")

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/conf/PoolingLayerConfigurationBuilder.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/conf/PoolingLayerConfigurationBuilder.java
@@ -36,9 +36,9 @@ public final class PoolingLayerConfigurationBuilder implements Builder<Configura
     return new PoolingLayerConfigurationBuilder();
   }
 
-  private String poolingType;
-  private int strideHeight;
-  private int strideWidth;
+  private String poolingType = "MAX";
+  private int strideHeight = 1;
+  private int strideWidth = 1;
   private int kernelHeight;
   private int kernelWidth;
 

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/layerparam/initializer/ConvolutionalLayerParameterInitializer.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/layerparam/initializer/ConvolutionalLayerParameterInitializer.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright (C) 2016 Seoul National University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.snu.dolphin.dnn.layerparam.initializer;
+
+import edu.snu.dolphin.dnn.blas.Matrix;
+import edu.snu.dolphin.dnn.blas.MatrixFactory;
+import edu.snu.dolphin.dnn.conf.LayerConfigurationParameters;
+import edu.snu.dolphin.dnn.layers.LayerParameter;
+import org.apache.reef.tang.annotations.Parameter;
+
+import javax.inject.Inject;
+
+import static edu.snu.dolphin.dnn.util.NeuralNetworkUtils.shapeFromString;
+
+/**
+ * Convolutional Layer parameter initializer.
+ *
+ * initializes the weight matrix with pseudo random normal distributed value with mean 0 and given standard deviation.
+ * initializes the bias vector with the given value.
+ * includes function that compute the output shape.
+ */
+public final class ConvolutionalLayerParameterInitializer implements LayerParameterInitializer {
+
+  private final MatrixFactory matrixFactory;
+  private final int index;
+  private final int[] inputShape;
+  private final int[] outputShape;
+  private final int paddingHeight;
+  private final int paddingWidth;
+  private final int strideHeight;
+  private final int strideWidth;
+  private final int kernelHeight;
+  private final int kernelWidth;
+  private final float initWeight;
+  private final float initBias;
+  private final long randomSeed;
+
+  @Inject
+  private ConvolutionalLayerParameterInitializer(
+      final MatrixFactory matrixFactory,
+      @Parameter(LayerConfigurationParameters.LayerIndex.class) final int index,
+      @Parameter(LayerConfigurationParameters.LayerInputShape.class) final String inputShape,
+      @Parameter(LayerConfigurationParameters.PaddingHeight.class) final int paddingHeight,
+      @Parameter(LayerConfigurationParameters.PaddingWidth.class) final int paddingWidth,
+      @Parameter(LayerConfigurationParameters.StrideHeight.class) final int strideHeight,
+      @Parameter(LayerConfigurationParameters.StrideWidth.class) final int strideWidth,
+      @Parameter(LayerConfigurationParameters.KernelHeight.class) final int kernelHeight,
+      @Parameter(LayerConfigurationParameters.KernelWidth.class) final int kernelWidth,
+      @Parameter(LayerConfigurationParameters.RandomSeed.class) final long randomSeed,
+      @Parameter(LayerConfigurationParameters.InitialWeight.class) final float initWeight,
+      @Parameter(LayerConfigurationParameters.InitialBias.class) final float initBias) {
+    this.matrixFactory = matrixFactory;
+    this.index = index;
+    this.inputShape = shapeFromString(inputShape);
+    this.paddingHeight = paddingHeight;
+    this.paddingWidth = paddingWidth;
+    this.strideHeight = strideHeight;
+    this.strideWidth = strideWidth;
+    this.kernelHeight = kernelHeight;
+    this.kernelWidth = kernelWidth;
+    this.outputShape = computeOutputShape();
+    this.randomSeed = randomSeed;
+    this.initWeight = initWeight;
+    this.initBias = initBias;
+  }
+
+  /**
+   * @return the initial parameter of the layer.
+   */
+  public LayerParameter generateInitialParameter() {
+    final Matrix weight = matrixFactory.randn(kernelHeight, kernelWidth, randomSeed);
+    final Matrix bias = matrixFactory.create(outputShape[0],outputShape[1]).fill(initBias);
+
+    weight.muli(initWeight); // multiply by standard deviation.
+
+    return LayerParameter.newBuilder()
+        .setWeightParam(weight)
+        .setBiasParam(bias)
+        .build();
+  }
+
+  /**
+   * @return the index of the layer.
+   */
+  public int getIndex() {
+    return index;
+}
+
+  /**
+   * This function checks if stride is set proper for the input shape.
+   */
+  private void checkShape() {
+    if ((inputShape[0] - kernelHeight + 2 * paddingHeight) % strideHeight != 0) {
+        throw new IllegalArgumentException("Stride height is not proper for input.");
+    } else if (inputShape.length == 2 && (inputShape[1] - kernelWidth + 2 * paddingWidth) % strideWidth != 0) {
+        throw new IllegalArgumentException("Stride width is not proper for input.");
+    }
+  }
+
+  /**
+   * This function computes output shape.
+   * input shape: row * col
+   * output shape: row' * col'
+   * row' = (row − kernelHeight + 2 * paddingHeight) / stride + 1
+   * col' = (col − kernelWidth + 2 * paddingWidth) / stride + 1
+   * @return shape of output
+   */
+  private int[] computeOutputShape() {
+    final int[] computedShape = new int[2];
+    checkShape();
+    switch (inputShape.length) {
+    case 1:
+      computedShape[0] = (inputShape[0] - kernelHeight + 2 * paddingHeight) / strideHeight + 1;
+      computedShape[1] = 1;
+      return computedShape;
+    case 2:
+            computedShape[0] = (inputShape[0] - kernelHeight + 2 * paddingHeight) / strideHeight + 1;
+            computedShape[1] = (inputShape[1] - kernelWidth + 2 * paddingWidth) / strideWidth + 1;
+            return computedShape;
+    default:
+            throw new IllegalArgumentException("Unsupported input dimension: " + Integer.toString(inputShape.length));
+    }
+  }
+
+  /**
+   * @return shape of output
+   */
+  @Override
+  public int[] getOutputShape() {
+    return outputShape;
+  }
+}

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/layerparam/initializer/ConvolutionalLayerParameterInitializer.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/layerparam/initializer/ConvolutionalLayerParameterInitializer.java
@@ -104,8 +104,8 @@ public final class ConvolutionalLayerParameterInitializer implements LayerParame
    * This function computes output shape.
    * input shape: row * col
    * output shape: row' * col'
-   * row' = (row − kernelHeight + 2 * paddingHeight) / stride + 1
-   * col' = (col − kernelWidth + 2 * paddingWidth) / stride + 1
+   * row' = ceil((row − kernelHeight + 2 * paddingHeight) / stride) + 1
+   * col' = ceil((col − kernelWidth + 2 * paddingWidth) / stride) + 1
    * @return shape of output
    */
   private int[] computeOutputShape() {

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/layerparam/initializer/ConvolutionalLayerParameterInitializer.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/layerparam/initializer/ConvolutionalLayerParameterInitializer.java
@@ -28,9 +28,10 @@ import static edu.snu.dolphin.dnn.util.NeuralNetworkUtils.shapeFromString;
 /**
  * Convolutional Layer parameter initializer.
  *
- * initializes the weight matrix with pseudo random normal distributed value with mean 0 and given standard deviation.
- * initializes the bias vector with the given value.
- * includes function that computes the output shape.
+ * This class initializes the weight matrix
+ * with pseudo random normal distributed value with mean 0 and given standard deviation.
+ * This class initializes the bias vector with the given value.
+ * This class includes function that computes the output shape.
  */
 public final class ConvolutionalLayerParameterInitializer implements LayerParameterInitializer {
 
@@ -100,17 +101,6 @@ public final class ConvolutionalLayerParameterInitializer implements LayerParame
   }
 
   /**
-   * This function checks if stride is set proper for the input shape.
-   */
-  private void checkShape() {
-    if ((inputShape[0] - kernelHeight + 2 * paddingHeight) % strideHeight != 0) {
-      throw new IllegalArgumentException("Stride height is not proper for input.");
-    } else if ((inputShape[1] - kernelWidth + 2 * paddingWidth) % strideWidth != 0) {
-      throw new IllegalArgumentException("Stride width is not proper for input.");
-    }
-  }
-
-  /**
    * This function computes output shape.
    * input shape: row * col
    * output shape: row' * col'
@@ -120,9 +110,8 @@ public final class ConvolutionalLayerParameterInitializer implements LayerParame
    */
   private int[] computeOutputShape() {
     final int[] computedShape = new int[2];
-    checkShape();
-    computedShape[0] = (inputShape[0] - kernelHeight + 2 * paddingHeight) / strideHeight + 1;
-    computedShape[1] = (inputShape[1] - kernelWidth + 2 * paddingWidth) / strideWidth + 1;
+    computedShape[0] = (int) Math.ceil((double) (inputShape[0] - kernelHeight + 2 * paddingHeight) / strideHeight) + 1;
+    computedShape[1] = (int) Math.ceil((double) (inputShape[1] - kernelWidth + 2 * paddingWidth) / strideWidth) + 1;
     return computedShape;
   }
 

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/layerparam/initializer/ConvolutionalLayerParameterInitializer.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/layerparam/initializer/ConvolutionalLayerParameterInitializer.java
@@ -110,8 +110,11 @@ public final class ConvolutionalLayerParameterInitializer implements LayerParame
    */
   private int[] computeOutputShape() {
     final int[] computedShape = new int[2];
-    computedShape[0] = (int) Math.ceil((double) (inputShape[0] - kernelHeight + 2 * paddingHeight) / strideHeight) + 1;
-    computedShape[1] = (int) Math.ceil((double) (inputShape[1] - kernelWidth + 2 * paddingWidth) / strideWidth) + 1;
+    if (inputShape.length != 2) {
+      throw new IllegalArgumentException("Unsupported input dimensions: " + inputShape.length);
+    }
+    computedShape[0] = (int) Math.ceil((float) (inputShape[0] - kernelHeight + 2 * paddingHeight) / strideHeight) + 1;
+    computedShape[1] = (int) Math.ceil((float) (inputShape[1] - kernelWidth + 2 * paddingWidth) / strideWidth) + 1;
     return computedShape;
   }
 

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/layerparam/initializer/ConvolutionalLayerParameterInitializer.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/layerparam/initializer/ConvolutionalLayerParameterInitializer.java
@@ -30,7 +30,7 @@ import static edu.snu.dolphin.dnn.util.NeuralNetworkUtils.shapeFromString;
  *
  * initializes the weight matrix with pseudo random normal distributed value with mean 0 and given standard deviation.
  * initializes the bias vector with the given value.
- * includes function that compute the output shape.
+ * includes function that computes the output shape.
  */
 public final class ConvolutionalLayerParameterInitializer implements LayerParameterInitializer {
 
@@ -82,7 +82,7 @@ public final class ConvolutionalLayerParameterInitializer implements LayerParame
    */
   public LayerParameter generateInitialParameter() {
     final Matrix weight = matrixFactory.randn(kernelHeight, kernelWidth, randomSeed);
-    final Matrix bias = matrixFactory.create(outputShape[0],outputShape[1]).fill(initBias);
+    final Matrix bias = matrixFactory.create(outputShape[0], outputShape[1]).fill(initBias);
 
     weight.muli(initWeight); // multiply by standard deviation.
 
@@ -97,16 +97,16 @@ public final class ConvolutionalLayerParameterInitializer implements LayerParame
    */
   public int getIndex() {
     return index;
-}
+  }
 
   /**
    * This function checks if stride is set proper for the input shape.
    */
   private void checkShape() {
     if ((inputShape[0] - kernelHeight + 2 * paddingHeight) % strideHeight != 0) {
-        throw new IllegalArgumentException("Stride height is not proper for input.");
-    } else if (inputShape.length == 2 && (inputShape[1] - kernelWidth + 2 * paddingWidth) % strideWidth != 0) {
-        throw new IllegalArgumentException("Stride width is not proper for input.");
+      throw new IllegalArgumentException("Stride height is not proper for input.");
+    } else if ((inputShape[1] - kernelWidth + 2 * paddingWidth) % strideWidth != 0) {
+      throw new IllegalArgumentException("Stride width is not proper for input.");
     }
   }
 
@@ -121,18 +121,9 @@ public final class ConvolutionalLayerParameterInitializer implements LayerParame
   private int[] computeOutputShape() {
     final int[] computedShape = new int[2];
     checkShape();
-    switch (inputShape.length) {
-    case 1:
-      computedShape[0] = (inputShape[0] - kernelHeight + 2 * paddingHeight) / strideHeight + 1;
-      computedShape[1] = 1;
-      return computedShape;
-    case 2:
-            computedShape[0] = (inputShape[0] - kernelHeight + 2 * paddingHeight) / strideHeight + 1;
-            computedShape[1] = (inputShape[1] - kernelWidth + 2 * paddingWidth) / strideWidth + 1;
-            return computedShape;
-    default:
-            throw new IllegalArgumentException("Unsupported input dimension: " + Integer.toString(inputShape.length));
-    }
+    computedShape[0] = (inputShape[0] - kernelHeight + 2 * paddingHeight) / strideHeight + 1;
+    computedShape[1] = (inputShape[1] - kernelWidth + 2 * paddingWidth) / strideWidth + 1;
+    return computedShape;
   }
 
   /**

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/layerparam/initializer/FullyConnectedLayerParameterInitializer.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/layerparam/initializer/FullyConnectedLayerParameterInitializer.java
@@ -29,8 +29,9 @@ import static edu.snu.dolphin.dnn.util.NeuralNetworkUtils.shapeFromString;
 /**
  * Parameter Initializer of fully connected layer.
  *
- * initializes the weight matrix with pseudo random normal distributed value with mean 0 and given standard deviation.
- * initializes the bias vector with the given value.
+ * This class initializes the weight matrix
+ * with pseudo random normal distributed value with mean 0 and given standard deviation.
+ * This class initializes the bias vector with the given value.
  */
 public final class FullyConnectedLayerParameterInitializer implements LayerParameterInitializer {
 

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/layers/ConvolutionalLayer.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/layers/ConvolutionalLayer.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (C) 2016 Seoul National University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.snu.dolphin.dnn.layers;
+
+import edu.snu.dolphin.dnn.blas.Matrix;
+import edu.snu.dolphin.dnn.blas.MatrixFactory;
+import edu.snu.dolphin.dnn.conf.LayerConfigurationParameters.*;
+import edu.snu.dolphin.dnn.layerparam.initializer.LayerParameterInitializer;
+import org.apache.reef.tang.annotations.Parameter;
+
+import javax.inject.Inject;
+
+  /**
+   * Convolutional layer.
+   *
+   * This layer is learnable having the updatable parameter (weight and bias).
+   * This layer works for only 1D and 2D inputs.
+   * In a forward pass,
+   * In a backward pass,
+   */
+public final class ConvolutionalLayer extends LayerBase {
+
+  private final int[] outputShape;
+  private final int paddingHeight;
+  private final int paddingWidth;
+  private final int strideHeight;
+  private final int strideWidth;
+  private final int kernelHeight;
+  private final int kernelWidth;
+
+  @Inject
+  private ConvolutionalLayer(@Parameter(LayerIndex.class) final int index,
+                             @Parameter(LayerInputShape.class) final String inputShape,
+                             @Parameter(StrideHeight.class) final int paddingHeight,
+                             @Parameter(StrideWidth.class) final int paddingWidth,
+                             @Parameter(StrideHeight.class) final int strideHeight,
+                             @Parameter(StrideWidth.class) final int strideWidth,
+                             @Parameter(KernelHeight.class) final int kernelHeight,
+                             @Parameter(KernelWidth.class) final int kernelWidth,
+                             final LayerParameterInitializer layerParameterInitializer) {
+    super(index, inputShape);
+    this.paddingHeight = paddingHeight;
+    this.paddingWidth = paddingWidth;
+    this.strideHeight = strideHeight;
+    this.strideWidth = strideWidth;
+    this.kernelHeight = kernelHeight;
+    this.kernelWidth = kernelWidth;
+    this.outputShape = layerParameterInitializer.getOutputShape();
+    setLayerParameter(layerParameterInitializer.generateInitialParameter());
+  }
+
+  @Override
+  public int[] getOutputShape() {
+    return outputShape;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public boolean isLearnable() {
+    return false;
+  }
+
+  @Override
+  public Matrix feedForward(final Matrix input) {
+    throw new RuntimeException();
+  }
+
+  /**
+   * Computes errors for this convolutional layer.
+   * @param input the input values for this layer.
+   * @param activation the output values.
+   * @param nextError the errors of the next layer - the one closer to the output layer.
+   * @return errors for this layer with the specified input value.
+   */
+  @Override
+  public Matrix backPropagate(final Matrix input, final Matrix activation, final Matrix nextError) {
+    throw new RuntimeException();
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public LayerParameter generateParameterGradient(final Matrix input, final Matrix error) {
+    return LayerParameter.newBuilder()
+        .setWeightParam(error.mmul(input.transpose()))
+        .setBiasParam(error.rowSums())
+        .build();
+  }
+}

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/layers/ConvolutionalLayer.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/layers/ConvolutionalLayer.java
@@ -16,7 +16,6 @@
 package edu.snu.dolphin.dnn.layers;
 
 import edu.snu.dolphin.dnn.blas.Matrix;
-import edu.snu.dolphin.dnn.blas.MatrixFactory;
 import edu.snu.dolphin.dnn.conf.LayerConfigurationParameters.*;
 import edu.snu.dolphin.dnn.layerparam.initializer.LayerParameterInitializer;
 import org.apache.reef.tang.annotations.Parameter;
@@ -27,9 +26,12 @@ import javax.inject.Inject;
    * Convolutional layer.
    *
    * This layer is learnable having the updatable parameter (weight and bias).
-   * This layer works for only 1D and 2D inputs.
+   * This layer works for only 2D inputs.
    * In a forward pass,
+   * computes the product between weight and the input within kernel range and produce activation matrix.
    * In a backward pass,
+   * error of each input pixel comes from
+   * the product between weight and errors of output pixels affected by the input pixel in feedforward step.
    */
 public final class ConvolutionalLayer extends LayerBase {
 
@@ -73,9 +75,14 @@ public final class ConvolutionalLayer extends LayerBase {
     return false;
   }
 
+  /**
+   * Computes output values for this convolutional layer.
+   * @param input input values for this layer.
+   * @return output values for this layer.
+   */
   @Override
   public Matrix feedForward(final Matrix input) {
-    throw new RuntimeException();
+    throw new RuntimeException("Not Implemented");
   }
 
   /**
@@ -87,7 +94,7 @@ public final class ConvolutionalLayer extends LayerBase {
    */
   @Override
   public Matrix backPropagate(final Matrix input, final Matrix activation, final Matrix nextError) {
-    throw new RuntimeException();
+    throw new RuntimeException("Not Implemented");
   }
 
   /** {@inheritDoc} */

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/layers/ConvolutionalLayer.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/layers/ConvolutionalLayer.java
@@ -22,17 +22,18 @@ import org.apache.reef.tang.annotations.Parameter;
 
 import javax.inject.Inject;
 
-  /**
-   * Convolutional layer.
-   *
-   * This layer is learnable having the updatable parameter (weight and bias).
-   * This layer works for only 2D inputs.
-   * In a forward pass,
-   * computes the product between weight and the input within kernel range and produce activation matrix.
-   * In a backward pass,
-   * error of each input pixel comes from
-   * the product between weight and errors of output pixels affected by the input pixel in feedforward step.
-   */
+/**
+ * Convolutional layer.
+ *
+ * This layer is learnable having the updatable parameter (weight and bias).
+ * This layer works for only 2D inputs.
+ * In a forward pass,
+ * feedForward function computes the product between weight and the input within kernel range
+ * and produce activation matrix.
+ * In a backward pass,
+ * the error of each input pixel comes from the product
+ * between weight and errors of output pixels affected by the input pixel in feedforward step.
+ */
 public final class ConvolutionalLayer extends LayerBase {
 
   private final int[] outputShape;
@@ -46,8 +47,8 @@ public final class ConvolutionalLayer extends LayerBase {
   @Inject
   private ConvolutionalLayer(@Parameter(LayerIndex.class) final int index,
                              @Parameter(LayerInputShape.class) final String inputShape,
-                             @Parameter(StrideHeight.class) final int paddingHeight,
-                             @Parameter(StrideWidth.class) final int paddingWidth,
+                             @Parameter(PaddingHeight.class) final int paddingHeight,
+                             @Parameter(PaddingWidth.class) final int paddingWidth,
                              @Parameter(StrideHeight.class) final int strideHeight,
                              @Parameter(StrideWidth.class) final int strideWidth,
                              @Parameter(KernelHeight.class) final int kernelHeight,
@@ -72,7 +73,7 @@ public final class ConvolutionalLayer extends LayerBase {
   /** {@inheritDoc} */
   @Override
   public boolean isLearnable() {
-    return false;
+    return true;
   }
 
   /**
@@ -100,9 +101,6 @@ public final class ConvolutionalLayer extends LayerBase {
   /** {@inheritDoc} */
   @Override
   public LayerParameter generateParameterGradient(final Matrix input, final Matrix error) {
-    return LayerParameter.newBuilder()
-        .setWeightParam(error.mmul(input.transpose()))
-        .setBiasParam(error.rowSums())
-        .build();
+    throw new RuntimeException("Not Implemented");
   }
 }

--- a/dolphin-dnn/src/main/proto/neural_network.proto
+++ b/dolphin-dnn/src/main/proto/neural_network.proto
@@ -24,23 +24,23 @@ message FullyConnectedLayerConfiguration {
 }
 
 message ConvolutionalLayerConfiguration {
-  optional uint32 padding_height = 1 [default = 0];
-  optional uint32 padding_width = 2 [default = 0];
-  optional uint32 stride_height = 3 [default = 1];
-  optional uint32 stride_width = 4 [default = 1];
-  required uint32 kernel_height = 5;
-  required uint32 kernel_width = 6;
+  required uint32 kernel_height = 1;
+  required uint32 kernel_width = 2;
+  optional uint32 padding_height = 3 [default = 0];
+  optional uint32 padding_width = 4 [default = 0];
+  optional uint32 stride_height = 5 [default = 1];
+  optional uint32 stride_width = 6 [default = 1];
   required float init_bias = 7;
   required float init_weight = 8;
   optional uint32 random_seed = 9;
 }
 
 message PoolingLayerConfiguration {
-  optional string pooling_type = 1 [default = "MAX"];
-  optional uint32 stride_height = 2 [default = 1];
-  optional uint32 stride_width = 3 [default = 1];
-  required uint32 kernel_height = 4;
-  required uint32 kernel_width = 5;
+  required uint32 kernel_height = 1;
+  required uint32 kernel_width = 2;
+  optional string pooling_type = 3 [default = "MAX"];
+  optional uint32 stride_height = 4 [default = 1];
+  optional uint32 stride_width = 5 [default = 1];
 }
 
 message ActivationLayerConfiguration {

--- a/dolphin-dnn/src/main/proto/neural_network.proto
+++ b/dolphin-dnn/src/main/proto/neural_network.proto
@@ -23,6 +23,18 @@ message FullyConnectedLayerConfiguration {
   required uint32 num_output = 4;
 }
 
+message ConvolutionalLayerConfiguration {
+  optional uint32 padding_height = 1 [default = 0];
+  optional uint32 padding_width = 2 [default = 0];
+  optional uint32 stride_height = 3 [default = 1];
+  optional uint32 stride_width = 4 [default = 1];
+  required uint32 kernel_height = 5;
+  required uint32 kernel_width = 6;
+  required float init_bias = 7;
+  required float init_weight = 8;
+  optional uint32 random_seed = 9;
+}
+
 message PoolingLayerConfiguration {
   optional string pooling_type = 1 [default = "MAX"];
   optional uint32 stride_height = 2 [default = 1];
@@ -46,6 +58,7 @@ message LayerConfiguration {
   optional ActivationLayerConfiguration activation_param = 3;
   optional ActivationWithLossLayerConfiguration activation_with_loss_param = 4;
   optional PoolingLayerConfiguration pooling_param = 5;
+  optional ConvolutionalLayerConfiguration convolutional_param = 6;
 }
 
 message ParameterProviderConfiguration {


### PR DESCRIPTION
This PR introduce new layer class `ConvolutionalLayer`. This layer extends `LayerBase`, and include implementation for `isLearnable()`, `getOutputShape()` and `generateParameterGradient()`. This PR include some modifications in `LayerParameter`, which enable `ConvolutionalLayer` to make use of its new parameters, `paddingHeight` and `paddingWidth`. Also, `ConvolutionalLayerConfigurationBuilder` class and `ConvolutionalLayerParameterInitializer` class are added for configuration of convolutional layer. `neural_network.proto` is modified to take inputs for convolutional layer. Concrete implementation for `feedForward()` and `backPropagate()` will be made in later PRs.