### PR TITLE
[DOLPHIN-176] Create partitioned, queued, single-node parameter server

### DIFF
--- a/bin/run_ps.sh
+++ b/bin/run_ps.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+# Copyright (C) 2016 Seoul National University
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# EXAMPLE USAGE
+# bin/run_ps.sh edu.snu.dolphin.ps.examples.add.ConcurrentPSExampleREEF -numUpdates 960 -timeout 360000 -numWorkers 4
+
+# RUNTIME
+SELF_JAR=`echo dolphin-ps/target/dolphin-ps-*-shaded.jar`
+
+LOGGING_CONFIG='-Djava.util.logging.config.class=org.apache.reef.util.logging.Config'
+
+CLASSPATH=$YARN_HOME/share/hadoop/common/*:$YARN_HOME/share/hadoop/common/lib/*:$YARN_HOME/share/hadoop/yarn/*:$YARN_HOME/share/hadoop/hdfs/*:$YARN_HOME/share/hadoop/mapreduce/lib/*:$YARN_HOME/share/hadoop/mapreduce/*
+
+YARN_CONF_DIR=$YARN_HOME/etc/hadoop
+
+CMD="java -cp $YARN_CONF_DIR:$SELF_JAR:$CLASSPATH $LOCAL_RUNTIME_TMP $LOGGING_CONFIG $*"
+echo $CMD
+$CMD # 2> /dev/null

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/NeuralNetworkParameterUpdater.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/NeuralNetworkParameterUpdater.java
@@ -19,7 +19,7 @@ import edu.snu.dolphin.dnn.conf.NeuralNetworkConfigurationParameters.*;
 import edu.snu.dolphin.dnn.data.NeuralNetParamServerData;
 import edu.snu.dolphin.dnn.layers.LayerParameter;
 import edu.snu.dolphin.dnn.util.ValidationStats;
-import edu.snu.dolphin.ps.server.ParameterUpdater;
+import edu.snu.dolphin.ps.server.api.ParameterUpdater;
 import org.apache.reef.io.network.util.Pair;
 import org.apache.reef.tang.Configuration;
 import org.apache.reef.tang.Injector;

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/NeuralNetworkREEF.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/NeuralNetworkREEF.java
@@ -18,7 +18,7 @@ package edu.snu.dolphin.dnn;
 import edu.snu.dolphin.bsp.parameters.*;
 import edu.snu.dolphin.dnn.data.NeuralNetParamServerDataCodec;
 import edu.snu.dolphin.ps.ParameterServerConfigurationBuilder;
-import edu.snu.dolphin.ps.driver.SingleNodeParameterServerManager;
+import edu.snu.dolphin.ps.driver.impl.ConcurrentParameterServerManager;
 import org.apache.hadoop.mapred.TextInputFormat;
 import org.apache.reef.client.DriverConfiguration;
 import org.apache.reef.client.DriverLauncher;
@@ -207,7 +207,7 @@ public final class NeuralNetworkREEF {
         .build();
 
     final Configuration parameterServerConfiguration = new ParameterServerConfigurationBuilder()
-        .setManagerClass(SingleNodeParameterServerManager.class)
+        .setManagerClass(ConcurrentParameterServerManager.class)
         .setUpdaterClass(NeuralNetworkParameterUpdater.class)
         .setPreValueCodecClass(NeuralNetParamServerDataCodec.class)
         .setValueCodecClass(NeuralNetParamServerDataCodec.class)

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/NeuralNetworkSingleNodeParameterServerDriver.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/NeuralNetworkSingleNodeParameterServerDriver.java
@@ -93,7 +93,7 @@ public final class NeuralNetworkSingleNodeParameterServerDriver {
             ContextConfiguration.CONF
                 .set(ContextConfiguration.IDENTIFIER, "ParameterServerContext")
                 .build(),
-            psDriver.getServerContextConfiguration());
+            psDriver.getContextConfiguration());
 
         // Add the configuration for Neural Network and
         // the server-side parameter server configuration.
@@ -113,7 +113,7 @@ public final class NeuralNetworkSingleNodeParameterServerDriver {
         final String nnCtxtId = NNCONTEXT_PREFIX + neuralNetworkContextIds.getAndIncrement();
         final Configuration contextConf = Configurations.merge(
             ContextConfiguration.CONF.set(ContextConfiguration.IDENTIFIER, nnCtxtId).build(),
-            psDriver.getWorkerContextConfiguration());
+            psDriver.getContextConfiguration());
 
         // Add Data Parse Service and Neural Network configurations,
         // as well as the worker-side parameter server configuration.

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/ParameterServerNeuralNetworkTask.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/ParameterServerNeuralNetworkTask.java
@@ -20,7 +20,7 @@ import edu.snu.dolphin.bsp.examples.ml.parameters.MaxIterations;
 import edu.snu.dolphin.dnn.blas.Matrix;
 import edu.snu.dolphin.dnn.data.NeuralNetParamServerData;
 import edu.snu.dolphin.dnn.util.Validator;
-import edu.snu.dolphin.ps.worker.ParameterWorker;
+import edu.snu.dolphin.ps.worker.api.ParameterWorker;
 import org.apache.reef.annotations.audience.TaskSide;
 import org.apache.reef.io.network.util.Pair;
 import org.apache.reef.tang.annotations.Parameter;

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/layerparam/provider/ParameterServerParameterProvider.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/layerparam/provider/ParameterServerParameterProvider.java
@@ -18,7 +18,7 @@ package edu.snu.dolphin.dnn.layerparam.provider;
 import edu.snu.dolphin.dnn.NeuralNetworkParameterUpdater;
 import edu.snu.dolphin.dnn.data.NeuralNetParamServerData;
 import edu.snu.dolphin.dnn.layers.LayerParameter;
-import edu.snu.dolphin.ps.worker.ParameterWorker;
+import edu.snu.dolphin.ps.worker.api.ParameterWorker;
 
 import javax.annotation.concurrent.ThreadSafe;
 import javax.inject.Inject;

--- a/dolphin-ps/src/main/java/edu/snu/dolphin/ps/ParameterServerConfigurationBuilder.java
+++ b/dolphin-ps/src/main/java/edu/snu/dolphin/ps/ParameterServerConfigurationBuilder.java
@@ -16,16 +16,19 @@
 package edu.snu.dolphin.ps;
 
 import edu.snu.dolphin.ps.ParameterServerParameters.*;
-import edu.snu.dolphin.ps.driver.ParameterServerManager;
-import edu.snu.dolphin.ps.server.ParameterUpdater;
+import edu.snu.dolphin.ps.driver.api.ParameterServerManager;
+import edu.snu.dolphin.ps.server.api.ParameterUpdater;
 import org.apache.reef.io.serialization.Codec;
 import org.apache.reef.io.serialization.SerializableCodec;
 import org.apache.reef.tang.Configuration;
 import org.apache.reef.tang.Tang;
 import org.apache.reef.tang.formats.AvroConfigurationSerializer;
+import org.apache.reef.tang.formats.ConfigurationSerializer;
 import org.apache.reef.util.Builder;
 
 public final class ParameterServerConfigurationBuilder implements Builder<Configuration> {
+
+  private static final ConfigurationSerializer CONFIGURATION_SERIALIZER = new AvroConfigurationSerializer();
 
   private Class<? extends ParameterServerManager> managerClass;
   private Class<? extends ParameterUpdater> updaterClass;
@@ -75,12 +78,12 @@ public final class ParameterServerConfigurationBuilder implements Builder<Config
     return Tang.Factory.getTang().newConfigurationBuilder()
         .bindImplementation(ParameterServerManager.class, managerClass)
         .bindNamedParameter(SerializedUpdaterConfiguration.class,
-            new AvroConfigurationSerializer().toString(
+            CONFIGURATION_SERIALIZER.toString(
                 Tang.Factory.getTang().newConfigurationBuilder()
                     .bindImplementation(ParameterUpdater.class, updaterClass)
                     .build()))
         .bindNamedParameter(SerializedCodecConfiguration.class,
-            new AvroConfigurationSerializer().toString(
+            CONFIGURATION_SERIALIZER.toString(
                 Tang.Factory.getTang().newConfigurationBuilder()
                     .bindNamedParameter(KeyCodecName.class, keyCodecClass)
                     .bindNamedParameter(PreValueCodecName.class, preValueCodecClass)

--- a/dolphin-ps/src/main/java/edu/snu/dolphin/ps/driver/ParameterServerDriver.java
+++ b/dolphin-ps/src/main/java/edu/snu/dolphin/ps/driver/ParameterServerDriver.java
@@ -17,9 +17,9 @@ package edu.snu.dolphin.ps.driver;
 
 import edu.snu.dolphin.ps.ParameterServerParameters.SerializedCodecConfiguration;
 import edu.snu.dolphin.ps.ParameterServerParameters.SerializedUpdaterConfiguration;
+import edu.snu.dolphin.ps.driver.api.ParameterServerManager;
 import edu.snu.dolphin.ps.ns.NetworkContextRegister;
 import edu.snu.dolphin.ps.ns.PSMessageHandler;
-import edu.snu.dolphin.ps.server.ServerSideMsgHandler;
 import edu.snu.dolphin.ps.worker.WorkerSideMsgHandler;
 import org.apache.reef.annotations.audience.DriverSide;
 import org.apache.reef.evaluator.context.parameters.ContextStartHandlers;
@@ -58,7 +58,7 @@ public final class ParameterServerDriver {
   private final Configuration codecConfiguration;
 
   /**
-   * Configuration that specifies the {@link edu.snu.dolphin.ps.server.ParameterUpdater} class to use.
+   * Configuration that specifies the {@link edu.snu.dolphin.ps.server.api.ParameterUpdater} class to use.
    */
   private final Configuration updaterConfiguration;
 
@@ -146,7 +146,6 @@ public final class ParameterServerDriver {
             updaterConfiguration,
             getNameResolverServiceConfiguration())
         .bindImplementation(IdentifierFactory.class, StringIdentifierFactory.class)
-        .bindNamedParameter(PSMessageHandler.class, ServerSideMsgHandler.class)
         .build();
   }
 }

--- a/dolphin-ps/src/main/java/edu/snu/dolphin/ps/driver/ParameterServerDriver.java
+++ b/dolphin-ps/src/main/java/edu/snu/dolphin/ps/driver/ParameterServerDriver.java
@@ -87,28 +87,13 @@ public final class ParameterServerDriver {
   }
 
   /**
-   * @return context configuration that both worker and server Evaluators use
+   * @return context configuration for an Evaluator that uses {@code ParameterWorker} or {@code ParameterServer}
    */
-  private Configuration getCommonContextConfiguration() {
+  public Configuration getContextConfiguration() {
     return Tang.Factory.getTang().newConfigurationBuilder()
         .bindSetEntry(ContextStartHandlers.class, NetworkContextRegister.RegisterContextHandler.class)
         .bindSetEntry(ContextStopHandlers.class, NetworkContextRegister.UnregisterContextHandler.class)
         .build();
-  }
-
-  /**
-   * @return context configuration for an Evaluator that uses a {@code ParameterWorker}
-   */
-  public Configuration getWorkerContextConfiguration() {
-    return getCommonContextConfiguration();
-
-  }
-
-  /**
-   * @return context configuration for an Evaluator that uses a {@code ParameterServer}
-   */
-  public Configuration getServerContextConfiguration() {
-    return getCommonContextConfiguration();
   }
 
   /**

--- a/dolphin-ps/src/main/java/edu/snu/dolphin/ps/driver/api/ParameterServerManager.java
+++ b/dolphin-ps/src/main/java/edu/snu/dolphin/ps/driver/api/ParameterServerManager.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package edu.snu.dolphin.ps.driver;
+package edu.snu.dolphin.ps.driver.api;
 
 import org.apache.reef.annotations.audience.DriverSide;
 import org.apache.reef.tang.Configuration;

--- a/dolphin-ps/src/main/java/edu/snu/dolphin/ps/driver/api/package-info.java
+++ b/dolphin-ps/src/main/java/edu/snu/dolphin/ps/driver/api/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 Seoul National University
+ * Copyright (C) 2016 Seoul National University
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,6 +14,6 @@
  * limitations under the License.
  */
 /**
- * Parameter Server classes that are instantiated at the driver.
+ * Interfaces for driver-side Parameter Server classes that can have several pluggable implementations.
  */
-package edu.snu.dolphin.ps.driver;
+package edu.snu.dolphin.ps.driver.api;

--- a/dolphin-ps/src/main/java/edu/snu/dolphin/ps/driver/impl/PartitionedParameterServerManager.java
+++ b/dolphin-ps/src/main/java/edu/snu/dolphin/ps/driver/impl/PartitionedParameterServerManager.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (C) 2016 Seoul National University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.snu.dolphin.ps.driver.impl;
+
+import edu.snu.dolphin.ps.driver.api.ParameterServerManager;
+import edu.snu.dolphin.ps.ns.EndpointId;
+import edu.snu.dolphin.ps.ns.PSMessageHandler;
+import edu.snu.dolphin.ps.server.partitioned.PartitionedParameterServer;
+import edu.snu.dolphin.ps.server.partitioned.PartitionedServerSideMsgHandler;
+import edu.snu.dolphin.ps.server.partitioned.PartitionedServerSideReplySender;
+import edu.snu.dolphin.ps.server.partitioned.PartitionedServerSideReplySenderImpl;
+import edu.snu.dolphin.ps.server.partitioned.parameters.NumPartitions;
+import edu.snu.dolphin.ps.server.partitioned.parameters.QueueSize;
+import edu.snu.dolphin.ps.worker.api.ParameterWorker;
+import edu.snu.dolphin.ps.worker.impl.SingleNodeParameterWorker;
+import org.apache.reef.annotations.audience.DriverSide;
+import org.apache.reef.driver.context.ServiceConfiguration;
+import org.apache.reef.tang.Configuration;
+import org.apache.reef.tang.Tang;
+import org.apache.reef.tang.annotations.Parameter;
+
+import javax.inject.Inject;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Manager class for a Partitioned Parameter Server, that supports atomic,
+ * in-order processing of push and pull operations, running on a single Evaluator.
+ * Partitions are based on the hash of the key.
+ * Each partition consists of a queue, kvStore, and thread.
+ *
+ * This manager does NOT handle server or worker faults.
+ */
+@DriverSide
+public final class PartitionedParameterServerManager implements ParameterServerManager {
+  private static final String SERVER_ID = "SINGLE_NODE_SERVER_ID";
+  private static final String WORKER_ID_PREFIX = "SINGLE_NODE_WORKER_ID_";
+
+  private final int numPartitions;
+  private final int queueSize;
+  private final AtomicInteger numWorkers;
+
+  @Inject
+  private PartitionedParameterServerManager(@Parameter(NumPartitions.class) final int numPartitions,
+                                            @Parameter(QueueSize.class) final int queueSize) {
+    this.numPartitions = numPartitions;
+    this.queueSize = queueSize;
+    this.numWorkers = new AtomicInteger(0);
+  }
+
+  /**
+   * Returns worker-side service configuration.
+   * Sets {@link SingleNodeParameterWorker} as the {@link ParameterWorker} class.
+   */
+  @Override
+  public Configuration getWorkerServiceConfiguration() {
+    final int workerIndex = numWorkers.getAndIncrement();
+
+    return Tang.Factory.getTang()
+        .newConfigurationBuilder(ServiceConfiguration.CONF
+            .set(ServiceConfiguration.SERVICES, SingleNodeParameterWorker.class)
+            .build())
+        .bindImplementation(ParameterWorker.class, SingleNodeParameterWorker.class)
+        .bindNamedParameter(ServerId.class, SERVER_ID)
+        .bindNamedParameter(EndpointId.class, WORKER_ID_PREFIX + workerIndex)
+        .build();
+  }
+
+  /**
+   * Returns server-side service configuration.
+   */
+  @Override
+  public Configuration getServerServiceConfiguration() {
+    return Tang.Factory.getTang()
+        .newConfigurationBuilder(ServiceConfiguration.CONF
+            .set(ServiceConfiguration.SERVICES, PartitionedParameterServer.class)
+            .build())
+        .bindNamedParameter(EndpointId.class, SERVER_ID)
+        .bindNamedParameter(PSMessageHandler.class, PartitionedServerSideMsgHandler.class)
+        .bindNamedParameter(NumPartitions.class, Integer.toString(numPartitions))
+        .bindNamedParameter(QueueSize.class, Integer.toString(queueSize))
+        .bindImplementation(PartitionedServerSideReplySender.class, PartitionedServerSideReplySenderImpl.class)
+        .build();
+  }
+}

--- a/dolphin-ps/src/main/java/edu/snu/dolphin/ps/driver/impl/ServerId.java
+++ b/dolphin-ps/src/main/java/edu/snu/dolphin/ps/driver/impl/ServerId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 Seoul National University
+ * Copyright (C) 2016 Seoul National University
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/**
- * Parameter Server classes that are instantiated at the driver.
- */
-package edu.snu.dolphin.ps.driver;
+package edu.snu.dolphin.ps.driver.impl;
+
+import org.apache.reef.tang.annotations.Name;
+import org.apache.reef.tang.annotations.NamedParameter;
+
+@NamedParameter(doc = "server identifier for Network Connection Service")
+public final class ServerId implements Name<String> {
+}

--- a/dolphin-ps/src/main/java/edu/snu/dolphin/ps/driver/impl/package-info.java
+++ b/dolphin-ps/src/main/java/edu/snu/dolphin/ps/driver/impl/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 Seoul National University
+ * Copyright (C) 2016 Seoul National University
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,6 +14,6 @@
  * limitations under the License.
  */
 /**
- * Parameter Server classes that are instantiated at the driver.
+ * Implementations for driver-side Parameter Server classes in {@link edu.snu.dolphin.ps.driver.api}.
  */
-package edu.snu.dolphin.ps.driver;
+package edu.snu.dolphin.ps.driver.impl;

--- a/dolphin-ps/src/main/java/edu/snu/dolphin/ps/examples/add/AddUpdater.java
+++ b/dolphin-ps/src/main/java/edu/snu/dolphin/ps/examples/add/AddUpdater.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2016 Seoul National University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.snu.dolphin.ps.examples.add;
+
+import edu.snu.dolphin.ps.server.api.ParameterUpdater;
+
+import javax.inject.Inject;
+
+/**
+ * A ParameterUpdater that add integers. The initial value is 0, and updates
+ * are applied as oldValue + deltaValue.
+ */
+public final class AddUpdater implements ParameterUpdater<Integer, Integer, Integer> {
+
+  @Inject
+  private AddUpdater() {
+  }
+
+  @Override
+  public Integer process(final Integer key, final Integer preValue) {
+    return preValue;
+  }
+
+  @Override
+  public Integer update(final Integer oldValue, final Integer deltaValue) {
+    return oldValue + deltaValue;
+  }
+
+  @Override
+  public Integer initValue(final Integer key) {
+    return 0;
+  }
+}

--- a/dolphin-ps/src/main/java/edu/snu/dolphin/ps/examples/add/ConcurrentPSExampleREEF.java
+++ b/dolphin-ps/src/main/java/edu/snu/dolphin/ps/examples/add/ConcurrentPSExampleREEF.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright (C) 2016 Seoul National University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.snu.dolphin.ps.examples.add;
+
+import edu.snu.dolphin.ps.ParameterServerConfigurationBuilder;
+import edu.snu.dolphin.ps.driver.impl.ConcurrentParameterServerManager;
+import edu.snu.dolphin.ps.examples.add.parameters.NumKeys;
+import edu.snu.dolphin.ps.examples.add.parameters.NumUpdates;
+import edu.snu.dolphin.ps.examples.add.parameters.NumWorkers;
+import edu.snu.dolphin.ps.examples.add.parameters.JobTimeout;
+import edu.snu.dolphin.ps.examples.add.parameters.StartKey;
+import org.apache.reef.client.DriverConfiguration;
+import org.apache.reef.client.DriverLauncher;
+import org.apache.reef.client.LauncherStatus;
+import org.apache.reef.runtime.local.client.LocalRuntimeConfiguration;
+import org.apache.reef.tang.Configuration;
+import org.apache.reef.tang.Configurations;
+import org.apache.reef.tang.JavaConfigurationBuilder;
+import org.apache.reef.tang.Tang;
+import org.apache.reef.tang.annotations.Parameter;
+import org.apache.reef.tang.exceptions.InjectionException;
+import org.apache.reef.tang.formats.CommandLine;
+import org.apache.reef.util.EnvironmentUtils;
+
+import javax.inject.Inject;
+import java.io.IOException;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * ParameterServer Example for the Concurrent (single-node) PS.
+ */
+public final class ConcurrentPSExampleREEF {
+  private static final Logger LOG = Logger.getLogger(ConcurrentPSExampleREEF.class.getName());
+
+  private final long timeout;
+  private final int numWorkers;
+  private final int numUpdates;
+  private final int startKey;
+  private final int numKeys;
+
+  @Inject
+  private ConcurrentPSExampleREEF(@Parameter(JobTimeout.class) final long timeout,
+                                  @Parameter(NumWorkers.class) final int numWorkers,
+                                  @Parameter(NumUpdates.class) final int numUpdates,
+                                  @Parameter(StartKey.class) final int startKey,
+                                  @Parameter(NumKeys.class) final int numKeys) {
+    this.timeout = timeout;
+    this.numWorkers = numWorkers;
+    this.numUpdates = numUpdates;
+    this.startKey = startKey;
+    this.numKeys = numKeys;
+  }
+
+  private Configuration getDriverConf() {
+    final Configuration driverConf = DriverConfiguration.CONF
+        .set(DriverConfiguration.GLOBAL_LIBRARIES,
+            EnvironmentUtils.getClassLocation(PSExampleDriver.class))
+        .set(DriverConfiguration.DRIVER_IDENTIFIER, "ConcurrentPSExample")
+        .set(DriverConfiguration.ON_DRIVER_STARTED,
+            PSExampleDriver.StartHandler.class)
+        .set(DriverConfiguration.ON_EVALUATOR_ALLOCATED,
+            PSExampleDriver.EvaluatorAllocatedHandler.class)
+        .set(DriverConfiguration.ON_CONTEXT_ACTIVE,
+            PSExampleDriver.ActiveContextHandler.class)
+        .set(DriverConfiguration.ON_TASK_RUNNING,
+            PSExampleDriver.RunningTaskHandler.class)
+        .set(DriverConfiguration.ON_TASK_COMPLETED,
+            PSExampleDriver.CompletedTaskHandler.class)
+        .build();
+
+    final Configuration parametersConf = Tang.Factory.getTang().newConfigurationBuilder()
+        .bindNamedParameter(NumWorkers.class, Integer.toString(numWorkers))
+        .bindNamedParameter(NumUpdates.class, Integer.toString(numUpdates))
+        .bindNamedParameter(StartKey.class, Integer.toString(startKey))
+        .bindNamedParameter(NumKeys.class, Integer.toString(numKeys))
+        .build();
+
+    final Configuration psConf = new ParameterServerConfigurationBuilder()
+        .setManagerClass(ConcurrentParameterServerManager.class)
+        .setUpdaterClass(AddUpdater.class)
+        .setKeyCodecClass(IntegerCodec.class)
+        .setPreValueCodecClass(IntegerCodec.class)
+        .setValueCodecClass(IntegerCodec.class)
+        .build();
+
+    return Configurations.merge(driverConf, parametersConf, psConf);
+  }
+
+  private Configuration getRuntimeConfiguration() {
+    return getLocalRuntimeConfiguration();
+  }
+
+  private Configuration getLocalRuntimeConfiguration() {
+    return LocalRuntimeConfiguration.CONF
+        .set(LocalRuntimeConfiguration.MAX_NUMBER_OF_EVALUATORS, numWorkers + 1)
+        .build();
+  }
+
+  private LauncherStatus run() throws InjectionException {
+    return DriverLauncher.getLauncher(getRuntimeConfiguration()).run(getDriverConf(), timeout);
+  }
+
+  private static ConcurrentPSExampleREEF parseCommandLine(final String[] args) throws IOException, InjectionException {
+    final JavaConfigurationBuilder cb = Tang.Factory.getTang().newConfigurationBuilder();
+    final CommandLine cl = new CommandLine(cb);
+    cl.registerShortNameOfClass(JobTimeout.class);
+    cl.registerShortNameOfClass(NumWorkers.class);
+    cl.registerShortNameOfClass(NumUpdates.class);
+    cl.registerShortNameOfClass(StartKey.class);
+    cl.registerShortNameOfClass(NumKeys.class);
+
+    cl.processCommandLine(args);
+
+    return Tang.Factory.getTang().newInjector(cb.build()).getInstance(ConcurrentPSExampleREEF.class);
+  }
+
+  public static void main(final String[] args) {
+    LauncherStatus status;
+    try {
+      final ConcurrentPSExampleREEF concurrentPSExampleREEF = parseCommandLine(args);
+      status = concurrentPSExampleREEF.run();
+    } catch (final Exception e) {
+      LOG.log(Level.SEVERE, "Fatal exception occurred: {0}", e);
+      status = LauncherStatus.failed(e);
+    }
+    LOG.log(Level.INFO, "REEF job completed: {0}", status);
+  }
+}

--- a/dolphin-ps/src/main/java/edu/snu/dolphin/ps/examples/add/IntegerCodec.java
+++ b/dolphin-ps/src/main/java/edu/snu/dolphin/ps/examples/add/IntegerCodec.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2016 Seoul National University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.snu.dolphin.ps.examples.add;
+
+import org.apache.reef.wake.remote.Codec;
+
+import javax.inject.Inject;
+import java.nio.ByteBuffer;
+
+/**
+ * A simple codec for Integer.
+ */
+public final class IntegerCodec implements Codec<Integer>, org.apache.reef.io.serialization.Codec<Integer> {
+
+  @Inject
+  private IntegerCodec() {
+  }
+
+  @Override
+  public Integer decode(final byte[] bytes) {
+    final ByteBuffer byteBuffer = ByteBuffer.wrap(bytes);
+    return byteBuffer.getInt();
+  }
+
+  @Override
+  public byte[] encode(final Integer integer) {
+    final ByteBuffer byteBuffer = ByteBuffer.allocate(Integer.SIZE / Byte.SIZE);
+    byteBuffer.putInt(integer);
+    return byteBuffer.array();
+  }
+}

--- a/dolphin-ps/src/main/java/edu/snu/dolphin/ps/examples/add/PSExampleDriver.java
+++ b/dolphin-ps/src/main/java/edu/snu/dolphin/ps/examples/add/PSExampleDriver.java
@@ -1,0 +1,234 @@
+/*
+ * Copyright (C) 2016 Seoul National University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.snu.dolphin.ps.examples.add;
+
+import edu.snu.dolphin.ps.driver.ParameterServerDriver;
+import edu.snu.dolphin.ps.examples.add.parameters.NumKeys;
+import edu.snu.dolphin.ps.examples.add.parameters.NumUpdates;
+import edu.snu.dolphin.ps.examples.add.parameters.NumWorkers;
+import edu.snu.dolphin.ps.examples.add.parameters.StartKey;
+import org.apache.reef.annotations.audience.DriverSide;
+import org.apache.reef.driver.context.ActiveContext;
+import org.apache.reef.driver.context.ContextConfiguration;
+import org.apache.reef.driver.evaluator.AllocatedEvaluator;
+import org.apache.reef.driver.evaluator.EvaluatorRequest;
+import org.apache.reef.driver.evaluator.EvaluatorRequestor;
+import org.apache.reef.driver.task.CompletedTask;
+import org.apache.reef.driver.task.RunningTask;
+import org.apache.reef.driver.task.TaskConfiguration;
+import org.apache.reef.tang.Configuration;
+import org.apache.reef.tang.Configurations;
+import org.apache.reef.tang.Tang;
+import org.apache.reef.tang.annotations.Parameter;
+import org.apache.reef.tang.annotations.Unit;
+import org.apache.reef.wake.EventHandler;
+import org.apache.reef.wake.time.event.StartTime;
+
+import javax.inject.Inject;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * The ParameterServer Example Driver.
+ * We launch Evaluators for Workers and Parameter Servers on Start (currently only one PS).
+ * These Evaluators are then given PS Context and Services, and UpdaterTasks are run.
+ * When all UpdaterTasks are complete, a ValidatorTask is run.
+ * When the ValidatorTask is complete, the Parameter Service is shutdown;
+ * the Driver will shutdown because it is idle.
+ */
+@DriverSide
+@Unit
+public final class PSExampleDriver {
+  private static final Logger LOG = Logger.getLogger(PSExampleDriver.class.getName());
+
+  private static final String PS_ID = "PS";
+  private static final String WORKER_CONTEXT_PREFIX = "Worker-Context-";
+  private static final String UPDATER_TASK_PREFIX = "Updater-Task-";
+  private static final String VALIDATOR_TASK_ID = "Validator-Task";
+
+  private final ParameterServerDriver psDriver;
+  private final EvaluatorRequestor evalRequestor;
+
+  private final int numWorkers;
+  private final int numUpdatesPerWorker;
+  private final int startKey;
+  private final int numKeys;
+
+  private final AtomicInteger evalCounter = new AtomicInteger(0);
+  private final AtomicInteger taskCompletedCounter = new AtomicInteger(0);
+
+  private ActiveContext psActiveContext = null;
+
+  /**
+   * numUpdates is the _total_ number of updates to push.
+   * This value is then divided by numWorkers and passed as numUpdatesPerWorker to the Tasks.
+   *
+   * @throws IllegalArgumentException numUpdates must be divisible by numWorkers and (numWorkers * numKeys).
+   *                                  If not, the exception is thrown.
+   *                                  This makes accounting of updates across Workers much simpler.
+   */
+  @Inject
+  private PSExampleDriver(final ParameterServerDriver psDriver,
+                          final EvaluatorRequestor evalRequestor,
+                          @Parameter(NumWorkers.class) final int numWorkers,
+                          @Parameter(NumUpdates.class) final int numUpdates,
+                          @Parameter(StartKey.class) final int startKey,
+                          @Parameter(NumKeys.class) final int numKeys) {
+    if (numUpdates % numWorkers != 0) {
+      throw new IllegalArgumentException(
+          String.format("numUpdates %d must be divisible by numWorkers %d", numUpdates, numWorkers));
+    }
+    if ((numUpdates / numWorkers) % numKeys != 0) {
+      throw new IllegalArgumentException(
+          String.format("numUpdates %d must be divisible by (numWorkers %d * numKeys %d)",
+              numUpdates, numWorkers, numKeys));
+    }
+
+    this.psDriver = psDriver;
+    this.evalRequestor = evalRequestor;
+    this.numWorkers = numWorkers;
+    this.numUpdatesPerWorker = numUpdates / numWorkers;
+    this.startKey = startKey;
+    this.numKeys = numKeys;
+  }
+
+  /**
+   * Launch Evaluators for Workers and Parameter Servers.
+   */
+  final class StartHandler implements EventHandler<StartTime> {
+    @Override
+    public void onNext(final StartTime startTime) {
+      evalRequestor.submit(EvaluatorRequest.newBuilder()
+          .setNumber(numWorkers + 1)
+          .setMemory(512)
+          .setNumberOfCores(1)
+          .build());
+    }
+  }
+
+  /**
+   * Submit PS Context and Services, and run UpdaterTasks.
+   */
+  final class EvaluatorAllocatedHandler implements EventHandler<AllocatedEvaluator> {
+    @Override
+    public void onNext(final AllocatedEvaluator allocatedEvaluator) {
+      final int evalCount = evalCounter.incrementAndGet();
+
+      if (evalCount == 1) { // Submit the ParameterServer
+
+        final Configuration contextConf = Configurations.merge(
+            ContextConfiguration.CONF
+                .set(ContextConfiguration.IDENTIFIER, PS_ID)
+                .build(),
+            psDriver.getContextConfiguration());
+
+        final Configuration serviceConf = psDriver.getServerServiceConfiguration();
+
+        allocatedEvaluator.submitContextAndService(contextConf, serviceConf);
+
+      } else { // Submit a Context and Service for the PS Worker, and run an UpdaterTask on top of that
+
+        final Configuration contextConf = Configurations.merge(
+            ContextConfiguration.CONF
+                .set(ContextConfiguration.IDENTIFIER,
+                    WORKER_CONTEXT_PREFIX + (evalCount - 1))
+                .build(),
+            psDriver.getContextConfiguration()
+        );
+
+        final Configuration serviceConf = psDriver.getWorkerServiceConfiguration();
+
+        final Configuration taskConf = TaskConfiguration.CONF
+            .set(TaskConfiguration.IDENTIFIER, UPDATER_TASK_PREFIX + (evalCount - 1))
+            .set(TaskConfiguration.TASK, UpdaterTask.class)
+            .build();
+
+        final Configuration parametersConf = Tang.Factory.getTang().newConfigurationBuilder()
+            .bindNamedParameter(NumUpdates.class, Integer.toString(numUpdatesPerWorker))
+            .bindNamedParameter(StartKey.class, Integer.toString(startKey))
+            .bindNamedParameter(NumKeys.class, Integer.toString(numKeys))
+            .build();
+
+        allocatedEvaluator.submitContextAndServiceAndTask(contextConf, serviceConf,
+            Configurations.merge(taskConf, parametersConf));
+      }
+    }
+  }
+
+  /**
+   * Save the Parameter Server's active context.
+   */
+  final class ActiveContextHandler implements EventHandler<ActiveContext> {
+    @Override
+    public void onNext(final ActiveContext activeContext) {
+      LOG.log(Level.INFO, "Context active: {0}", activeContext.getId());
+      if (activeContext.getId().equals(PS_ID)) {
+        psActiveContext = activeContext;
+      }
+    }
+  }
+
+  /**
+   * Log task running status.
+   */
+  final class RunningTaskHandler implements EventHandler<RunningTask> {
+    @Override
+    public void onNext(final RunningTask runningTask) {
+      LOG.log(Level.INFO, "Task running: {0}", runningTask.getId());
+    }
+  }
+
+  /**
+   * When all UpdaterTasks are complete, run a ValidatorTask.
+   * When the ValidatorTask is complete, shutdown the Parameter Service.
+   * The Driver will then shutdown because it is idle.
+   */
+  final class CompletedTaskHandler implements EventHandler<CompletedTask> {
+    @Override
+    public void onNext(final CompletedTask completedTask) {
+      LOG.log(Level.INFO, "Task completed: {0}", completedTask.getId());
+
+      final int taskCompletedCount = taskCompletedCounter.incrementAndGet();
+      if (taskCompletedCount < numWorkers) { // Close Contexts when their task is completed, up to the last Worker.
+        completedTask.getActiveContext().close();
+
+      } else if (taskCompletedCount == numWorkers) { // For the last Worker, run the Validator Task.
+        LOG.log(Level.INFO, "All Tasks have completed, running Validator Task.");
+
+        final Configuration taskConf = TaskConfiguration.CONF
+            .set(TaskConfiguration.IDENTIFIER, VALIDATOR_TASK_ID)
+            .set(TaskConfiguration.TASK, ValidatorTask.class)
+            .build();
+
+        final Configuration parameterConf = Tang.Factory.getTang().newConfigurationBuilder()
+            .bindNamedParameter(NumWorkers.class, Integer.toString(numWorkers))
+            .bindNamedParameter(NumUpdates.class, Integer.toString(numUpdatesPerWorker))
+            .bindNamedParameter(StartKey.class, Integer.toString(startKey))
+            .bindNamedParameter(NumKeys.class, Integer.toString(numKeys))
+            .build();
+
+        completedTask.getActiveContext().submitTask(Configurations.merge(taskConf, parameterConf));
+
+      } else if (taskCompletedCount == numWorkers + 1) { // When the Validator Task is complete, shutdown the PS Server.
+        completedTask.getActiveContext().close();
+
+        LOG.log(Level.INFO, "Correct result validated, shutting down parameter server.");
+        psActiveContext.close();
+      }
+    }
+  }
+}

--- a/dolphin-ps/src/main/java/edu/snu/dolphin/ps/examples/add/PartitionedPSExampleREEF.java
+++ b/dolphin-ps/src/main/java/edu/snu/dolphin/ps/examples/add/PartitionedPSExampleREEF.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright (C) 2016 Seoul National University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.snu.dolphin.ps.examples.add;
+
+import edu.snu.dolphin.ps.ParameterServerConfigurationBuilder;
+import edu.snu.dolphin.ps.driver.impl.PartitionedParameterServerManager;
+import edu.snu.dolphin.ps.examples.add.parameters.*;
+import edu.snu.dolphin.ps.server.partitioned.parameters.NumPartitions;
+import edu.snu.dolphin.ps.server.partitioned.parameters.QueueSize;
+import org.apache.reef.client.DriverConfiguration;
+import org.apache.reef.client.DriverLauncher;
+import org.apache.reef.client.LauncherStatus;
+import org.apache.reef.runtime.local.client.LocalRuntimeConfiguration;
+import org.apache.reef.tang.Configuration;
+import org.apache.reef.tang.Configurations;
+import org.apache.reef.tang.JavaConfigurationBuilder;
+import org.apache.reef.tang.Tang;
+import org.apache.reef.tang.annotations.Parameter;
+import org.apache.reef.tang.exceptions.InjectionException;
+import org.apache.reef.tang.formats.CommandLine;
+import org.apache.reef.util.EnvironmentUtils;
+
+import javax.inject.Inject;
+import java.io.IOException;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * ParameterServer Example for the Partitioned (single-node) PS.
+ */
+public final class PartitionedPSExampleREEF {
+  private static final Logger LOG = Logger.getLogger(PartitionedPSExampleREEF.class.getName());
+
+  private final long timeout;
+  private final int numWorkers;
+  private final int numUpdates;
+  private final int numKeys;
+  private final int startKey;
+  private final int numPartitions;
+  private final int queueSize;
+
+  @Inject
+  private PartitionedPSExampleREEF(@Parameter(JobTimeout.class) final long timeout,
+                                   @Parameter(NumWorkers.class) final int numWorkers,
+                                   @Parameter(NumUpdates.class) final int numUpdates,
+                                   @Parameter(NumKeys.class) final int numKeys,
+                                   @Parameter(StartKey.class) final int startKey,
+                                   @Parameter(NumPartitions.class) final int numPartitions,
+                                   @Parameter(QueueSize.class) final int queueSize) {
+    this.timeout = timeout;
+    this.numWorkers = numWorkers;
+    this.numUpdates = numUpdates;
+    this.numKeys = numKeys;
+    this.startKey = startKey;
+    this.numPartitions = numPartitions;
+    this.queueSize = queueSize;
+  }
+
+  private Configuration getDriverConf() {
+    final Configuration driverConf = DriverConfiguration.CONF
+        .set(DriverConfiguration.GLOBAL_LIBRARIES,
+            EnvironmentUtils.getClassLocation(PSExampleDriver.class))
+        .set(DriverConfiguration.DRIVER_IDENTIFIER, "PartitionedPSExample")
+        .set(DriverConfiguration.ON_DRIVER_STARTED,
+            PSExampleDriver.StartHandler.class)
+        .set(DriverConfiguration.ON_EVALUATOR_ALLOCATED,
+            PSExampleDriver.EvaluatorAllocatedHandler.class)
+        .set(DriverConfiguration.ON_CONTEXT_ACTIVE,
+            PSExampleDriver.ActiveContextHandler.class)
+        .set(DriverConfiguration.ON_TASK_RUNNING,
+            PSExampleDriver.RunningTaskHandler.class)
+        .set(DriverConfiguration.ON_TASK_COMPLETED,
+            PSExampleDriver.CompletedTaskHandler.class)
+        .build();
+
+    final Configuration parametersConf = Tang.Factory.getTang().newConfigurationBuilder()
+        .bindNamedParameter(NumWorkers.class, Integer.toString(numWorkers))
+        .bindNamedParameter(NumUpdates.class, Integer.toString(numUpdates))
+        .bindNamedParameter(NumKeys.class, Integer.toString(numKeys))
+        .bindNamedParameter(StartKey.class, Integer.toString(startKey))
+        .bindNamedParameter(NumPartitions.class, Integer.toString(numPartitions))
+        .bindNamedParameter(QueueSize.class, Integer.toString(queueSize))
+        .build();
+
+    final Configuration psConf = new ParameterServerConfigurationBuilder()
+        .setManagerClass(PartitionedParameterServerManager.class)
+        .setUpdaterClass(AddUpdater.class)
+        .setKeyCodecClass(IntegerCodec.class)
+        .setPreValueCodecClass(IntegerCodec.class)
+        .setValueCodecClass(IntegerCodec.class)
+        .build();
+
+    return Configurations.merge(driverConf, parametersConf, psConf);
+  }
+
+  private Configuration getRuntimeConfiguration() {
+    return getLocalRuntimeConfiguration();
+  }
+
+  private Configuration getLocalRuntimeConfiguration() {
+    return LocalRuntimeConfiguration.CONF
+        .set(LocalRuntimeConfiguration.MAX_NUMBER_OF_EVALUATORS, numWorkers + 1)
+        .build();
+  }
+
+  private LauncherStatus run() throws InjectionException {
+    return DriverLauncher.getLauncher(getRuntimeConfiguration()).run(getDriverConf(), timeout);
+  }
+
+  private static PartitionedPSExampleREEF parseCommandLine(final String[] args) throws IOException, InjectionException {
+    final JavaConfigurationBuilder cb = Tang.Factory.getTang().newConfigurationBuilder();
+    final CommandLine cl = new CommandLine(cb);
+    cl.registerShortNameOfClass(JobTimeout.class);
+    cl.registerShortNameOfClass(NumWorkers.class);
+    cl.registerShortNameOfClass(NumUpdates.class);
+    cl.registerShortNameOfClass(NumKeys.class);
+    cl.registerShortNameOfClass(StartKey.class);
+    cl.registerShortNameOfClass(NumPartitions.class);
+    cl.registerShortNameOfClass(QueueSize.class);
+
+    cl.processCommandLine(args);
+
+    return Tang.Factory.getTang().newInjector(cb.build()).getInstance(PartitionedPSExampleREEF.class);
+  }
+
+  public static void main(final String[] args) {
+    LauncherStatus status;
+    try {
+      final PartitionedPSExampleREEF singleNodePSExampleREEF = parseCommandLine(args);
+      status = singleNodePSExampleREEF.run();
+    } catch (final Exception e) {
+      LOG.log(Level.SEVERE, "Fatal exception occurred: {0}", e);
+      status = LauncherStatus.failed(e);
+    }
+    LOG.log(Level.INFO, "REEF job completed: {0}", status);
+  }
+}

--- a/dolphin-ps/src/main/java/edu/snu/dolphin/ps/examples/add/UpdaterTask.java
+++ b/dolphin-ps/src/main/java/edu/snu/dolphin/ps/examples/add/UpdaterTask.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C) 2016 Seoul National University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.snu.dolphin.ps.examples.add;
+
+import edu.snu.dolphin.ps.examples.add.parameters.NumKeys;
+import edu.snu.dolphin.ps.examples.add.parameters.StartKey;
+import edu.snu.dolphin.ps.examples.add.parameters.NumUpdates;
+import edu.snu.dolphin.ps.worker.api.ParameterWorker;
+import org.apache.reef.annotations.audience.TaskSide;
+import org.apache.reef.tang.annotations.Parameter;
+import org.apache.reef.task.Task;
+
+import javax.inject.Inject;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * The Updater Task that runs on all Workers.
+ * We run push updates that increment the value,
+ * numUpdates times (passed in from numUpdatesPerWorker on the Driver),
+ * in a round-robin order on keys in the range [startKey, startKey + numKeys).
+ * We then run pull on this key range.
+ * The result of the pull will be a _maximum_ of numUpdatesPerWorker * numWorkers (defined at Driver), i.e.
+ * reflecting the global total of updates.
+ * Some global updates may not have been processed yet. All updates will be accounted for in the ValidatorTask.
+ */
+@TaskSide
+public final class UpdaterTask implements Task {
+  private static final Logger LOG = Logger.getLogger(UpdaterTask.class.getName());
+
+  private final ParameterWorker<Integer, Integer, Integer> worker;
+  private final int startKey;
+  private final int numKeys;
+  private final int numUpdates;
+
+  @Inject
+  private UpdaterTask(final ParameterWorker<Integer, Integer, Integer> worker,
+                      @Parameter(StartKey.class) final int startKey,
+                      @Parameter(NumKeys.class) final int numKeys,
+                      @Parameter(NumUpdates.class) final int numUpdates) {
+    this.worker = worker;
+    this.startKey = startKey;
+    this.numKeys = numKeys;
+    this.numUpdates = numUpdates;
+  }
+
+  @Override
+  public byte[] call(final byte[] bytes) throws Exception {
+    LOG.log(Level.INFO, "Task.call() commencing...");
+    final int loggingInterval = numUpdates / 4;
+
+    for (int i = 0; i < numUpdates; i++) {
+      if (i % loggingInterval == 0) {
+        LOG.log(Level.INFO, "{0} updates complete", i);
+      }
+      worker.push(startKey + (i % numKeys), 1);
+    }
+
+    LOG.log(Level.INFO, "{0} updates complete", numUpdates);
+    for (int i = 0; i < numKeys; i++) {
+      final int pullResult = worker.pull(startKey + i);
+      LOG.log(Level.INFO, "Pull result for key {0}: {1}", new Object[]{startKey + i, pullResult});
+    }
+    LOG.log(Level.INFO, "{0} pulls complete", numKeys);
+
+    return null;
+  }
+}

--- a/dolphin-ps/src/main/java/edu/snu/dolphin/ps/examples/add/ValidatorTask.java
+++ b/dolphin-ps/src/main/java/edu/snu/dolphin/ps/examples/add/ValidatorTask.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2016 Seoul National University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.snu.dolphin.ps.examples.add;
+
+import edu.snu.dolphin.ps.examples.add.parameters.NumKeys;
+import edu.snu.dolphin.ps.examples.add.parameters.StartKey;
+import edu.snu.dolphin.ps.examples.add.parameters.NumUpdates;
+import edu.snu.dolphin.ps.examples.add.parameters.NumWorkers;
+import edu.snu.dolphin.ps.worker.api.ParameterWorker;
+import org.apache.reef.annotations.audience.TaskSide;
+import org.apache.reef.tang.annotations.Parameter;
+import org.apache.reef.task.Task;
+
+import javax.inject.Inject;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * The Validator Task that runs on a single Worker (the Worker that finishes Updater Task last).
+ * The expected result for each key is (numWorkers * numUpdates / numKeys), as each update increments the value by one.
+ * An exception is thrown if the expected result is not found.
+ */
+@TaskSide
+public final class ValidatorTask implements Task {
+  private static final Logger LOG = Logger.getLogger(ValidatorTask.class.getName());
+
+  private final ParameterWorker<Integer, Integer, Integer> worker;
+  private final int startKey;
+  private final int numKeys;
+  private final int numWorkers;
+  private final int numUpdates;
+
+  @Inject
+  private ValidatorTask(final ParameterWorker<Integer, Integer, Integer> worker,
+                        @Parameter(StartKey.class) final int startKey,
+                        @Parameter(NumKeys.class) final int numKeys,
+                        @Parameter(NumWorkers.class) final int numWorkers,
+                        @Parameter(NumUpdates.class) final int numUpdates) {
+    this.worker = worker;
+    this.startKey = startKey;
+    this.numKeys = numKeys;
+    this.numWorkers = numWorkers;
+    this.numUpdates = numUpdates;
+  }
+
+  @Override
+  public byte[] call(final byte[] bytes) throws Exception {
+    LOG.log(Level.INFO, "Task.call() commencing...");
+
+    final int expectedResult = numWorkers * numUpdates / numKeys;
+
+    for (int i = 0; i < numKeys; i++) {
+      final int result = worker.pull(startKey + i);
+
+      if (expectedResult != result) {
+        LOG.log(Level.SEVERE, "For key {0}, expected value {1} but received {2}",
+            new Object[]{startKey + i, expectedResult, result});
+        throw new RuntimeException(String.format("For key %d, expected value %d but received %d",
+            startKey + i, expectedResult, result));
+      } else {
+        LOG.log(Level.INFO, "For key {0}, received expected value {1}.", new Object[]{startKey + i, expectedResult});
+      }
+    }
+
+    return null;
+  }
+}

--- a/dolphin-ps/src/main/java/edu/snu/dolphin/ps/examples/add/package-info.java
+++ b/dolphin-ps/src/main/java/edu/snu/dolphin/ps/examples/add/package-info.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2016 Seoul National University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * A simple example that uses the Parameter Server and AddUpdater.
+ * It pushes updates from multiple workers by running UpdaterTask,
+ * then pulls and validates the resulting values by running ValidatorTask.
+ *
+ * The example has two main purposes:
+ *   1. It shows how a PS implementation can be configured.
+ *   2. It can also work as a simple load generator to test PS implementations.
+ */
+package edu.snu.dolphin.ps.examples.add;

--- a/dolphin-ps/src/main/java/edu/snu/dolphin/ps/examples/add/parameters/JobTimeout.java
+++ b/dolphin-ps/src/main/java/edu/snu/dolphin/ps/examples/add/parameters/JobTimeout.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 2016 Seoul National University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.snu.dolphin.ps.examples.add.parameters;
+
+import org.apache.reef.tang.annotations.Name;
+import org.apache.reef.tang.annotations.NamedParameter;
+
+@NamedParameter(doc = "Job Timeout in ms", default_value = "15000", short_name = "timeout")
+public final class JobTimeout implements Name<Long> {
+}

--- a/dolphin-ps/src/main/java/edu/snu/dolphin/ps/examples/add/parameters/NumKeys.java
+++ b/dolphin-ps/src/main/java/edu/snu/dolphin/ps/examples/add/parameters/NumKeys.java
@@ -19,6 +19,7 @@ import org.apache.reef.tang.annotations.Name;
 import org.apache.reef.tang.annotations.NamedParameter;
 
 @NamedParameter(doc = "Number of keys to apply updates on: updates are done on [KeyStart, KeyStart + NumKeys)",
-    default_value = "8")
+                default_value = "8",
+                short_name = "numKeys")
 public final class NumKeys implements Name<Integer> {
 }

--- a/dolphin-ps/src/main/java/edu/snu/dolphin/ps/examples/add/parameters/NumKeys.java
+++ b/dolphin-ps/src/main/java/edu/snu/dolphin/ps/examples/add/parameters/NumKeys.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2016 Seoul National University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.snu.dolphin.ps.examples.add.parameters;
+
+import org.apache.reef.tang.annotations.Name;
+import org.apache.reef.tang.annotations.NamedParameter;
+
+@NamedParameter(doc = "Number of keys to apply updates on: updates are done on [KeyStart, KeyStart + NumKeys)",
+    default_value = "8")
+public final class NumKeys implements Name<Integer> {
+}

--- a/dolphin-ps/src/main/java/edu/snu/dolphin/ps/examples/add/parameters/NumUpdates.java
+++ b/dolphin-ps/src/main/java/edu/snu/dolphin/ps/examples/add/parameters/NumUpdates.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 2016 Seoul National University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.snu.dolphin.ps.examples.add.parameters;
+
+import org.apache.reef.tang.annotations.Name;
+import org.apache.reef.tang.annotations.NamedParameter;
+
+@NamedParameter(doc = "Number of updates to apply per worker", default_value = "100", short_name = "numUpdates")
+public final class NumUpdates implements Name<Integer> {
+}

--- a/dolphin-ps/src/main/java/edu/snu/dolphin/ps/examples/add/parameters/NumWorkers.java
+++ b/dolphin-ps/src/main/java/edu/snu/dolphin/ps/examples/add/parameters/NumWorkers.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 2016 Seoul National University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.snu.dolphin.ps.examples.add.parameters;
+
+import org.apache.reef.tang.annotations.Name;
+import org.apache.reef.tang.annotations.NamedParameter;
+
+@NamedParameter(doc = "Number of workers to run updater tasks on", default_value = "1", short_name = "numWorkers")
+public final class NumWorkers implements Name<Integer> {
+}

--- a/dolphin-ps/src/main/java/edu/snu/dolphin/ps/examples/add/parameters/StartKey.java
+++ b/dolphin-ps/src/main/java/edu/snu/dolphin/ps/examples/add/parameters/StartKey.java
@@ -19,6 +19,7 @@ import org.apache.reef.tang.annotations.Name;
 import org.apache.reef.tang.annotations.NamedParameter;
 
 @NamedParameter(doc = "Start key to apply updates on: updates are done on [KeyStart, KeyStart + NumKeys)",
-    default_value = "0")
+                default_value = "0",
+                short_name = "startKey")
 public final class StartKey implements Name<Integer> {
 }

--- a/dolphin-ps/src/main/java/edu/snu/dolphin/ps/examples/add/parameters/StartKey.java
+++ b/dolphin-ps/src/main/java/edu/snu/dolphin/ps/examples/add/parameters/StartKey.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2016 Seoul National University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.snu.dolphin.ps.examples.add.parameters;
+
+import org.apache.reef.tang.annotations.Name;
+import org.apache.reef.tang.annotations.NamedParameter;
+
+@NamedParameter(doc = "Start key to apply updates on: updates are done on [KeyStart, KeyStart + NumKeys)",
+    default_value = "0")
+public final class StartKey implements Name<Integer> {
+}

--- a/dolphin-ps/src/main/java/edu/snu/dolphin/ps/examples/add/parameters/package-info.java
+++ b/dolphin-ps/src/main/java/edu/snu/dolphin/ps/examples/add/parameters/package-info.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright (C) 2016 Seoul National University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Parameters related to PS examples.
+ */
+package edu.snu.dolphin.ps.examples.add.parameters;

--- a/dolphin-ps/src/main/java/edu/snu/dolphin/ps/ns/PSNetworkSetup.java
+++ b/dolphin-ps/src/main/java/edu/snu/dolphin/ps/ns/PSNetworkSetup.java
@@ -28,7 +28,7 @@ import org.apache.reef.wake.IdentifierFactory;
 import javax.inject.Inject;
 
 /**
- * Register and unregister an evaluator to Network Connection Service, and open connections to other evaluators.
+ * Register and unregister an evaluator to/from Network Connection Service, and open connections to other evaluators.
  */
 public final class PSNetworkSetup {
   private static final String PARAMETER_SERVER_IDENTIFIER = "PS";

--- a/dolphin-ps/src/main/java/edu/snu/dolphin/ps/server/api/ParameterUpdater.java
+++ b/dolphin-ps/src/main/java/edu/snu/dolphin/ps/server/api/ParameterUpdater.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package edu.snu.dolphin.ps.server;
+package edu.snu.dolphin.ps.server.api;
 
 /**
  * A Parameter Server updater that handles preValues sent from workers before they are stored at the server.

--- a/dolphin-ps/src/main/java/edu/snu/dolphin/ps/server/api/package-info.java
+++ b/dolphin-ps/src/main/java/edu/snu/dolphin/ps/server/api/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 Seoul National University
+ * Copyright (C) 2016 Seoul National University
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,6 +14,6 @@
  * limitations under the License.
  */
 /**
- * Parameter Server classes that are instantiated at the driver.
+ * Interfaces for server-side Parameter Server classes that can have several pluggable implementations.
  */
-package edu.snu.dolphin.ps.driver;
+package edu.snu.dolphin.ps.server.api;

--- a/dolphin-ps/src/main/java/edu/snu/dolphin/ps/server/concurrent/api/ParameterServer.java
+++ b/dolphin-ps/src/main/java/edu/snu/dolphin/ps/server/concurrent/api/ParameterServer.java
@@ -13,13 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package edu.snu.dolphin.ps.server;
+package edu.snu.dolphin.ps.server.concurrent.api;
 
+import edu.snu.dolphin.ps.server.concurrent.impl.ValueEntry;
 import org.apache.reef.annotations.audience.EvaluatorSide;
 
 /**
  * A Parameter Server server that interacts with workers (clients) and stores parameters in the form of a k-v store.
- * Works as a set with {@link edu.snu.dolphin.ps.worker.ParameterWorker}.
+ * Works as a set with {@link edu.snu.dolphin.ps.worker.api.ParameterWorker}.
  * @param <K> class type of parameter keys
  * @param <P> class type of parameter values before they are processed at the server
  * @param <V> class type of parameter values after they are processed at the server

--- a/dolphin-ps/src/main/java/edu/snu/dolphin/ps/server/concurrent/api/ServerSideMsgSender.java
+++ b/dolphin-ps/src/main/java/edu/snu/dolphin/ps/server/concurrent/api/ServerSideMsgSender.java
@@ -13,32 +13,26 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package edu.snu.dolphin.ps.worker;
+package edu.snu.dolphin.ps.server.concurrent.api;
 
+import edu.snu.dolphin.ps.server.concurrent.impl.ServerSideMsgSenderImpl;
+import edu.snu.dolphin.ps.server.concurrent.impl.ValueEntry;
 import org.apache.reef.annotations.audience.EvaluatorSide;
 import org.apache.reef.tang.annotations.DefaultImplementation;
 
 /**
- * Worker-side Parameter Server message sender.
+ * Server-side Parameter Server message sender.
  */
 @EvaluatorSide
-@DefaultImplementation(WorkerSideMsgSenderImpl.class)
-public interface WorkerSideMsgSender<K, P> {
+@DefaultImplementation(ServerSideMsgSenderImpl.class)
+public interface ServerSideMsgSender<K, V> {
 
   /**
-   * Send a key-value pair to another evaluator.
+   * Send a reply to another evaluator that requested a certain value.
+   * This message is a reply to a {@link edu.snu.dolphin.ps.avro.PullMsg}.
    * @param destId Network Connection Service identifier of the destination evaluator
-   * @param key key object representing what is being sent
-   * @param preValue value to be sent to the destination
+   * @param key key object associated with the expected value
+   * @param valueEntry {@link ValueEntry} object containing the requested value
    */
-  void sendPushMsg(final String destId, final K key, final P preValue);
-
-  /**
-   * Send a request to another evaluator for fetching a certain value.
-   * After this message, a {@link edu.snu.dolphin.ps.avro.ReplyMsg} containing the requested value
-   * should be sent from the destination as a reply.
-   * @param destId Network Connection Service identifier of the destination evaluator
-   * @param key key object representing the expected value
-   */
-  void sendPullMsg(final String destId, final K key);
+  void sendReplyMsg(final String destId, final K key, final ValueEntry<V> valueEntry);
 }

--- a/dolphin-ps/src/main/java/edu/snu/dolphin/ps/server/concurrent/api/package-info.java
+++ b/dolphin-ps/src/main/java/edu/snu/dolphin/ps/server/concurrent/api/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 Seoul National University
+ * Copyright (C) 2016 Seoul National University
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,6 +14,6 @@
  * limitations under the License.
  */
 /**
- * Parameter Server classes that are instantiated at the driver.
+ * Interfaces for server-side Parameter Server classes that can have several pluggable implementations.
  */
-package edu.snu.dolphin.ps.driver;
+package edu.snu.dolphin.ps.server.concurrent.api;

--- a/dolphin-ps/src/main/java/edu/snu/dolphin/ps/server/concurrent/impl/ConcurrentParameterServer.java
+++ b/dolphin-ps/src/main/java/edu/snu/dolphin/ps/server/concurrent/impl/ConcurrentParameterServer.java
@@ -13,8 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package edu.snu.dolphin.ps.server;
+package edu.snu.dolphin.ps.server.concurrent.impl;
 
+import edu.snu.dolphin.ps.server.concurrent.api.ParameterServer;
+import edu.snu.dolphin.ps.server.api.ParameterUpdater;
 import org.apache.reef.annotations.audience.EvaluatorSide;
 
 import javax.inject.Inject;
@@ -27,7 +29,7 @@ import java.util.concurrent.ConcurrentMap;
  * This class is thread-safe if and only if {@link ParameterUpdater} is thread-safe.
  */
 @EvaluatorSide
-public final class SingleNodeParameterServer<K, P, V> implements ParameterServer<K, P, V> {
+public final class ConcurrentParameterServer<K, P, V> implements ParameterServer<K, P, V> {
 
   /**
    * A map holding keys and values sent from workers.
@@ -40,7 +42,7 @@ public final class SingleNodeParameterServer<K, P, V> implements ParameterServer
   private final ParameterUpdater<K, P, V> parameterUpdater;
 
   @Inject
-  private SingleNodeParameterServer(final ParameterUpdater<K, P, V> parameterUpdater) {
+  private ConcurrentParameterServer(final ParameterUpdater<K, P, V> parameterUpdater) {
     this.kvStore = new ConcurrentHashMap<>();
     this.parameterUpdater = parameterUpdater;
   }

--- a/dolphin-ps/src/main/java/edu/snu/dolphin/ps/server/concurrent/impl/ServerSideMsgHandler.java
+++ b/dolphin-ps/src/main/java/edu/snu/dolphin/ps/server/concurrent/impl/ServerSideMsgHandler.java
@@ -13,13 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package edu.snu.dolphin.ps.server;
+package edu.snu.dolphin.ps.server.concurrent.impl;
 
 import edu.snu.dolphin.ps.ParameterServerParameters.KeyCodecName;
 import edu.snu.dolphin.ps.ParameterServerParameters.PreValueCodecName;
 import edu.snu.dolphin.ps.avro.AvroParameterServerMsg;
 import edu.snu.dolphin.ps.avro.PullMsg;
 import edu.snu.dolphin.ps.avro.PushMsg;
+import edu.snu.dolphin.ps.server.concurrent.api.ParameterServer;
+import edu.snu.dolphin.ps.server.concurrent.api.ServerSideMsgSender;
 import edu.snu.dolphin.util.SingleMessageExtractor;
 import org.apache.reef.annotations.audience.EvaluatorSide;
 import org.apache.reef.io.network.Message;

--- a/dolphin-ps/src/main/java/edu/snu/dolphin/ps/server/concurrent/impl/ServerSideMsgSenderImpl.java
+++ b/dolphin-ps/src/main/java/edu/snu/dolphin/ps/server/concurrent/impl/ServerSideMsgSenderImpl.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package edu.snu.dolphin.ps.server;
+package edu.snu.dolphin.ps.server.concurrent.impl;
 
 import edu.snu.dolphin.ps.ParameterServerParameters.KeyCodecName;
 import edu.snu.dolphin.ps.ParameterServerParameters.ValueCodecName;
@@ -21,6 +21,7 @@ import edu.snu.dolphin.ps.avro.AvroParameterServerMsg;
 import edu.snu.dolphin.ps.avro.ReplyMsg;
 import edu.snu.dolphin.ps.avro.Type;
 import edu.snu.dolphin.ps.ns.PSNetworkSetup;
+import edu.snu.dolphin.ps.server.concurrent.api.ServerSideMsgSender;
 import org.apache.reef.annotations.audience.EvaluatorSide;
 import org.apache.reef.exception.evaluator.NetworkException;
 import org.apache.reef.io.network.Connection;

--- a/dolphin-ps/src/main/java/edu/snu/dolphin/ps/server/concurrent/impl/ValueEntry.java
+++ b/dolphin-ps/src/main/java/edu/snu/dolphin/ps/server/concurrent/impl/ValueEntry.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package edu.snu.dolphin.ps.server;
+package edu.snu.dolphin.ps.server.concurrent.impl;
 
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;

--- a/dolphin-ps/src/main/java/edu/snu/dolphin/ps/server/concurrent/impl/package-info.java
+++ b/dolphin-ps/src/main/java/edu/snu/dolphin/ps/server/concurrent/impl/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 Seoul National University
+ * Copyright (C) 2016 Seoul National University
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,6 +14,6 @@
  * limitations under the License.
  */
 /**
- * Parameter Server classes that are instantiated at the driver.
+ * Implementations for server-side Parameter Server classes in {@link edu.snu.dolphin.ps.server.concurrent.api}.
  */
-package edu.snu.dolphin.ps.driver;
+package edu.snu.dolphin.ps.server.concurrent.impl;

--- a/dolphin-ps/src/main/java/edu/snu/dolphin/ps/server/package-info.java
+++ b/dolphin-ps/src/main/java/edu/snu/dolphin/ps/server/package-info.java
@@ -14,6 +14,6 @@
  * limitations under the License.
  */
 /**
- * Classes that are instantiated at an evaluator that acts as a Parameter Server.
+ * Server-side Parameter Server classes.
  */
 package edu.snu.dolphin.ps.server;

--- a/dolphin-ps/src/main/java/edu/snu/dolphin/ps/server/partitioned/PartitionedParameterServer.java
+++ b/dolphin-ps/src/main/java/edu/snu/dolphin/ps/server/partitioned/PartitionedParameterServer.java
@@ -1,0 +1,312 @@
+/*
+ * Copyright (C) 2016 Seoul National University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.snu.dolphin.ps.server.partitioned;
+
+import edu.snu.dolphin.ps.server.api.ParameterUpdater;
+import edu.snu.dolphin.ps.server.partitioned.parameters.NumPartitions;
+import edu.snu.dolphin.ps.server.partitioned.parameters.QueueSize;
+import org.apache.reef.annotations.audience.EvaluatorSide;
+import org.apache.reef.tang.annotations.Parameter;
+
+import javax.inject.Inject;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * A Partitioned Parameter Server.
+ * Receives push and pull operations from (e.g., from the network) and immediately queues them.
+ * The processing loop (for each partition) applies these operations in order; for pull operations
+ * this results in a send call via {@link PartitionedServerSideReplySender}.
+ * For more information about the partition implementation, see {@link Partition}.
+ *
+ * Supports a static number of partitions (the number of partitions is fixed at construction time).
+ */
+@EvaluatorSide
+public final class PartitionedParameterServer<K, P, V> {
+  private static final Logger LOG = Logger.getLogger(PartitionedParameterServer.class.getName());
+
+  /**
+   * Number of partitions.
+   */
+  private final int numPartitions;
+
+  /**
+   * Max size of each partition's queue.
+   */
+  private final int queueSize;
+
+  /**
+   * Thread pool, where each Partition is submitted.
+   */
+  private final ExecutorService threadPool;
+
+  /**
+   * Running partitions.
+   */
+  private final Partition<K, V>[] partitions;
+
+  /**
+   * Object for processing preValues and applying updates to existing values.
+   */
+  private final ParameterUpdater<K, P, V> parameterUpdater;
+
+  /**
+   * Sender that sends pull responses.
+   */
+  private final PartitionedServerSideReplySender sender;
+
+  @Inject
+  private PartitionedParameterServer(@Parameter(NumPartitions.class) final int numPartitions,
+                                     @Parameter(QueueSize.class) final int queueSize,
+                                     final ParameterUpdater<K, P, V> parameterUpdater,
+                                     final PartitionedServerSideReplySender sender) {
+    this.numPartitions = numPartitions;
+    this.queueSize = queueSize;
+    this.threadPool = Executors.newFixedThreadPool(numPartitions);
+    this.partitions = initPartitions();
+    this.parameterUpdater = parameterUpdater;
+    this.sender = sender;
+  }
+
+  /**
+   * Call after initializing numPartitions and threadPool.
+   */
+  @SuppressWarnings("unchecked")
+  private Partition<K, V>[] initPartitions() {
+    LOG.log(Level.INFO, "Initializing {0} partitions", numPartitions);
+    final Partition<K, V>[] initialized = new Partition[numPartitions];
+    for (int i = 0; i < numPartitions; i++) {
+      initialized[i] = new Partition<>(queueSize);
+      threadPool.submit(initialized[i]);
+    }
+    return initialized;
+  }
+
+  /**
+   * Process a {@code preValue} sent from a worker and store the resulting value.
+   * Uses {@link ParameterUpdater} to generate a value from {@code preValue} and to apply the generated value to
+   * the k-v store.
+   *
+   * The push operation is enqueued to its partition and returned immediately.
+   *
+   * @param key key object that {@code preValue} is associated with
+   * @param preValue preValue sent from the worker
+   */
+  public void push(final K key, final P preValue) {
+    partitions[getPartitionIndex(key)].enqueue(new PushOp(key, preValue));
+  }
+
+  /**
+   * Reply to srcId via {@link PartitionedServerSideReplySender}
+   * with the value corresponding to the key.
+   *
+   * The pull operation is enqueued to its partition and returned immediately.
+   *
+   * @param key key object that the requested {@code value} is associated with
+   * @param srcId network Id of the requester
+   */
+  public void pull(final K key, final String srcId) {
+    partitions[getPartitionIndex(key)].enqueue(new PullOp(key, srcId));
+  }
+
+  private int getPartitionIndex(final K key) {
+    return key.hashCode() % numPartitions;
+  }
+
+  /**
+   * @return number of operations pending, on all queues
+   */
+  public int opsPending() {
+    int sum = 0;
+    for (int i = 0; i < numPartitions; i++) {
+      sum += partitions[i].opsPending();
+    }
+    return sum;
+  }
+
+  /**
+   * A generic operation; operations are queued at each Partition.
+   */
+  private interface Op<K, V> {
+    /**
+     * Method to apply when dequeued by the Partition.
+     * @param kvStore the raw kvStore map, provided by the Partition.
+     */
+    void apply(Map<K, V> kvStore);
+  }
+
+  /**
+   * A push operation.
+   */
+  private class PushOp implements Op<K, V> {
+    private final K key;
+    private final P preValue;
+
+    public PushOp(final K key, final P preValue) {
+      this.key = key;
+      this.preValue = preValue;
+    }
+
+    /**
+     * Read from kvStore, modify (update), and write to kvStore.
+     */
+    @Override
+    public void apply(final Map<K, V> kvStore) {
+      if (!kvStore.containsKey(key)) {
+        kvStore.put(key, parameterUpdater.initValue(key));
+      }
+
+      final V deltaValue = parameterUpdater.process(key, preValue);
+      if (deltaValue == null) {
+        return;
+      }
+
+      final V updatedValue = parameterUpdater.update(kvStore.get(key), deltaValue);
+      kvStore.put(key, updatedValue);
+    }
+  }
+
+  /**
+   * A pull operation.
+   */
+  private class PullOp implements Op<K, V> {
+    private final K key;
+    private final String srcId;
+
+    public PullOp(final K key, final String srcId) {
+      this.key = key;
+      this.srcId = srcId;
+    }
+
+    /**
+     * Read from kvStore and send the key-value pair to srcId.
+     * To ensure atomicity, the key-value pair should be serialized immediately in sender.
+     */
+    @Override
+    public void apply(final Map<K, V> kvStore) {
+      if (!kvStore.containsKey(key)) {
+        kvStore.put(key, parameterUpdater.initValue(key));
+      }
+
+      sender.sendReplyMsg(srcId, key, kvStore.get(key));
+    }
+  }
+
+  /**
+   * A partition of the parameter server. Must be started as a thread.
+   * All push and pull operations should be sent to the appropriate partition.
+   * The partition's processing loop dequeues and applies operations to its local kvStore.
+   * The queue and single thread per partition ensures that all operations on a key
+   * are performed atomically, in order (no updates can be lost).
+   *
+   * The single queue-and-thread design provides a simple guarantee of atomicity for applying operations.
+   * It also means pull operations are queued behind push operations.
+   * This ensures that pull operations return with up-to-date information (for a single client, this
+   * is basically read-your-writes).
+   * However, it also means that pull operations may take awhile to process.
+   * Workers block for pulls, while sending pushes asynchronously.
+   * We should further explore this trade-off with real ML workloads.
+   */
+  private static class Partition<K, V> implements Runnable {
+    private static final long QUEUE_TIMEOUT_MS = 3000;
+
+    private final Map<K, V> kvStore;
+    private final BlockingQueue<Op<K, V>> queue;
+    private final ArrayList<Op<K, V>> localOps; // Operations drained from the queue, and processed locally.
+    private final int drainSize; // Max number of operations to drain per iteration.
+
+    private volatile boolean shutdown = false;
+
+    public Partition(final int queueSize) {
+      this.kvStore = new HashMap<>();
+      this.queue = new ArrayBlockingQueue<>(queueSize);
+      this.drainSize = queueSize / 10;
+      this.localOps = new ArrayList<>(drainSize);
+    }
+
+    /**
+     * Enqueue an operation onto the queue, blocking if the queue is full.
+     * When the queue is full, this method will block; thus, a full queue will block the thread calling
+     * enqueue, e.g., from the NCS message thread pool, until the queue is drained. This seems reasonable,
+     * as it will block client messages from being processed and overloading the system.
+     *
+     * An alternative would be to send a "busy" message in response, and have
+     * the client resend the operation. This will require changes in the client as well.
+     *
+     * @param op the operation to enqueue
+     */
+    public void enqueue(final Op<K, V> op) {
+      try {
+        queue.put(op);
+      } catch (final InterruptedException e) {
+        LOG.log(Level.SEVERE, "Enqueue failed with InterruptedException", e);
+        return;
+      }
+    }
+
+    /**
+     * @return number of pending operations in the queue.
+     */
+    public int opsPending() {
+      return queue.size();
+    }
+
+    /**
+     * Loop that dequeues operations and applies them.
+     * Dequeues is only performed through this thread.
+     */
+    @Override
+    public void run() {
+      while (!shutdown) {
+        // First, poll and apply. The timeout allows the run thread to shutdown cleanly within timeout ms.
+        try {
+          final Op<K, V> op = queue.poll(QUEUE_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+          if (op == null) {
+            continue;
+          }
+          op.apply(kvStore);
+        } catch (final InterruptedException e) {
+          LOG.log(Level.SEVERE, "Poll failed with InterruptedException", e);
+          continue;
+        }
+
+        // Then, drain up to LOCAL_OPS_SIZE of the remaining queue and apply.
+        // Calling drainTo does not block if queue is empty, which is why we poll first.
+        // This should be faster than polling each op, because the blocking queue's lock is only acquired once.
+        queue.drainTo(localOps, drainSize);
+        for (final Op<K, V> op : localOps) {
+          op.apply(kvStore);
+        }
+        localOps.clear();
+      }
+    }
+
+    /**
+     * Cleanly shutdown the run thread.
+     */
+    public void shutdown() {
+      shutdown = true;
+    }
+  }
+}

--- a/dolphin-ps/src/main/java/edu/snu/dolphin/ps/server/partitioned/PartitionedServerSideMsgHandler.java
+++ b/dolphin-ps/src/main/java/edu/snu/dolphin/ps/server/partitioned/PartitionedServerSideMsgHandler.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (C) 2016 Seoul National University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.snu.dolphin.ps.server.partitioned;
+
+import edu.snu.dolphin.ps.ParameterServerParameters.KeyCodecName;
+import edu.snu.dolphin.ps.ParameterServerParameters.PreValueCodecName;
+import edu.snu.dolphin.ps.avro.AvroParameterServerMsg;
+import edu.snu.dolphin.ps.avro.PullMsg;
+import edu.snu.dolphin.ps.avro.PushMsg;
+import edu.snu.dolphin.util.SingleMessageExtractor;
+import org.apache.reef.annotations.audience.EvaluatorSide;
+import org.apache.reef.io.network.Message;
+import org.apache.reef.io.serialization.Codec;
+import org.apache.reef.tang.annotations.Parameter;
+import org.apache.reef.wake.EventHandler;
+
+import javax.inject.Inject;
+import java.util.logging.Logger;
+
+/**
+ * Server-side Parameter Server message handler.
+ * Decode messages and call the appropriate {@link PartitionedParameterServer} method.
+ */
+@EvaluatorSide
+public final class PartitionedServerSideMsgHandler<K, P, V> implements EventHandler<Message<AvroParameterServerMsg>> {
+  private static final Logger LOG = Logger.getLogger(PartitionedServerSideMsgHandler.class.getName());
+
+  /**
+   * The Partitioned Parameter Server.
+   */
+  private final PartitionedParameterServer<K, P, V> parameterServer;
+
+  /**
+   * Codec for decoding PS keys.
+   */
+  private final Codec<K> keyCodec;
+
+  /**
+   * Codec for decoding PS preValues.
+   */
+  private final Codec<P> preValueCodec;
+
+  @Inject
+  private PartitionedServerSideMsgHandler(final PartitionedParameterServer<K, P, V> parameterServer,
+                                          @Parameter(KeyCodecName.class) final Codec<K> keyCodec,
+                                          @Parameter(PreValueCodecName.class) final Codec<P> preValueCodec) {
+    this.parameterServer = parameterServer;
+    this.keyCodec = keyCodec;
+    this.preValueCodec = preValueCodec;
+  }
+
+  /**
+   * Hand over values given from workers to {@link PartitionedParameterServer}.
+   * Throws an exception if messages of an unexpected type arrive.
+   */
+  @Override
+  public void onNext(final Message<AvroParameterServerMsg> msg) {
+    LOG.entering(PartitionedServerSideMsgHandler.class.getSimpleName(), "onNext");
+
+    final AvroParameterServerMsg innerMsg = SingleMessageExtractor.extract(msg);
+    switch (innerMsg.getType()) {
+    case PushMsg:
+      onPushMsg(innerMsg.getPushMsg());
+      break;
+
+    case PullMsg:
+      onPullMsg(innerMsg.getPullMsg());
+      break;
+
+    default:
+      throw new RuntimeException("Unexpected message type: " + innerMsg.getType().toString());
+    }
+
+    LOG.exiting(PartitionedServerSideMsgHandler.class.getSimpleName(), "onNext");
+  }
+
+  private void onPushMsg(final PushMsg pushMsg) {
+    final K key = keyCodec.decode(pushMsg.getKey().array());
+    final P preValue = preValueCodec.decode(pushMsg.getPreValue().array());
+    parameterServer.push(key, preValue);
+  }
+
+  private void onPullMsg(final PullMsg pullMsg) {
+    final String srcId = pullMsg.getSrcId().toString();
+    final K key = keyCodec.decode(pullMsg.getKey().array());
+    parameterServer.pull(key, srcId);
+  }
+}

--- a/dolphin-ps/src/main/java/edu/snu/dolphin/ps/server/partitioned/PartitionedServerSideReplySender.java
+++ b/dolphin-ps/src/main/java/edu/snu/dolphin/ps/server/partitioned/PartitionedServerSideReplySender.java
@@ -13,11 +13,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package edu.snu.dolphin.ps.examples.add.parameters;
+package edu.snu.dolphin.ps.server.partitioned;
 
-import org.apache.reef.tang.annotations.Name;
-import org.apache.reef.tang.annotations.NamedParameter;
-
-@NamedParameter(doc = "Total number of updates", default_value = "100", short_name = "numUpdates")
-public final class NumUpdates implements Name<Integer> {
+/**
+ * Sender for PartitionedParameterServer.
+ */
+public interface PartitionedServerSideReplySender<K, V> {
+  /**
+   * Implementing classes must serialize K, V immediately within the calling thread,
+   * to ensure atomicity of updates.
+   * @param destId the destination's network address
+   * @param key key, to be serialized immediately
+   * @param value value, to be serialized immediately
+   */
+  void sendReplyMsg(String destId, K key, V value);
 }

--- a/dolphin-ps/src/main/java/edu/snu/dolphin/ps/server/partitioned/PartitionedServerSideReplySenderImpl.java
+++ b/dolphin-ps/src/main/java/edu/snu/dolphin/ps/server/partitioned/PartitionedServerSideReplySenderImpl.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (C) 2016 Seoul National University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.snu.dolphin.ps.server.partitioned;
+
+import edu.snu.dolphin.ps.ParameterServerParameters;
+import edu.snu.dolphin.ps.avro.AvroParameterServerMsg;
+import edu.snu.dolphin.ps.avro.ReplyMsg;
+import edu.snu.dolphin.ps.avro.Type;
+import edu.snu.dolphin.ps.ns.PSNetworkSetup;
+import org.apache.reef.annotations.audience.EvaluatorSide;
+import org.apache.reef.exception.evaluator.NetworkException;
+import org.apache.reef.io.network.Connection;
+import org.apache.reef.io.serialization.Codec;
+import org.apache.reef.tang.InjectionFuture;
+import org.apache.reef.tang.annotations.Parameter;
+import org.apache.reef.wake.IdentifierFactory;
+
+import javax.inject.Inject;
+import java.nio.ByteBuffer;
+
+/**
+ * Sender implementation that uses Network Connection Service.
+ */
+@EvaluatorSide
+public final class PartitionedServerSideReplySenderImpl<K, V> implements PartitionedServerSideReplySender<K, V> {
+
+  /**
+   * Network Connection Service related setup required for a Parameter Server application.
+   */
+  private final InjectionFuture<PSNetworkSetup> psNetworkSetup;
+
+  /**
+   * Required for using Network Connection Service API.
+   */
+  private final IdentifierFactory identifierFactory;
+
+  /**
+   * Codec for encoding PS keys.
+   */
+  private final Codec<K> keyCodec;
+
+  /**
+   * Codec for encoding PS values.
+   */
+  private final Codec<V> valueCodec;
+
+  @Inject
+  private PartitionedServerSideReplySenderImpl(
+      final InjectionFuture<PSNetworkSetup> psNetworkSetup,
+      final IdentifierFactory identifierFactory,
+      @Parameter(ParameterServerParameters.KeyCodecName.class) final Codec<K> keyCodec,
+      @Parameter(ParameterServerParameters.ValueCodecName.class) final Codec<V> valueCodec) {
+
+    this.psNetworkSetup = psNetworkSetup;
+    this.identifierFactory = identifierFactory;
+    this.keyCodec = keyCodec;
+    this.valueCodec = valueCodec;
+  }
+
+  private void send(final String destId, final AvroParameterServerMsg msg) {
+    final Connection<AvroParameterServerMsg> conn = psNetworkSetup.get().getConnectionFactory()
+        .newConnection(identifierFactory.getNewInstance(destId));
+    try {
+      conn.open();
+      conn.write(msg);
+    } catch (final NetworkException ex) {
+      throw new RuntimeException("NetworkException during connection open/write", ex);
+    }
+  }
+
+  /**
+   * Send an Avro message via NetworkConnectionService.
+   */
+  @Override
+  public void sendReplyMsg(final String destId, final K key, final V value) {
+    final ReplyMsg replyMsg = ReplyMsg.newBuilder()
+        .setKey(ByteBuffer.wrap(keyCodec.encode(key)))
+        .setValue(ByteBuffer.wrap(valueCodec.encode(value)))
+        .build();
+
+    send(destId,
+        AvroParameterServerMsg.newBuilder()
+            .setType(Type.ReplyMsg)
+            .setReplyMsg(replyMsg)
+            .build());
+  }
+}

--- a/dolphin-ps/src/main/java/edu/snu/dolphin/ps/server/partitioned/package-info.java
+++ b/dolphin-ps/src/main/java/edu/snu/dolphin/ps/server/partitioned/package-info.java
@@ -13,11 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package edu.snu.dolphin.ps.examples.add.parameters;
-
-import org.apache.reef.tang.annotations.Name;
-import org.apache.reef.tang.annotations.NamedParameter;
-
-@NamedParameter(doc = "Total number of updates", default_value = "100", short_name = "numUpdates")
-public final class NumUpdates implements Name<Integer> {
-}
+/**
+ * A Partitioned Parameter Server, that supports atomic, in-order processing of push and pull operations.
+ * Partitions are based on the hash of the key.
+ * Each partition consists of a queue, kvStore, and thread.
+ * Operations are immediately added to the queue, so the message processing threads will not block,
+ * except when the queue is full.
+ */
+package edu.snu.dolphin.ps.server.partitioned;

--- a/dolphin-ps/src/main/java/edu/snu/dolphin/ps/server/partitioned/parameters/NumPartitions.java
+++ b/dolphin-ps/src/main/java/edu/snu/dolphin/ps/server/partitioned/parameters/NumPartitions.java
@@ -13,11 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package edu.snu.dolphin.ps.examples.add.parameters;
+package edu.snu.dolphin.ps.server.partitioned.parameters;
 
 import org.apache.reef.tang.annotations.Name;
 import org.apache.reef.tang.annotations.NamedParameter;
 
-@NamedParameter(doc = "Total number of updates", default_value = "100", short_name = "numUpdates")
-public final class NumUpdates implements Name<Integer> {
+@NamedParameter(doc = "Number of partitions", default_value = "2", short_name = "numPartitions")
+public final class NumPartitions implements Name<Integer> {
 }

--- a/dolphin-ps/src/main/java/edu/snu/dolphin/ps/server/partitioned/parameters/QueueSize.java
+++ b/dolphin-ps/src/main/java/edu/snu/dolphin/ps/server/partitioned/parameters/QueueSize.java
@@ -13,11 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package edu.snu.dolphin.ps.examples.add.parameters;
+package edu.snu.dolphin.ps.server.partitioned.parameters;
 
 import org.apache.reef.tang.annotations.Name;
 import org.apache.reef.tang.annotations.NamedParameter;
 
-@NamedParameter(doc = "Total number of updates", default_value = "100", short_name = "numUpdates")
-public final class NumUpdates implements Name<Integer> {
+@NamedParameter(doc = "Max number of items that can be queued for each partition", default_value = "1000",
+    short_name = "queueSize")
+public final class QueueSize implements Name<Integer> {
 }

--- a/dolphin-ps/src/main/java/edu/snu/dolphin/ps/server/partitioned/parameters/package-info.java
+++ b/dolphin-ps/src/main/java/edu/snu/dolphin/ps/server/partitioned/parameters/package-info.java
@@ -13,11 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package edu.snu.dolphin.ps.examples.add.parameters;
-
-import org.apache.reef.tang.annotations.Name;
-import org.apache.reef.tang.annotations.NamedParameter;
-
-@NamedParameter(doc = "Total number of updates", default_value = "100", short_name = "numUpdates")
-public final class NumUpdates implements Name<Integer> {
-}
+/**
+ * Parameters related to Partitioned PS.
+ */
+package edu.snu.dolphin.ps.server.partitioned.parameters;

--- a/dolphin-ps/src/main/java/edu/snu/dolphin/ps/worker/WorkerSideMsgHandler.java
+++ b/dolphin-ps/src/main/java/edu/snu/dolphin/ps/worker/WorkerSideMsgHandler.java
@@ -19,6 +19,7 @@ import edu.snu.dolphin.ps.ParameterServerParameters.KeyCodecName;
 import edu.snu.dolphin.ps.ParameterServerParameters.ValueCodecName;
 import edu.snu.dolphin.ps.avro.AvroParameterServerMsg;
 import edu.snu.dolphin.ps.avro.ReplyMsg;
+import edu.snu.dolphin.ps.worker.api.ParameterWorker;
 import edu.snu.dolphin.util.SingleMessageExtractor;
 import org.apache.reef.annotations.audience.EvaluatorSide;
 import org.apache.reef.io.network.Message;

--- a/dolphin-ps/src/main/java/edu/snu/dolphin/ps/worker/api/ParameterWorker.java
+++ b/dolphin-ps/src/main/java/edu/snu/dolphin/ps/worker/api/ParameterWorker.java
@@ -13,13 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package edu.snu.dolphin.ps.worker;
+package edu.snu.dolphin.ps.worker.api;
 
 import org.apache.reef.annotations.audience.EvaluatorSide;
 
 /**
  * A Parameter Server worker (client) that interacts with the server to provide or fetch parameters.
- * Works as a set with {@link edu.snu.dolphin.ps.server.ParameterServer}.
+ * Works as a set with {@link edu.snu.dolphin.ps.server.concurrent.api.ParameterServer}.
  * @param <K> class type of parameter keys
  * @param <P> class type of parameter values before they are processed at the server
  * @param <V> class type of parameter values after they are processed at the server

--- a/dolphin-ps/src/main/java/edu/snu/dolphin/ps/worker/api/package-info.java
+++ b/dolphin-ps/src/main/java/edu/snu/dolphin/ps/worker/api/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 Seoul National University
+ * Copyright (C) 2016 Seoul National University
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,6 +14,6 @@
  * limitations under the License.
  */
 /**
- * Parameter Server classes that are instantiated at the driver.
+ * Interfaces for worker-side Parameter Server classes that can have several pluggable implementations.
  */
-package edu.snu.dolphin.ps.driver;
+package edu.snu.dolphin.ps.worker.api;

--- a/dolphin-ps/src/main/java/edu/snu/dolphin/ps/worker/impl/SingleNodeParameterWorker.java
+++ b/dolphin-ps/src/main/java/edu/snu/dolphin/ps/worker/impl/SingleNodeParameterWorker.java
@@ -13,9 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package edu.snu.dolphin.ps.worker;
+package edu.snu.dolphin.ps.worker.impl;
 
-import edu.snu.dolphin.ps.driver.SingleNodeParameterServerManager;
+import edu.snu.dolphin.ps.driver.impl.ServerId;
+import edu.snu.dolphin.ps.worker.api.ParameterWorker;
 import org.apache.reef.annotations.audience.EvaluatorSide;
 import org.apache.reef.tang.InjectionFuture;
 import org.apache.reef.tang.annotations.Parameter;
@@ -34,7 +35,7 @@ import java.util.logging.Logger;
 @EvaluatorSide
 public final class SingleNodeParameterWorker<K, P, V> implements ParameterWorker<K, P, V> {
   private static final Logger LOG = Logger.getLogger(SingleNodeParameterWorker.class.getName());
-  private static final long TIMEOUT = 10000; // milliseconds
+  private static final long TIMEOUT = 40000; // milliseconds
 
   /**
    * Network Connection Service identifier of the server.
@@ -54,7 +55,7 @@ public final class SingleNodeParameterWorker<K, P, V> implements ParameterWorker
   private final ConcurrentMap<K, ValueWrapper> keyToValueWrapper;
 
   @Inject
-  private SingleNodeParameterWorker(@Parameter(SingleNodeParameterServerManager.ServerId.class) final String serverId,
+  private SingleNodeParameterWorker(@Parameter(ServerId.class) final String serverId,
                                     final InjectionFuture<WorkerSideMsgSender<K, P>> sender) {
     this.serverId = serverId;
     this.sender = sender;
@@ -72,7 +73,7 @@ public final class SingleNodeParameterWorker<K, P, V> implements ParameterWorker
   /**
    * Try to fetch a {@code value} from the server, waiting for a certain {@code TIMEOUT} period.
    * If a value associated with {@code key} doesn't exist, then the server will create an initial value
-   * using {@link edu.snu.dolphin.ps.server.ParameterUpdater} and return that value.
+   * using {@link edu.snu.dolphin.ps.server.api.ParameterUpdater} and return that value.
    * @param key key object representing the expected value
    * @return value specified by the {@code key}, or null if wait time exceeds {@code TIMEOUT}
    */

--- a/dolphin-ps/src/main/java/edu/snu/dolphin/ps/worker/impl/WorkerSideMsgSender.java
+++ b/dolphin-ps/src/main/java/edu/snu/dolphin/ps/worker/impl/WorkerSideMsgSender.java
@@ -13,24 +13,32 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package edu.snu.dolphin.ps.server;
+package edu.snu.dolphin.ps.worker.impl;
 
 import org.apache.reef.annotations.audience.EvaluatorSide;
 import org.apache.reef.tang.annotations.DefaultImplementation;
 
 /**
- * Server-side Parameter Server message sender.
+ * Worker-side Parameter Server message sender.
  */
 @EvaluatorSide
-@DefaultImplementation(ServerSideMsgSenderImpl.class)
-public interface ServerSideMsgSender<K, V> {
+@DefaultImplementation(WorkerSideMsgSenderImpl.class)
+public interface WorkerSideMsgSender<K, P> {
 
   /**
-   * Send a reply to another evaluator that requested a certain value.
-   * This message is a reply to a {@link edu.snu.dolphin.ps.avro.PullMsg}.
+   * Send a key-value pair to another evaluator.
    * @param destId Network Connection Service identifier of the destination evaluator
-   * @param key key object associated with the expected value
-   * @param valueEntry {@link ValueEntry} object containing the requested value
+   * @param key key object representing what is being sent
+   * @param preValue value to be sent to the destination
    */
-  void sendReplyMsg(final String destId, final K key, final ValueEntry<V> valueEntry);
+  void sendPushMsg(final String destId, final K key, final P preValue);
+
+  /**
+   * Send a request to another evaluator for fetching a certain value.
+   * After this message, a {@link edu.snu.dolphin.ps.avro.ReplyMsg} containing the requested value
+   * should be sent from the destination as a reply.
+   * @param destId Network Connection Service identifier of the destination evaluator
+   * @param key key object representing the expected value
+   */
+  void sendPullMsg(final String destId, final K key);
 }

--- a/dolphin-ps/src/main/java/edu/snu/dolphin/ps/worker/impl/WorkerSideMsgSenderImpl.java
+++ b/dolphin-ps/src/main/java/edu/snu/dolphin/ps/worker/impl/WorkerSideMsgSenderImpl.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package edu.snu.dolphin.ps.worker;
+package edu.snu.dolphin.ps.worker.impl;
 
 import edu.snu.dolphin.ps.ParameterServerParameters.KeyCodecName;
 import edu.snu.dolphin.ps.ParameterServerParameters.PreValueCodecName;

--- a/dolphin-ps/src/main/java/edu/snu/dolphin/ps/worker/impl/package-info.java
+++ b/dolphin-ps/src/main/java/edu/snu/dolphin/ps/worker/impl/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 Seoul National University
+ * Copyright (C) 2016 Seoul National University
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 /**
- * Parameter Server classes that are instantiated at the driver.
+ * Concurrent implementation of Parameter Server worker (client).
+ * For use with server in {@link edu.snu.dolphin.ps.server.concurrent}.
  */
-package edu.snu.dolphin.ps.driver;
+package edu.snu.dolphin.ps.worker.impl;

--- a/dolphin-ps/src/test/java/edu/snu/dolphin/ps/server/ConcurrentParameterServerTest.java
+++ b/dolphin-ps/src/test/java/edu/snu/dolphin/ps/server/ConcurrentParameterServerTest.java
@@ -16,6 +16,9 @@
 package edu.snu.dolphin.ps.server;
 
 import edu.snu.dolphin.ps.TestUtils;
+import edu.snu.dolphin.ps.server.api.ParameterUpdater;
+import edu.snu.dolphin.ps.server.concurrent.impl.ConcurrentParameterServer;
+import edu.snu.dolphin.ps.server.concurrent.impl.ValueEntry;
 import org.apache.reef.tang.Injector;
 import org.apache.reef.tang.Tang;
 import org.apache.reef.tang.exceptions.InjectionException;
@@ -29,13 +32,13 @@ import static org.junit.Assert.*;
 
 
 /**
- * Tests for {@link SingleNodeParameterServer}.
+ * Tests for {@link ConcurrentParameterServer}.
  */
-public final class SingleNodeParameterServerTest {
+public final class ConcurrentParameterServerTest {
   private static final Integer KEY = 0;
   private static final String MSG_THREADS_NOT_FINISHED = "threads not finished (possible deadlock or infinite loop)";
   private static final String MSG_RESULT_ASSERTION = "final result of concurrent pushes and pulls";
-  private SingleNodeParameterServer<Integer, Integer, Integer> server;
+  private ConcurrentParameterServer<Integer, Integer, Integer> server;
 
   @Before
   public void setup() throws InjectionException {
@@ -58,11 +61,11 @@ public final class SingleNodeParameterServerTest {
       }
     });
 
-    server = injector.getInstance(SingleNodeParameterServer.class);
+    server = injector.getInstance(ConcurrentParameterServer.class);
   }
 
   /**
-   * Test the thread safety of {@link SingleNodeParameterServer} by
+   * Test the thread safety of {@link ConcurrentParameterServer} by
    * running threads that push values to and pull values from the server, concurrently.
    */
   @Test
@@ -74,25 +77,27 @@ public final class SingleNodeParameterServerTest {
     final CountDownLatch countDownLatch = new CountDownLatch(numPushThreads + numPullThreads);
     final Runnable[] threads = new Runnable[numPushThreads + numPullThreads];
 
-    for (int index = 0; index < numPushThreads; index++) {
-      threads[index] = new Runnable() {
+    for (int threadIndex = 0; threadIndex < numPushThreads; threadIndex++) {
+      final int threadId = threadIndex;
+      threads[threadIndex] = new Runnable() {
         @Override
         public void run() {
           for (int index = 0; index < numPushes; index++) {
             // each thread increments the server's value by 1 per push
-            server.push(KEY, 1);
+            server.push(KEY + threadId, 1);
           }
           countDownLatch.countDown();
         }
       };
     }
 
-    for (int index = 0; index < numPullThreads; index++) {
-      threads[index + numPushThreads] = new Runnable() {
+    for (int threadIndex = 0; threadIndex < numPullThreads; threadIndex++) {
+      final int threadId = threadIndex;
+      threads[threadIndex + numPushThreads] = new Runnable() {
         @Override
         public void run() {
           for (int index = 0; index < numPulls; index++) {
-            final ValueEntry<Integer> value = server.pull(KEY);
+            final ValueEntry<Integer> value = server.pull(KEY + threadId);
             value.getReadWriteLock().readLock().lock();
             try {
               value.getValue();
@@ -105,11 +110,16 @@ public final class SingleNodeParameterServerTest {
       };
     }
 
+    final long startTime = System.currentTimeMillis();
     TestUtils.runConcurrently(threads);
     final boolean allThreadsFinished = countDownLatch.await(10, TimeUnit.SECONDS);
+    final long endTime = System.currentTimeMillis();
+    System.out.println("Ops completed in " + (endTime - startTime) + " milliseconds");
 
     assertTrue(MSG_THREADS_NOT_FINISHED, allThreadsFinished);
-    final ValueEntry<Integer> value = server.pull(KEY);
-    assertEquals(MSG_RESULT_ASSERTION, numPushThreads * numPushes, (int) value.getValue());
+    for (int threadIndex = 0; threadIndex < numPushThreads; threadIndex++) {
+      final ValueEntry<Integer> value = server.pull(KEY + threadIndex);
+      assertEquals(MSG_RESULT_ASSERTION, numPushes, (int) value.getValue());
+    }
   }
 }

--- a/dolphin-ps/src/test/java/edu/snu/dolphin/ps/server/PartitionedParameterServerTest.java
+++ b/dolphin-ps/src/test/java/edu/snu/dolphin/ps/server/PartitionedParameterServerTest.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright (C) 2016 Seoul National University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.snu.dolphin.ps.server;
+
+import edu.snu.dolphin.ps.ParameterServerParameters;
+import edu.snu.dolphin.ps.TestUtils;
+import edu.snu.dolphin.ps.examples.add.IntegerCodec;
+import edu.snu.dolphin.ps.server.api.ParameterUpdater;
+import edu.snu.dolphin.ps.server.partitioned.PartitionedParameterServer;
+import edu.snu.dolphin.ps.server.partitioned.PartitionedServerSideReplySender;
+import edu.snu.dolphin.ps.server.partitioned.parameters.NumPartitions;
+import org.apache.reef.tang.Configuration;
+import org.apache.reef.tang.Injector;
+import org.apache.reef.tang.Tang;
+import org.apache.reef.tang.exceptions.InjectionException;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.inject.Inject;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+
+/**
+ * Tests for {@link PartitionedParameterServer}.
+ */
+public final class PartitionedParameterServerTest {
+  private static final Integer KEY = 0;
+  private static final String MSG_THREADS_NOT_FINISHED = "threads not finished (possible deadlock or infinite loop)";
+  private static final String MSG_RESULT_ASSERTION = "final result of concurrent pushes and pulls";
+  private PartitionedParameterServer<Integer, Integer, Integer> server;
+  private MockPartitionedServerSideReplySender mockSender;
+
+  @Before
+  public void setup() throws InjectionException {
+    final Configuration conf = Tang.Factory.getTang().newConfigurationBuilder()
+        .bind(PartitionedServerSideReplySender.class, MockPartitionedServerSideReplySender.class)
+        .bindNamedParameter(ParameterServerParameters.KeyCodecName.class, IntegerCodec.class)
+        .bindNamedParameter(ParameterServerParameters.ValueCodecName.class, IntegerCodec.class)
+        .bindNamedParameter(ParameterServerParameters.PreValueCodecName.class, IntegerCodec.class)
+        .bindNamedParameter(NumPartitions.class, "4")
+        .build();
+    final Injector injector = Tang.Factory.getTang().newInjector(conf);
+    injector.bindVolatileInstance(ParameterUpdater.class, new ParameterUpdater<Integer, Integer, Integer>() {
+      @Override
+      public Integer process(final Integer key, final Integer preValue) {
+        return preValue;
+      }
+
+      @Override
+      public Integer update(final Integer oldValue, final Integer deltaValue) {
+        // simply add the processed value to the original value
+        return oldValue + deltaValue;
+      }
+
+      @Override
+      public Integer initValue(final Integer key) {
+        return 0;
+      }
+    });
+    mockSender = injector.getInstance(MockPartitionedServerSideReplySender.class);
+    server = injector.getInstance(PartitionedParameterServer.class);
+  }
+
+  /**
+   * Test the performance of {@link PartitionedParameterServer} by
+   * running threads that push values to and pull values from the server, concurrently.
+   */
+  @Test
+  public void testMultiThreadPushPull() throws InterruptedException {
+    final int numPushThreads = 8;
+    final int numPushes = 1000000;
+    final int numPullThreads = 8;
+    final int numPulls = 1000000;
+    final CountDownLatch countDownLatch = new CountDownLatch(numPushThreads + numPullThreads);
+    final Runnable[] threads = new Runnable[numPushThreads + numPullThreads];
+
+    for (int threadIndex = 0; threadIndex < numPushThreads; threadIndex++) {
+      final int threadId = threadIndex;
+      threads[threadIndex] = new Runnable() {
+        @Override
+        public void run() {
+          for (int index = 0; index < numPushes; index++) {
+            // each thread increments the server's value by 1 per push
+            server.push(KEY + threadId, 1);
+          }
+          countDownLatch.countDown();
+        }
+      };
+    }
+
+    for (int threadIndex = 0; threadIndex < numPullThreads; threadIndex++) {
+      final int threadId = threadIndex;
+      threads[threadIndex + numPushThreads] = new Runnable() {
+        @Override
+        public void run() {
+          for (int index = 0; index < numPulls; index++) {
+            server.pull(KEY + threadId, "");
+          }
+          countDownLatch.countDown();
+        }
+      };
+    }
+
+    final long startTime = System.currentTimeMillis();
+    TestUtils.runConcurrently(threads);
+    final boolean allThreadsFinished = countDownLatch.await(100, TimeUnit.SECONDS);
+    waitForOps();
+    final long endTime = System.currentTimeMillis();
+    System.out.println("Ops completed in " + (endTime - startTime) + " milliseconds");
+
+    assertTrue(MSG_THREADS_NOT_FINISHED, allThreadsFinished);
+    for (int threadIndex = 0; threadIndex < numPushThreads; threadIndex++) {
+      server.pull(KEY + threadIndex, "");
+      waitForOps();
+      assertEquals(MSG_RESULT_ASSERTION, numPushes, mockSender.getLatest());
+    }
+  }
+
+  private void waitForOps() throws InterruptedException {
+    int opsPending = server.opsPending();
+    while (opsPending > 0) {
+      System.out.println("Ops Pending: " + opsPending);
+      Thread.sleep(5);
+      opsPending = server.opsPending();
+    }
+  }
+
+  private static class MockPartitionedServerSideReplySender
+      implements PartitionedServerSideReplySender<Integer, Integer> {
+    private volatile int latest = -1;
+
+    @Inject
+    public MockPartitionedServerSideReplySender() {
+    }
+
+    @Override
+    public void sendReplyMsg(final String destId, final Integer key, final Integer value) {
+      latest = value;
+    }
+
+    public int getLatest() {
+      return latest;
+    }
+  }
+}

--- a/dolphin-ps/src/test/java/edu/snu/dolphin/ps/worker/SingleNodeParameterWorkerTest.java
+++ b/dolphin-ps/src/test/java/edu/snu/dolphin/ps/worker/SingleNodeParameterWorkerTest.java
@@ -16,7 +16,9 @@
 package edu.snu.dolphin.ps.worker;
 
 import edu.snu.dolphin.ps.TestUtils;
-import edu.snu.dolphin.ps.driver.SingleNodeParameterServerManager;
+import edu.snu.dolphin.ps.driver.impl.ServerId;
+import edu.snu.dolphin.ps.worker.impl.SingleNodeParameterWorker;
+import edu.snu.dolphin.ps.worker.impl.WorkerSideMsgSender;
 import org.apache.reef.tang.Configuration;
 import org.apache.reef.tang.Injector;
 import org.apache.reef.tang.Tang;
@@ -45,7 +47,7 @@ public final class SingleNodeParameterWorkerTest {
   @Before
   public void setup() throws InjectionException {
     final Configuration configuration = Tang.Factory.getTang().newConfigurationBuilder()
-        .bindNamedParameter(SingleNodeParameterServerManager.ServerId.class, "ServerId")
+        .bindNamedParameter(ServerId.class, "ServerId")
         .build();
     final Injector injector = Tang.Factory.getTang().newInjector(configuration);
     final WorkerSideMsgSender<Integer, Integer> mockSender = mock(WorkerSideMsgSender.class);


### PR DESCRIPTION
Closes #176

- Adds a new Parameter Server, PartitionedParameterServer. The server supports atomic, in-order processing of push and pull operations, using multiple threads.
- Renames the existing "Single Node" Server as ConcurrentParameterServer.

I've done a simple performance comparison between PartitionedPS and ConcurrentPS by running the unit tests (1million reads + 1million writes) on my local laptop. The PartitionedPS has worse performance. Note that the ConcurrentPS can lose updates.
- ConcurrentPS: Avg 1.5s
- PartitionedPS: Avg 2s

Also, the unit test does not include hash computation. A version of the test (not committed) that uses MurmurHash had an Avg runtime of 3s. However, this test also requires the key to be copied into a byte array, which we avoid in the actual implementation by using the original serialized value from the message.