### PR TITLE
support 3D input data

### DIFF
--- a/dolphin-dnn/README.md
+++ b/dolphin-dnn/README.md
@@ -102,6 +102,7 @@ parameter_provider {
     * `init_weight`: the standard deviation that is used to initialize the weights in this layer from a Gaussian distribution with mean 0.
     * `init_bias`: constant value with which the biases of this layer are initialized.
     * `random_seed`: the seed for generating random initial parameters.
+    * `num_output`[default = 1]: the number of outputs for this layer.
 
 ##### Activation Layer
 * Layer type: `Activation`

--- a/dolphin-dnn/README.md
+++ b/dolphin-dnn/README.md
@@ -102,7 +102,7 @@ parameter_provider {
     * `init_weight`: the standard deviation that is used to initialize the weights in this layer from a Gaussian distribution with mean 0.
     * `init_bias`: constant value with which the biases of this layer are initialized.
     * `random_seed`: the seed for generating random initial parameters.
-    * `num_output`[default = 1]: the number of outputs for this layer.
+    * `num_output`: the number of outputs for this layer.
 
 ##### Activation Layer
 * Layer type: `Activation`

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/conf/ConvolutionalLayerConfigurationBuilder.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/conf/ConvolutionalLayerConfigurationBuilder.java
@@ -46,7 +46,7 @@ public final class ConvolutionalLayerConfigurationBuilder implements Builder<Con
   private long randomSeed = System.currentTimeMillis();
   private float initWeight;
   private float initBias;
-  private int numOutput = 1;
+  private int numOutput;
 
   public synchronized ConvolutionalLayerConfigurationBuilder setPaddingHeight(final int paddingHeight) {
     this.paddingHeight = paddingHeight;

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/conf/ConvolutionalLayerConfigurationBuilder.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/conf/ConvolutionalLayerConfigurationBuilder.java
@@ -46,6 +46,7 @@ public final class ConvolutionalLayerConfigurationBuilder implements Builder<Con
   private long randomSeed = System.currentTimeMillis();
   private float initWeight;
   private float initBias;
+  private int numOutput = 1;
 
   public synchronized ConvolutionalLayerConfigurationBuilder setPaddingHeight(final int paddingHeight) {
     this.paddingHeight = paddingHeight;
@@ -92,6 +93,11 @@ public final class ConvolutionalLayerConfigurationBuilder implements Builder<Con
     return this;
   }
 
+  public synchronized ConvolutionalLayerConfigurationBuilder setNumOutput(final int numOutput) {
+    this.numOutput = numOutput;
+    return this;
+  }
+
 
   public synchronized ConvolutionalLayerConfigurationBuilder fromProtoConfiguration(
       final NeuralNetworkProtos.LayerConfiguration protoConf) {
@@ -106,6 +112,7 @@ public final class ConvolutionalLayerConfigurationBuilder implements Builder<Con
     }
     initWeight = protoConf.getConvolutionalParam().getInitWeight();
     initBias = protoConf.getConvolutionalParam().getInitBias();
+    numOutput = protoConf.getConvolutionalParam().getNumOutput();
     return this;
   }
 
@@ -121,6 +128,7 @@ public final class ConvolutionalLayerConfigurationBuilder implements Builder<Con
         .bindNamedParameter(LayerConfigurationParameters.RandomSeed.class, String.valueOf(randomSeed))
         .bindNamedParameter(LayerConfigurationParameters.InitialWeight.class, String.valueOf(initWeight))
         .bindNamedParameter(LayerConfigurationParameters.InitialBias.class, String.valueOf(initBias))
+        .bindNamedParameter(LayerConfigurationParameters.NumberOfOutput.class, String.valueOf(numOutput))
         .bindImplementation(LayerBase.class, ConvolutionalLayer.class)
         .bindImplementation(LayerParameterInitializer.class, ConvolutionalLayerParameterInitializer.class)
         .build();

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/layerparam/initializer/PoolingLayerParameterInitializer.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/layerparam/initializer/PoolingLayerParameterInitializer.java
@@ -88,8 +88,8 @@ public final class PoolingLayerParameterInitializer implements LayerParameterIni
    * @return shape of output
    */
   private int[] computeOutputShape() {
-    final int[] computedShape = new int[2];
-    if (inputShape.length != 2) {
+    final int[] computedShape = new int[3];
+    if (inputShape.length != 2 && inputShape.length != 3) {
       throw new IllegalArgumentException("Unsupported input dimensions: " + inputShape.length);
     }
     if (paddingHeight >= kernelHeight) {
@@ -115,6 +115,11 @@ public final class PoolingLayerParameterInitializer implements LayerParameterIni
         throw new IllegalArgumentException("The second last pooling still starts outside of the image " +
             "even though we clip the last.");
       }
+    }
+    if (inputShape.length == 3) {
+      computedShape[2] = inputShape[2];
+    } else {
+      computedShape[2] = 1;
     }
     return computedShape;
   }

--- a/dolphin-dnn/src/main/proto/neural_network.proto
+++ b/dolphin-dnn/src/main/proto/neural_network.proto
@@ -33,7 +33,7 @@ message ConvolutionalLayerConfiguration {
   required float init_bias = 7;
   required float init_weight = 8;
   optional uint32 random_seed = 9;
-  optional uint32 num_output = 10 [default = 1];
+  required uint32 num_output = 10;
 }
 
 message PoolingLayerConfiguration {

--- a/dolphin-dnn/src/main/proto/neural_network.proto
+++ b/dolphin-dnn/src/main/proto/neural_network.proto
@@ -33,6 +33,7 @@ message ConvolutionalLayerConfiguration {
   required float init_bias = 7;
   required float init_weight = 8;
   optional uint32 random_seed = 9;
+  optional uint32 num_output = 10 [default = 1];
 }
 
 message PoolingLayerConfiguration {

--- a/dolphin-dnn/src/test/java/edu/snu/dolphin/dnn/layers/ConvolutionalLayerTest.java
+++ b/dolphin-dnn/src/test/java/edu/snu/dolphin/dnn/layers/ConvolutionalLayerTest.java
@@ -122,31 +122,58 @@ public class ConvolutionalLayerTest {
       {0.165702f, 0.133655f},
       {-0.124812f, 0.0905167f},
       {-0.153994f, -0.0412462f}});
-
+  private final Matrix input3D = matrixFactory.create(new float[][]{
+      {0, 10, 10, 2, 0, 5,
+       1, 5, 0, 1, 10, 1}}).transpose();
+  private final Matrix expectedConvolutional3DActivation = matrixFactory.create(new float[][]{
+      {0.462375f, -1.040396f, -1.410072f, -1.575518f,
+       -0.703437f, -2.622436f, -6.148920f, 1.164392f}}).transpose();
+  private final Matrix nextError3D = matrixFactory.create(new float[][]{
+      {0, 0.1f, 0.2f, 0.1f,
+       0.4f, 0.1f, 0, 0.2f}}).transpose();
+  private final Matrix expectedConvolutional3DError = matrixFactory.create(new float[][]{
+      {-0.000347f, -0.047422f, -0.017259f, -0.062726f, 0.017144f, 0.083920f,
+       -0.041767f, -0.036403f, -0.017025f, -0.138155f, -0.002363f, -0.116153f}}).transpose();
   private final LayerParameter expectedConvolutionalLayerParams =
       LayerParameter.newBuilder()
       .setWeightParam(matrixFactory.create(new float[]
-          {15.8f, 12.29999f, 13.9f, 9.8f}).transpose())
+          {15.8f, 12.29999f, 13.9f, 9.8f}))
       .setBiasParam(matrixFactory.create(new float[]
-          {0.1f, 0.6f, 1, 0.5f}).transpose())
+          {0.1f, 0.6f, 1, 0.5f}))
       .build();
 
   private final LayerParameter expectedConvolutionalLayerWithPaddingParams =
       LayerParameter.newBuilder()
       .setWeightParam(matrixFactory.create(new float[]
-          {58.7f, 41.699997f, 58.6f, 52.300003f}).transpose())
+          {58.7f, 41.699997f, 58.6f, 52.300003f}))
       .setBiasParam(matrixFactory.create(new float[]
-          {0.2f, 0.5f, 1.6f, 0.9f, 0.2f, 0.3f, 1.7f, 1.5f, 1.4f, 0.6f, 0.1f, 0.4f, 0.7f, 0.1f, 0.9f, 0.8f}).transpose())
+          {0.2f, 0.5f, 1.6f, 0.9f, 0.2f, 0.3f, 1.7f, 1.5f, 1.4f, 0.6f, 0.1f, 0.4f, 0.7f, 0.1f, 0.9f, 0.8f}))
+      .build();
+
+  private final LayerParameter expectedConvolutional3DLayerParams =
+      LayerParameter.newBuilder()
+      .setWeightParam(matrixFactory.create(new float[][]{
+          {3, 3, 0.7f, 1, 1.1f, 0.5f, 2.2f, 1.2f},
+          {2, 1, 1.2f, 0.8f, 0.1f, 0.9f, 0.3f, 1.4f}}).transpose())
+      .setBiasParam(matrixFactory.create(new float[]
+          {0, 0.1f, 0.2f, 0.1f, 0.4f, 0.1f, 0, 0.2f}))
       .build();
 
   private LayerBase convolutionalLayer;
   private LayerBase convolutionalWithPaddingLayer;
+  private LayerBase convolutional3DLayer;
 
   @Before
   public void setup() throws InjectionException {
     final Configuration layerConf = Tang.Factory.getTang().newConfigurationBuilder()
         .bindNamedParameter(LayerIndex.class, String.valueOf(0))
         .bindNamedParameter(LayerInputShape.class, "3,3")
+        .bindImplementation(MatrixFactory.class, MatrixJBLASFactory.class)
+        .build();
+
+    final Configuration layerConf3D = Tang.Factory.getTang().newConfigurationBuilder()
+        .bindNamedParameter(LayerIndex.class, String.valueOf(0))
+        .bindNamedParameter(LayerInputShape.class, "2,2,3")
         .bindImplementation(MatrixFactory.class, MatrixJBLASFactory.class)
         .build();
 
@@ -172,12 +199,28 @@ public class ConvolutionalLayerTest {
         .setStrideHeight(1)
         .setStrideWidth(1);
 
+    final ConvolutionalLayerConfigurationBuilder builder3D = ConvolutionalLayerConfigurationBuilder
+        .newConfigurationBuilder()
+        .setInitWeight(0.2f)
+        .setInitBias(0)
+        .setRandomSeed(10)
+        .setKernelHeight(2)
+        .setKernelWidth(2)
+        .setStrideHeight(1)
+        .setStrideWidth(1)
+        .setPaddingWidth(1)
+        .setNumOutput(2);
+
     this.convolutionalLayer =
         Tang.Factory.getTang().newInjector(layerConf, builder.build())
         .getInstance(LayerBase.class);
 
     this.convolutionalWithPaddingLayer =
         Tang.Factory.getTang().newInjector(layerConf, builderWithPadding.build())
+        .getInstance(LayerBase.class);
+
+    this.convolutional3DLayer =
+        Tang.Factory.getTang().newInjector(layerConf3D, builder3D.build())
         .getInstance(LayerBase.class);
   }
 
@@ -217,5 +260,24 @@ public class ConvolutionalLayerTest {
     final LayerParameter convolutionalLayerParams =
         convolutionalWithPaddingLayer.generateParameterGradient(input, nextErrorWithPadding);
     assertTrue(compare(expectedConvolutionalLayerWithPaddingParams, convolutionalLayerParams, TOLERANCE));
+  }
+
+  @Test
+  public void testConvolutional3DActivation() {
+    final Matrix convolutionalActivation = convolutional3DLayer.feedForward(input3D);
+    assertTrue(expectedConvolutional3DActivation.compare(convolutionalActivation, TOLERANCE));
+  }
+
+  @Test
+  public void testConvolutional3DBackPropagate() {
+    final Matrix error = convolutional3DLayer.backPropagate(input3D, expectedConvolutional3DActivation, nextError3D);
+    assertTrue(expectedConvolutional3DError.compare(error, TOLERANCE));
+  }
+
+  @Test
+  public void testConvolutional3DGradient() {
+    final LayerParameter convolutionalLayerParams
+        = convolutional3DLayer.generateParameterGradient(input3D, nextError3D);
+    assertTrue(compare(expectedConvolutional3DLayerParams, convolutionalLayerParams, TOLERANCE));
   }
 }

--- a/dolphin-dnn/src/test/java/edu/snu/dolphin/dnn/layers/ConvolutionalLayerTest.java
+++ b/dolphin-dnn/src/test/java/edu/snu/dolphin/dnn/layers/ConvolutionalLayerTest.java
@@ -185,7 +185,8 @@ public class ConvolutionalLayerTest {
         .setKernelHeight(2)
         .setKernelWidth(2)
         .setStrideHeight(1)
-        .setStrideWidth(1);
+        .setStrideWidth(1)
+        .setNumOutput(1);
 
     final ConvolutionalLayerConfigurationBuilder builderWithPadding = ConvolutionalLayerConfigurationBuilder
         .newConfigurationBuilder()
@@ -197,7 +198,8 @@ public class ConvolutionalLayerTest {
         .setKernelHeight(2)
         .setKernelWidth(2)
         .setStrideHeight(1)
-        .setStrideWidth(1);
+        .setStrideWidth(1)
+        .setNumOutput(1);
 
     final ConvolutionalLayerConfigurationBuilder builder3D = ConvolutionalLayerConfigurationBuilder
         .newConfigurationBuilder()


### PR DESCRIPTION
This PR includes support for 3D input data and multi-filters. `num_output` decides the number of the filters. As new parameter is added in convolutional layer, configuration parts related to that layer are modified.  For convenience of computation, `im2row()` and `row2im()` are implemented. A few test cases with 3D input data are added, too.