### PR TITLE
Implement padding in pooling layer

### DIFF
--- a/dolphin-dnn/README.md
+++ b/dolphin-dnn/README.md
@@ -83,6 +83,8 @@ parameter_provider {
 * Layer type: `Pooling`
 * Parameters (`PoolingLayerConfiguration pooling_param`)
     * `pooling_type`[default="MAX"]: the type of pooling for this layer. Available types are MAX and AVERAGE.
+    * `padding_height`[default=0]: the space on the border of the input volume.
+    * `padding_width`[default=0]: the space on the border of the input volume.
     * `stride_height`[default=1]: the interval at which pooling layers apply filters to inputs.
     * `stride_width`[default=1]: the interval at which pooling layers apply filters to inputs.
     * `kernel_height`: the height of kernel for this layer.

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/conf/PoolingLayerConfigurationBuilder.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/conf/PoolingLayerConfigurationBuilder.java
@@ -37,6 +37,8 @@ public final class PoolingLayerConfigurationBuilder implements Builder<Configura
   }
 
   private String poolingType = "MAX";
+  private int paddingHeight = 0;
+  private int paddingWidth = 0;
   private int strideHeight = 1;
   private int strideWidth = 1;
   private int kernelHeight;
@@ -44,6 +46,16 @@ public final class PoolingLayerConfigurationBuilder implements Builder<Configura
 
   public synchronized PoolingLayerConfigurationBuilder setPoolingType(final String poolingType) {
     this.poolingType = poolingType;
+    return this;
+  }
+
+  public synchronized PoolingLayerConfigurationBuilder setPaddingHeight(final int paddingHeight) {
+    this.paddingHeight = paddingHeight;
+    return this;
+  }
+
+  public synchronized PoolingLayerConfigurationBuilder setPaddingWidth(final int paddingWidth) {
+    this.paddingWidth = paddingWidth;
     return this;
   }
 
@@ -70,6 +82,8 @@ public final class PoolingLayerConfigurationBuilder implements Builder<Configura
   public synchronized PoolingLayerConfigurationBuilder fromProtoConfiguration(
       final NeuralNetworkProtos.LayerConfiguration protoConf) {
     poolingType = protoConf.getPoolingParam().getPoolingType();
+    paddingHeight = protoConf.getPoolingParam().getPaddingHeight();
+    paddingWidth = protoConf.getPoolingParam().getPaddingWidth();
     strideHeight = protoConf.getPoolingParam().getStrideHeight();
     strideWidth = protoConf.getPoolingParam().getStrideWidth();
     kernelHeight = protoConf.getPoolingParam().getKernelHeight();
@@ -81,6 +95,8 @@ public final class PoolingLayerConfigurationBuilder implements Builder<Configura
   public synchronized Configuration build() {
     return Tang.Factory.getTang().newConfigurationBuilder()
         .bindNamedParameter(LayerConfigurationParameters.PoolingType.class, poolingType)
+        .bindNamedParameter(LayerConfigurationParameters.PaddingHeight.class, String.valueOf(paddingHeight))
+        .bindNamedParameter(LayerConfigurationParameters.PaddingWidth.class, String.valueOf(paddingWidth))
         .bindNamedParameter(LayerConfigurationParameters.StrideHeight.class, String.valueOf(strideHeight))
         .bindNamedParameter(LayerConfigurationParameters.StrideWidth.class, String.valueOf(strideWidth))
         .bindNamedParameter(LayerConfigurationParameters.KernelHeight.class, String.valueOf(kernelHeight))

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/layerparam/initializer/PoolingLayerParameterInitializer.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/layerparam/initializer/PoolingLayerParameterInitializer.java
@@ -105,13 +105,15 @@ public final class PoolingLayerParameterInitializer implements LayerParameterIni
     if ((computedShape[0] - 1) * strideHeight >= inputShape[0] + paddingHeight) {
       --computedShape[0];
       if ((computedShape[0] - 1) * strideHeight >= inputShape[0] + paddingHeight) {
-        throw new IllegalArgumentException("The second last as well as the last pooling starts out of the image.");
+        throw new IllegalArgumentException("The second last pooling still starts outside of the image " +
+            "even though we clip the last.");
       }
     }
     if ((computedShape[1] - 1) * strideWidth >= inputShape[1] + paddingWidth) {
       --computedShape[1];
       if ((computedShape[1] - 1) * strideWidth >= inputShape[1] + paddingWidth) {
-        throw new IllegalArgumentException("The second last as well as the last pooling starts out of the image.");
+        throw new IllegalArgumentException("The second last pooling still starts outside of the image " +
+            "even though we clip the last.");
       }
     }
     return computedShape;

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/layerparam/initializer/PoolingLayerParameterInitializer.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/layerparam/initializer/PoolingLayerParameterInitializer.java
@@ -44,15 +44,15 @@ public final class PoolingLayerParameterInitializer implements LayerParameterIni
 
   @Inject
   private PoolingLayerParameterInitializer(
-      final MatrixFactory matrixFactory,
-      @Parameter(LayerConfigurationParameters.LayerIndex.class) final int index,
-      @Parameter(LayerConfigurationParameters.LayerInputShape.class) final String inputShape,
-      @Parameter(LayerConfigurationParameters.PaddingHeight.class) final int paddingHeight,
-      @Parameter(LayerConfigurationParameters.PaddingWidth.class) final int paddingWidth,
-      @Parameter(LayerConfigurationParameters.StrideHeight.class) final int strideHeight,
-      @Parameter(LayerConfigurationParameters.StrideWidth.class) final int strideWidth,
-      @Parameter(LayerConfigurationParameters.KernelHeight.class) final int kernelHeight,
-      @Parameter(LayerConfigurationParameters.KernelWidth.class) final int kernelWidth) {
+          final MatrixFactory matrixFactory,
+          @Parameter(LayerConfigurationParameters.LayerIndex.class) final int index,
+          @Parameter(LayerConfigurationParameters.LayerInputShape.class) final String inputShape,
+          @Parameter(LayerConfigurationParameters.PaddingHeight.class) final int paddingHeight,
+          @Parameter(LayerConfigurationParameters.PaddingWidth.class) final int paddingWidth,
+          @Parameter(LayerConfigurationParameters.StrideHeight.class) final int strideHeight,
+          @Parameter(LayerConfigurationParameters.StrideWidth.class) final int strideWidth,
+          @Parameter(LayerConfigurationParameters.KernelHeight.class) final int kernelHeight,
+          @Parameter(LayerConfigurationParameters.KernelWidth.class) final int kernelWidth) {
     this.index = index;
     this.inputShape = shapeFromString(inputShape);
     this.paddingHeight = paddingHeight;
@@ -83,8 +83,8 @@ public final class PoolingLayerParameterInitializer implements LayerParameterIni
    * This function computes output shape.
    * input shape: row * col
    * output shape: row' * col'
-   * row' = ceil((row − kernelHeight + 2 * paddingHeight) / stride) + 1
-   * col' = ceil((col − kernelWidth - 2 * paddingHeight) / stride) + 1
+   * row' = ceil((row − kernelHeight + 2 * paddingHeight) / strideHeight) + 1
+   * col' = ceil((col − kernelWidth - 2 * paddingWidth) / strideWidth) + 1
    * @return shape of output
    */
   private int[] computeOutputShape() {
@@ -104,9 +104,15 @@ public final class PoolingLayerParameterInitializer implements LayerParameterIni
     //If the last pooling starts outside the input image, clip that output.
     if ((computedShape[0] - 1) * strideHeight >= inputShape[0] + paddingHeight) {
       --computedShape[0];
+      if ((computedShape[0] - 1) * strideHeight >= inputShape[0] + paddingHeight) {
+        throw new IllegalArgumentException("Stride height is too large for the input image.");
+      }
     }
     if ((computedShape[1] - 1) * strideWidth >= inputShape[1] + paddingWidth) {
       --computedShape[1];
+      if ((computedShape[1] - 1) * strideWidth >= inputShape[1] + paddingWidth) {
+        throw new IllegalArgumentException("Stride width is too large for the input image.");
+      }
     }
     return computedShape;
   }

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/layerparam/initializer/PoolingLayerParameterInitializer.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/layerparam/initializer/PoolingLayerParameterInitializer.java
@@ -44,15 +44,15 @@ public final class PoolingLayerParameterInitializer implements LayerParameterIni
 
   @Inject
   private PoolingLayerParameterInitializer(
-          final MatrixFactory matrixFactory,
-          @Parameter(LayerConfigurationParameters.LayerIndex.class) final int index,
-          @Parameter(LayerConfigurationParameters.LayerInputShape.class) final String inputShape,
-          @Parameter(LayerConfigurationParameters.PaddingHeight.class) final int paddingHeight,
-          @Parameter(LayerConfigurationParameters.PaddingWidth.class) final int paddingWidth,
-          @Parameter(LayerConfigurationParameters.StrideHeight.class) final int strideHeight,
-          @Parameter(LayerConfigurationParameters.StrideWidth.class) final int strideWidth,
-          @Parameter(LayerConfigurationParameters.KernelHeight.class) final int kernelHeight,
-          @Parameter(LayerConfigurationParameters.KernelWidth.class) final int kernelWidth) {
+      final MatrixFactory matrixFactory,
+      @Parameter(LayerConfigurationParameters.LayerIndex.class) final int index,
+      @Parameter(LayerConfigurationParameters.LayerInputShape.class) final String inputShape,
+      @Parameter(LayerConfigurationParameters.PaddingHeight.class) final int paddingHeight,
+      @Parameter(LayerConfigurationParameters.PaddingWidth.class) final int paddingWidth,
+      @Parameter(LayerConfigurationParameters.StrideHeight.class) final int strideHeight,
+      @Parameter(LayerConfigurationParameters.StrideWidth.class) final int strideWidth,
+      @Parameter(LayerConfigurationParameters.KernelHeight.class) final int kernelHeight,
+      @Parameter(LayerConfigurationParameters.KernelWidth.class) final int kernelWidth) {
     this.index = index;
     this.inputShape = shapeFromString(inputShape);
     this.paddingHeight = paddingHeight;
@@ -84,7 +84,7 @@ public final class PoolingLayerParameterInitializer implements LayerParameterIni
    * input shape: row * col
    * output shape: row' * col'
    * row' = ceil((row − kernelHeight + 2 * paddingHeight) / strideHeight) + 1
-   * col' = ceil((col − kernelWidth - 2 * paddingWidth) / strideWidth) + 1
+   * col' = ceil((col − kernelWidth + 2 * paddingWidth) / strideWidth) + 1
    * @return shape of output
    */
   private int[] computeOutputShape() {
@@ -105,13 +105,13 @@ public final class PoolingLayerParameterInitializer implements LayerParameterIni
     if ((computedShape[0] - 1) * strideHeight >= inputShape[0] + paddingHeight) {
       --computedShape[0];
       if ((computedShape[0] - 1) * strideHeight >= inputShape[0] + paddingHeight) {
-        throw new IllegalArgumentException("Stride height is too large for the input image.");
+        throw new IllegalArgumentException("The second last as well as the last pooling starts out of the image.");
       }
     }
     if ((computedShape[1] - 1) * strideWidth >= inputShape[1] + paddingWidth) {
       --computedShape[1];
       if ((computedShape[1] - 1) * strideWidth >= inputShape[1] + paddingWidth) {
-        throw new IllegalArgumentException("Stride width is too large for the input image.");
+        throw new IllegalArgumentException("The second last as well as the last pooling starts out of the image.");
       }
     }
     return computedShape;

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/layerparam/initializer/PoolingLayerParameterInitializer.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/layerparam/initializer/PoolingLayerParameterInitializer.java
@@ -83,8 +83,8 @@ public final class PoolingLayerParameterInitializer implements LayerParameterIni
    * This function computes output shape.
    * input shape: row * col
    * output shape: row' * col'
-   * row' = (row − kernelHeight + 2 * paddingHeight) / stride + 1
-   * col' = (col − kernelWidth - 2 * paddingHeight) / stride + 1
+   * row' = ceil((row − kernelHeight + 2 * paddingHeight) / stride) + 1
+   * col' = ceil((col − kernelWidth - 2 * paddingHeight) / stride) + 1
    * @return shape of output
    */
   private int[] computeOutputShape() {
@@ -100,6 +100,7 @@ public final class PoolingLayerParameterInitializer implements LayerParameterIni
     }
     computedShape[0] = (int) Math.ceil((float) (inputShape[0] - kernelHeight + 2 * paddingHeight) / strideHeight) + 1;
     computedShape[1] = (int) Math.ceil((float) (inputShape[1] - kernelWidth + 2 * paddingWidth) / strideWidth) + 1;
+    //Pooling should start inside the input images.
     //If the last pooling starts outside the input image, clip that output.
     if ((computedShape[0] - 1) * strideHeight >= inputShape[0] + paddingHeight) {
       --computedShape[0];

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/layerparam/initializer/PoolingLayerParameterInitializer.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/layerparam/initializer/PoolingLayerParameterInitializer.java
@@ -34,6 +34,8 @@ public final class PoolingLayerParameterInitializer implements LayerParameterIni
   private final int index;
   private final int[] inputShape;
   private final int[] outputShape;
+  private final int paddingHeight;
+  private final int paddingWidth;
   private final int strideHeight;
   private final int strideWidth;
   private final int kernelHeight;
@@ -45,12 +47,16 @@ public final class PoolingLayerParameterInitializer implements LayerParameterIni
       final MatrixFactory matrixFactory,
       @Parameter(LayerConfigurationParameters.LayerIndex.class) final int index,
       @Parameter(LayerConfigurationParameters.LayerInputShape.class) final String inputShape,
+      @Parameter(LayerConfigurationParameters.PaddingHeight.class) final int paddingHeight,
+      @Parameter(LayerConfigurationParameters.PaddingWidth.class) final int paddingWidth,
       @Parameter(LayerConfigurationParameters.StrideHeight.class) final int strideHeight,
       @Parameter(LayerConfigurationParameters.StrideWidth.class) final int strideWidth,
       @Parameter(LayerConfigurationParameters.KernelHeight.class) final int kernelHeight,
       @Parameter(LayerConfigurationParameters.KernelWidth.class) final int kernelWidth) {
     this.index = index;
     this.inputShape = shapeFromString(inputShape);
+    this.paddingHeight = paddingHeight;
+    this.paddingWidth = paddingWidth;
     this.strideHeight = strideHeight;
     this.strideWidth = strideWidth;
     this.kernelHeight = kernelHeight;
@@ -77,8 +83,8 @@ public final class PoolingLayerParameterInitializer implements LayerParameterIni
    * This function computes output shape.
    * input shape: row * col
    * output shape: row' * col'
-   * row' = (row − kernelHeight) / stride + 1
-   * col' = (col − kernelWidth) / stride + 1
+   * row' = (row − kernelHeight + 2 * paddingHeight) / stride + 1
+   * col' = (col − kernelWidth - 2 * paddingHeight) / stride + 1
    * @return shape of output
    */
   private int[] computeOutputShape() {
@@ -86,8 +92,21 @@ public final class PoolingLayerParameterInitializer implements LayerParameterIni
     if (inputShape.length != 2) {
       throw new IllegalArgumentException("Unsupported input dimensions: " + inputShape.length);
     }
-    computedShape[0] = (int) Math.ceil((float) (inputShape[0] - kernelHeight) / strideHeight) + 1;
-    computedShape[1] = (int) Math.ceil((float) (inputShape[1] - kernelWidth) / strideWidth) + 1;
+    if (paddingHeight >= kernelHeight) {
+      throw new IllegalArgumentException("Padding height should be less than kernel height.");
+    }
+    if (paddingWidth >= kernelWidth) {
+      throw new IllegalArgumentException("Padding width should be less than kernel width.");
+    }
+    computedShape[0] = (int) Math.ceil((float) (inputShape[0] - kernelHeight + 2 * paddingHeight) / strideHeight) + 1;
+    computedShape[1] = (int) Math.ceil((float) (inputShape[1] - kernelWidth + 2 * paddingWidth) / strideWidth) + 1;
+    //If the last pooling starts outside the input image, clip that output.
+    if ((computedShape[0] - 1) * strideHeight >= inputShape[0] + paddingHeight) {
+      --computedShape[0];
+    }
+    if ((computedShape[1] - 1) * strideWidth >= inputShape[1] + paddingWidth) {
+      --computedShape[1];
+    }
     return computedShape;
   }
 

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/layers/PoolingLayer.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/layers/PoolingLayer.java
@@ -44,6 +44,8 @@ public final class PoolingLayer extends LayerBase {
   }
   private final int[] outputShape;
   private final PoolType poolingType;
+  private final int paddingHeight;
+  private final int paddingWidth;
   private final int strideHeight;
   private final int strideWidth;
   private final int kernelHeight;
@@ -55,6 +57,8 @@ public final class PoolingLayer extends LayerBase {
   private PoolingLayer(@Parameter(LayerIndex.class) final int index,
                        @Parameter(LayerInputShape.class) final String inputShape,
                        @Parameter(PoolingType.class) final String poolingType,
+                       @Parameter(PaddingHeight.class) final int paddingHeight,
+                       @Parameter(PaddingWidth.class) final int paddingWidth,
                        @Parameter(StrideHeight.class) final int strideHeight,
                        @Parameter(StrideWidth.class) final int strideWidth,
                        @Parameter(KernelHeight.class) final int kernelHeight,
@@ -62,6 +66,8 @@ public final class PoolingLayer extends LayerBase {
                        final LayerParameterInitializer layerParameterInitializer,
                        final MatrixFactory matrixFactory) {
     super(index, inputShape);
+    this.paddingHeight = paddingHeight;
+    this.paddingWidth = paddingWidth;
     this.strideHeight = strideHeight;
     this.strideWidth = strideWidth;
     this.kernelHeight = kernelHeight;
@@ -96,10 +102,12 @@ public final class PoolingLayer extends LayerBase {
       for (int oh = 0; oh < outputShape[0]; ++oh) {
         for (int ow = 0; ow < outputShape[1]; ++ow) {
           //Find the maximum value within kernel range and put it in the output matrix.
-          final int hstart = strideHeight * oh;
-          final int wstart = strideWidth * ow;
+          int hstart = strideHeight * oh - paddingHeight;
+          int wstart = strideWidth * ow - paddingWidth;
           final int hend = Math.min(kernelHeight + hstart, inputShape[0]);
           final int wend = Math.min(kernelWidth + wstart, inputShape[1]);
+          hstart = Math.max(hstart, 0);
+          wstart = Math.max(wstart, 0);
           int maxIndex = hstart * inputShape[1] + wstart;
           float max = input.get(maxIndex, n);
           for (int kh = hstart; kh < hend; ++kh) {
@@ -134,11 +142,15 @@ public final class PoolingLayer extends LayerBase {
       for (int oh = 0; oh < outputShape[0]; ++oh) {
         for (int ow = 0; ow < outputShape[1]; ++ow) {
           //Compute sum of values within kernel range and put the average value in the output matrix.
-          final int hstart = strideHeight * oh;
-          final int wstart = strideWidth * ow;
-          final int hend = Math.min(kernelHeight + hstart, inputShape[0]);
-          final int wend = Math.min(kernelWidth + wstart, inputShape[1]);
+          int hstart = strideHeight * oh - paddingHeight;
+          int wstart = strideWidth * ow - paddingWidth;
+          int hend = Math.min(kernelHeight + hstart, inputShape[0] + paddingHeight);
+          int wend = Math.min(kernelWidth + wstart, inputShape[1] + paddingWidth);
           final int kernelSize = (hend - hstart) * (wend - wstart);
+          hstart = Math.max(hstart, 0);
+          wstart = Math.max(wstart, 0);
+          hend = Math.min(hend, inputShape[0]);
+          wend = Math.min(wend, inputShape[1]);
           float sum = 0;
           for (int kh = hstart; kh < hend; ++kh) {
             for (int kw = wstart; kw < wend; ++kw) {
@@ -204,11 +216,15 @@ public final class PoolingLayer extends LayerBase {
     for (int n = 0; n < input.getColumns(); ++n) {
       for (int oh = 0; oh < outputShape[0]; ++oh) {
         for (int ow = 0; ow < outputShape[1]; ++ow) {
-          final int hstart = strideHeight * oh;
-          final int wstart = strideWidth * ow;
-          final int hend = Math.min(kernelHeight + hstart, inputShape[0]);
-          final int wend = Math.min(kernelWidth + wstart, inputShape[1]);
+          int hstart = strideHeight * oh - paddingHeight;
+          int wstart = strideWidth * ow - paddingWidth;
+          int hend = Math.min(kernelHeight + hstart, inputShape[0] + paddingHeight);
+          int wend = Math.min(kernelWidth + wstart, inputShape[1] + paddingWidth);
           final int kernelSize = (hend - hstart) * (wend - wstart);
+          hstart = Math.max(hstart, 0);
+          wstart = Math.max(wstart, 0);
+          hend = Math.min(hend, inputShape[0]);
+          wend = Math.min(wend, inputShape[1]);
           final int outputIndex = oh * outputShape[1] + ow;
 
           for (int kh = hstart; kh < hend; ++kh) {

--- a/dolphin-dnn/src/main/proto/neural_network.proto
+++ b/dolphin-dnn/src/main/proto/neural_network.proto
@@ -36,13 +36,13 @@ message ConvolutionalLayerConfiguration {
 }
 
 message PoolingLayerConfiguration {
-  optional string pooling_type = 1 [default = "MAX"];
-  optional uint32 padding_height = 2 [default = 0];
-  optional uint32 padding_width = 3 [default = 0];
-  optional uint32 stride_height = 4 [default = 1];
-  optional uint32 stride_width = 5 [default = 1];
-  required uint32 kernel_height = 6;
-  required uint32 kernel_width = 7;
+  required uint32 kernel_height = 1;
+  required uint32 kernel_width = 2;
+  optional uint32 padding_height = 3 [default = 0];
+  optional uint32 padding_width = 4 [default = 0];
+  optional uint32 stride_height = 5 [default = 1];
+  optional uint32 stride_width = 6 [default = 1];
+  optional string pooling_type = 7 [default = "MAX"];
 }
 
 message ActivationLayerConfiguration {

--- a/dolphin-dnn/src/main/proto/neural_network.proto
+++ b/dolphin-dnn/src/main/proto/neural_network.proto
@@ -36,11 +36,13 @@ message ConvolutionalLayerConfiguration {
 }
 
 message PoolingLayerConfiguration {
-  required uint32 kernel_height = 1;
-  required uint32 kernel_width = 2;
-  optional string pooling_type = 3 [default = "MAX"];
+  optional string pooling_type = 1 [default = "MAX"];
+  optional uint32 padding_height = 2 [default = 0];
+  optional uint32 padding_width = 3 [default = 0];
   optional uint32 stride_height = 4 [default = 1];
   optional uint32 stride_width = 5 [default = 1];
+  required uint32 kernel_height = 6;
+  required uint32 kernel_width = 7;
 }
 
 message ActivationLayerConfiguration {


### PR DESCRIPTION
This PR supports customizing padding in pooling layers. Now computations in pooling layers will be carried out with user-defined padding height and width. Padding parameters are added in classes related to pooling layer configuration files, computation process is a little modified to work well with padding and pooling layer with padding tests are added.