### PR TITLE
[DOLPHIN-154] Create a Partitioned PS Worker

### DIFF
--- a/dolphin-ps/src/main/java/edu/snu/dolphin/ps/driver/ParameterServerDriver.java
+++ b/dolphin-ps/src/main/java/edu/snu/dolphin/ps/driver/ParameterServerDriver.java
@@ -114,6 +114,7 @@ public final class ParameterServerDriver {
         .newConfigurationBuilder(
             codecConfiguration,
             psManager.getWorkerServiceConfiguration(),
+            updaterConfiguration,
             getNameResolverServiceConfiguration())
         .bindImplementation(IdentifierFactory.class, StringIdentifierFactory.class)
         .bindNamedParameter(PSMessageHandler.class, WorkerSideMsgHandler.class)

--- a/dolphin-ps/src/main/java/edu/snu/dolphin/ps/driver/impl/ConcurrentParameterServerManager.java
+++ b/dolphin-ps/src/main/java/edu/snu/dolphin/ps/driver/impl/ConcurrentParameterServerManager.java
@@ -19,10 +19,10 @@ import edu.snu.dolphin.ps.driver.api.ParameterServerManager;
 import edu.snu.dolphin.ps.ns.EndpointId;
 import edu.snu.dolphin.ps.ns.PSMessageHandler;
 import edu.snu.dolphin.ps.server.concurrent.api.ParameterServer;
-import edu.snu.dolphin.ps.server.concurrent.impl.ConcurrentParameterServer;
 import edu.snu.dolphin.ps.server.concurrent.impl.ServerSideMsgHandler;
+import edu.snu.dolphin.ps.server.concurrent.impl.ConcurrentParameterServer;
 import edu.snu.dolphin.ps.worker.api.ParameterWorker;
-import edu.snu.dolphin.ps.worker.impl.SingleNodeParameterWorker;
+import edu.snu.dolphin.ps.worker.concurrent.ConcurrentParameterWorker;
 import org.apache.reef.annotations.audience.DriverSide;
 import org.apache.reef.driver.context.ServiceConfiguration;
 import org.apache.reef.tang.Configuration;
@@ -48,7 +48,7 @@ public final class ConcurrentParameterServerManager implements ParameterServerMa
 
   /**
    * Returns worker-side service configuration.
-   * Sets {@link SingleNodeParameterWorker} as the {@link ParameterWorker} class.
+   * Sets {@link ConcurrentParameterWorker} as the {@link ParameterWorker} class.
    */
   @Override
   public Configuration getWorkerServiceConfiguration() {
@@ -56,9 +56,9 @@ public final class ConcurrentParameterServerManager implements ParameterServerMa
 
     return Tang.Factory.getTang()
         .newConfigurationBuilder(ServiceConfiguration.CONF
-            .set(ServiceConfiguration.SERVICES, SingleNodeParameterWorker.class)
+            .set(ServiceConfiguration.SERVICES, ConcurrentParameterWorker.class)
             .build())
-        .bindImplementation(ParameterWorker.class, SingleNodeParameterWorker.class)
+        .bindImplementation(ParameterWorker.class, ConcurrentParameterWorker.class)
         .bindNamedParameter(ServerId.class, SERVER_ID)
         .bindNamedParameter(EndpointId.class, WORKER_ID_PREFIX + workerIndex)
         .build();

--- a/dolphin-ps/src/main/java/edu/snu/dolphin/ps/driver/impl/PartitionedParameterServerManager.java
+++ b/dolphin-ps/src/main/java/edu/snu/dolphin/ps/driver/impl/PartitionedParameterServerManager.java
@@ -22,10 +22,10 @@ import edu.snu.dolphin.ps.server.partitioned.PartitionedParameterServer;
 import edu.snu.dolphin.ps.server.partitioned.PartitionedServerSideMsgHandler;
 import edu.snu.dolphin.ps.server.partitioned.PartitionedServerSideReplySender;
 import edu.snu.dolphin.ps.server.partitioned.PartitionedServerSideReplySenderImpl;
-import edu.snu.dolphin.ps.server.partitioned.parameters.NumPartitions;
-import edu.snu.dolphin.ps.server.partitioned.parameters.QueueSize;
+import edu.snu.dolphin.ps.server.partitioned.parameters.ServerNumPartitions;
+import edu.snu.dolphin.ps.server.partitioned.parameters.ServerQueueSize;
 import edu.snu.dolphin.ps.worker.api.ParameterWorker;
-import edu.snu.dolphin.ps.worker.impl.SingleNodeParameterWorker;
+import edu.snu.dolphin.ps.worker.partitioned.PartitionedParameterWorker;
 import org.apache.reef.annotations.audience.DriverSide;
 import org.apache.reef.driver.context.ServiceConfiguration;
 import org.apache.reef.tang.Configuration;
@@ -53,8 +53,8 @@ public final class PartitionedParameterServerManager implements ParameterServerM
   private final AtomicInteger numWorkers;
 
   @Inject
-  private PartitionedParameterServerManager(@Parameter(NumPartitions.class) final int numPartitions,
-                                            @Parameter(QueueSize.class) final int queueSize) {
+  private PartitionedParameterServerManager(@Parameter(ServerNumPartitions.class) final int numPartitions,
+                                            @Parameter(ServerQueueSize.class) final int queueSize) {
     this.numPartitions = numPartitions;
     this.queueSize = queueSize;
     this.numWorkers = new AtomicInteger(0);
@@ -62,7 +62,7 @@ public final class PartitionedParameterServerManager implements ParameterServerM
 
   /**
    * Returns worker-side service configuration.
-   * Sets {@link SingleNodeParameterWorker} as the {@link ParameterWorker} class.
+   * Sets {@link PartitionedParameterWorker} as the {@link ParameterWorker} class.
    */
   @Override
   public Configuration getWorkerServiceConfiguration() {
@@ -70,9 +70,9 @@ public final class PartitionedParameterServerManager implements ParameterServerM
 
     return Tang.Factory.getTang()
         .newConfigurationBuilder(ServiceConfiguration.CONF
-            .set(ServiceConfiguration.SERVICES, SingleNodeParameterWorker.class)
+            .set(ServiceConfiguration.SERVICES, PartitionedParameterWorker.class)
             .build())
-        .bindImplementation(ParameterWorker.class, SingleNodeParameterWorker.class)
+        .bindImplementation(ParameterWorker.class, PartitionedParameterWorker.class)
         .bindNamedParameter(ServerId.class, SERVER_ID)
         .bindNamedParameter(EndpointId.class, WORKER_ID_PREFIX + workerIndex)
         .build();
@@ -89,8 +89,8 @@ public final class PartitionedParameterServerManager implements ParameterServerM
             .build())
         .bindNamedParameter(EndpointId.class, SERVER_ID)
         .bindNamedParameter(PSMessageHandler.class, PartitionedServerSideMsgHandler.class)
-        .bindNamedParameter(NumPartitions.class, Integer.toString(numPartitions))
-        .bindNamedParameter(QueueSize.class, Integer.toString(queueSize))
+        .bindNamedParameter(ServerNumPartitions.class, Integer.toString(numPartitions))
+        .bindNamedParameter(ServerQueueSize.class, Integer.toString(queueSize))
         .bindImplementation(PartitionedServerSideReplySender.class, PartitionedServerSideReplySenderImpl.class)
         .build();
   }

--- a/dolphin-ps/src/main/java/edu/snu/dolphin/ps/driver/impl/PartitionedParameterServerManager.java
+++ b/dolphin-ps/src/main/java/edu/snu/dolphin/ps/driver/impl/PartitionedParameterServerManager.java
@@ -25,6 +25,7 @@ import edu.snu.dolphin.ps.server.partitioned.PartitionedServerSideReplySenderImp
 import edu.snu.dolphin.ps.server.partitioned.parameters.ServerNumPartitions;
 import edu.snu.dolphin.ps.server.partitioned.parameters.ServerQueueSize;
 import edu.snu.dolphin.ps.worker.api.ParameterWorker;
+import edu.snu.dolphin.ps.worker.partitioned.ContextStopHandler;
 import edu.snu.dolphin.ps.worker.partitioned.PartitionedParameterWorker;
 import org.apache.reef.annotations.audience.DriverSide;
 import org.apache.reef.driver.context.ServiceConfiguration;
@@ -45,8 +46,8 @@ import java.util.concurrent.atomic.AtomicInteger;
  */
 @DriverSide
 public final class PartitionedParameterServerManager implements ParameterServerManager {
-  private static final String SERVER_ID = "SINGLE_NODE_SERVER_ID";
-  private static final String WORKER_ID_PREFIX = "SINGLE_NODE_WORKER_ID_";
+  private static final String SERVER_ID = "PARTITIONED_SERVER_ID";
+  private static final String WORKER_ID_PREFIX = "PARTITIONED_WORKER_ID_";
 
   private final int numPartitions;
   private final int queueSize;
@@ -71,6 +72,7 @@ public final class PartitionedParameterServerManager implements ParameterServerM
     return Tang.Factory.getTang()
         .newConfigurationBuilder(ServiceConfiguration.CONF
             .set(ServiceConfiguration.SERVICES, PartitionedParameterWorker.class)
+            .set(ServiceConfiguration.ON_CONTEXT_STOP, ContextStopHandler.class)
             .build())
         .bindImplementation(ParameterWorker.class, PartitionedParameterWorker.class)
         .bindNamedParameter(ServerId.class, SERVER_ID)

--- a/dolphin-ps/src/main/java/edu/snu/dolphin/ps/examples/add/PartitionedPSExampleREEF.java
+++ b/dolphin-ps/src/main/java/edu/snu/dolphin/ps/examples/add/PartitionedPSExampleREEF.java
@@ -17,9 +17,11 @@ package edu.snu.dolphin.ps.examples.add;
 
 import edu.snu.dolphin.ps.ParameterServerConfigurationBuilder;
 import edu.snu.dolphin.ps.driver.impl.PartitionedParameterServerManager;
-import edu.snu.dolphin.ps.examples.add.parameters.*;
-import edu.snu.dolphin.ps.server.partitioned.parameters.NumPartitions;
-import edu.snu.dolphin.ps.server.partitioned.parameters.QueueSize;
+import edu.snu.dolphin.ps.examples.add.parameters.JobTimeout;
+import edu.snu.dolphin.ps.examples.add.parameters.NumUpdates;
+import edu.snu.dolphin.ps.examples.add.parameters.NumWorkers;
+import edu.snu.dolphin.ps.server.partitioned.parameters.ServerNumPartitions;
+import edu.snu.dolphin.ps.server.partitioned.parameters.ServerQueueSize;
 import org.apache.reef.client.DriverConfiguration;
 import org.apache.reef.client.DriverLauncher;
 import org.apache.reef.client.LauncherStatus;
@@ -47,8 +49,6 @@ public final class PartitionedPSExampleREEF {
   private final long timeout;
   private final int numWorkers;
   private final int numUpdates;
-  private final int numKeys;
-  private final int startKey;
   private final int numPartitions;
   private final int queueSize;
 
@@ -56,15 +56,11 @@ public final class PartitionedPSExampleREEF {
   private PartitionedPSExampleREEF(@Parameter(JobTimeout.class) final long timeout,
                                    @Parameter(NumWorkers.class) final int numWorkers,
                                    @Parameter(NumUpdates.class) final int numUpdates,
-                                   @Parameter(NumKeys.class) final int numKeys,
-                                   @Parameter(StartKey.class) final int startKey,
-                                   @Parameter(NumPartitions.class) final int numPartitions,
-                                   @Parameter(QueueSize.class) final int queueSize) {
+                                   @Parameter(ServerNumPartitions.class) final int numPartitions,
+                                   @Parameter(ServerQueueSize.class) final int queueSize) {
     this.timeout = timeout;
     this.numWorkers = numWorkers;
     this.numUpdates = numUpdates;
-    this.numKeys = numKeys;
-    this.startKey = startKey;
     this.numPartitions = numPartitions;
     this.queueSize = queueSize;
   }
@@ -89,10 +85,8 @@ public final class PartitionedPSExampleREEF {
     final Configuration parametersConf = Tang.Factory.getTang().newConfigurationBuilder()
         .bindNamedParameter(NumWorkers.class, Integer.toString(numWorkers))
         .bindNamedParameter(NumUpdates.class, Integer.toString(numUpdates))
-        .bindNamedParameter(NumKeys.class, Integer.toString(numKeys))
-        .bindNamedParameter(StartKey.class, Integer.toString(startKey))
-        .bindNamedParameter(NumPartitions.class, Integer.toString(numPartitions))
-        .bindNamedParameter(QueueSize.class, Integer.toString(queueSize))
+        .bindNamedParameter(ServerNumPartitions.class, Integer.toString(numPartitions))
+        .bindNamedParameter(ServerQueueSize.class, Integer.toString(queueSize))
         .build();
 
     final Configuration psConf = new ParameterServerConfigurationBuilder()
@@ -126,10 +120,8 @@ public final class PartitionedPSExampleREEF {
     cl.registerShortNameOfClass(JobTimeout.class);
     cl.registerShortNameOfClass(NumWorkers.class);
     cl.registerShortNameOfClass(NumUpdates.class);
-    cl.registerShortNameOfClass(NumKeys.class);
-    cl.registerShortNameOfClass(StartKey.class);
-    cl.registerShortNameOfClass(NumPartitions.class);
-    cl.registerShortNameOfClass(QueueSize.class);
+    cl.registerShortNameOfClass(ServerNumPartitions.class);
+    cl.registerShortNameOfClass(ServerQueueSize.class);
 
     cl.processCommandLine(args);
 

--- a/dolphin-ps/src/main/java/edu/snu/dolphin/ps/examples/add/PartitionedPSExampleREEF.java
+++ b/dolphin-ps/src/main/java/edu/snu/dolphin/ps/examples/add/PartitionedPSExampleREEF.java
@@ -17,11 +17,13 @@ package edu.snu.dolphin.ps.examples.add;
 
 import edu.snu.dolphin.ps.ParameterServerConfigurationBuilder;
 import edu.snu.dolphin.ps.driver.impl.PartitionedParameterServerManager;
-import edu.snu.dolphin.ps.examples.add.parameters.JobTimeout;
-import edu.snu.dolphin.ps.examples.add.parameters.NumUpdates;
-import edu.snu.dolphin.ps.examples.add.parameters.NumWorkers;
+import edu.snu.dolphin.ps.examples.add.parameters.*;
 import edu.snu.dolphin.ps.server.partitioned.parameters.ServerNumPartitions;
 import edu.snu.dolphin.ps.server.partitioned.parameters.ServerQueueSize;
+import edu.snu.dolphin.ps.worker.partitioned.parameters.WorkerExpireTimeout;
+import edu.snu.dolphin.ps.worker.partitioned.parameters.WorkerKeyCacheSize;
+import edu.snu.dolphin.ps.worker.partitioned.parameters.WorkerNumPartitions;
+import edu.snu.dolphin.ps.worker.partitioned.parameters.WorkerQueueSize;
 import org.apache.reef.client.DriverConfiguration;
 import org.apache.reef.client.DriverLauncher;
 import org.apache.reef.client.LauncherStatus;
@@ -49,20 +51,38 @@ public final class PartitionedPSExampleREEF {
   private final long timeout;
   private final int numWorkers;
   private final int numUpdates;
-  private final int numPartitions;
-  private final int queueSize;
+  private final int numKeys;
+  private final int startKey;
+  private final int serverNumPartitions;
+  private final int serverQueueSize;
+  private final int workerNumPartitions;
+  private final int workerQueueSize;
+  private final long workerExpireTimeout;
+  private final int workerKeyCacheSize;
 
   @Inject
   private PartitionedPSExampleREEF(@Parameter(JobTimeout.class) final long timeout,
                                    @Parameter(NumWorkers.class) final int numWorkers,
                                    @Parameter(NumUpdates.class) final int numUpdates,
-                                   @Parameter(ServerNumPartitions.class) final int numPartitions,
-                                   @Parameter(ServerQueueSize.class) final int queueSize) {
+                                   @Parameter(NumKeys.class) final int numKeys,
+                                   @Parameter(StartKey.class) final int startKey,
+                                   @Parameter(ServerNumPartitions.class) final int serverNumPartitions,
+                                   @Parameter(ServerQueueSize.class) final int serverQueueSize,
+                                   @Parameter(WorkerNumPartitions.class) final int workerNumPartitions,
+                                   @Parameter(WorkerQueueSize.class) final int workerQueueSize,
+                                   @Parameter(WorkerExpireTimeout.class) final long workerExpireTimeout,
+                                   @Parameter(WorkerKeyCacheSize.class) final int workerKeyCacheSize) {
     this.timeout = timeout;
     this.numWorkers = numWorkers;
     this.numUpdates = numUpdates;
-    this.numPartitions = numPartitions;
-    this.queueSize = queueSize;
+    this.numKeys = numKeys;
+    this.startKey = startKey;
+    this.serverNumPartitions = serverNumPartitions;
+    this.serverQueueSize = serverQueueSize;
+    this.workerNumPartitions = workerNumPartitions;
+    this.workerQueueSize = workerQueueSize;
+    this.workerExpireTimeout = workerExpireTimeout;
+    this.workerKeyCacheSize = workerKeyCacheSize;
   }
 
   private Configuration getDriverConf() {
@@ -85,8 +105,14 @@ public final class PartitionedPSExampleREEF {
     final Configuration parametersConf = Tang.Factory.getTang().newConfigurationBuilder()
         .bindNamedParameter(NumWorkers.class, Integer.toString(numWorkers))
         .bindNamedParameter(NumUpdates.class, Integer.toString(numUpdates))
-        .bindNamedParameter(ServerNumPartitions.class, Integer.toString(numPartitions))
-        .bindNamedParameter(ServerQueueSize.class, Integer.toString(queueSize))
+        .bindNamedParameter(NumKeys.class, Integer.toString(numKeys))
+        .bindNamedParameter(StartKey.class, Integer.toString(startKey))
+        .bindNamedParameter(ServerNumPartitions.class, Integer.toString(serverNumPartitions))
+        .bindNamedParameter(ServerQueueSize.class, Integer.toString(serverQueueSize))
+        .bindNamedParameter(WorkerNumPartitions.class, Integer.toString(workerNumPartitions))
+        .bindNamedParameter(WorkerQueueSize.class, Integer.toString(workerQueueSize))
+        .bindNamedParameter(WorkerExpireTimeout.class, Long.toString(workerExpireTimeout))
+        .bindNamedParameter(WorkerKeyCacheSize.class, Integer.toString(workerKeyCacheSize))
         .build();
 
     final Configuration psConf = new ParameterServerConfigurationBuilder()
@@ -120,8 +146,14 @@ public final class PartitionedPSExampleREEF {
     cl.registerShortNameOfClass(JobTimeout.class);
     cl.registerShortNameOfClass(NumWorkers.class);
     cl.registerShortNameOfClass(NumUpdates.class);
+    cl.registerShortNameOfClass(NumKeys.class);
+    cl.registerShortNameOfClass(StartKey.class);
     cl.registerShortNameOfClass(ServerNumPartitions.class);
     cl.registerShortNameOfClass(ServerQueueSize.class);
+    cl.registerShortNameOfClass(WorkerNumPartitions.class);
+    cl.registerShortNameOfClass(WorkerQueueSize.class);
+    cl.registerShortNameOfClass(WorkerExpireTimeout.class);
+    cl.registerShortNameOfClass(WorkerKeyCacheSize.class);
 
     cl.processCommandLine(args);
 

--- a/dolphin-ps/src/main/java/edu/snu/dolphin/ps/examples/add/UpdaterTask.java
+++ b/dolphin-ps/src/main/java/edu/snu/dolphin/ps/examples/add/UpdaterTask.java
@@ -65,17 +65,20 @@ public final class UpdaterTask implements Task {
     for (int i = 0; i < numUpdates; i++) {
       if (i % loggingInterval == 0) {
         LOG.log(Level.INFO, "{0} updates complete", i);
+        pullAllKeys();
       }
       worker.push(startKey + (i % numKeys), 1);
     }
 
     LOG.log(Level.INFO, "{0} updates complete", numUpdates);
+    pullAllKeys();
+    return null;
+  }
+
+  public void pullAllKeys() {
     for (int i = 0; i < numKeys; i++) {
       final int pullResult = worker.pull(startKey + i);
       LOG.log(Level.INFO, "Pull result for key {0}: {1}", new Object[]{startKey + i, pullResult});
     }
-    LOG.log(Level.INFO, "{0} pulls complete", numKeys);
-
-    return null;
   }
 }

--- a/dolphin-ps/src/main/java/edu/snu/dolphin/ps/examples/add/ValidatorTask.java
+++ b/dolphin-ps/src/main/java/edu/snu/dolphin/ps/examples/add/ValidatorTask.java
@@ -20,6 +20,7 @@ import edu.snu.dolphin.ps.examples.add.parameters.StartKey;
 import edu.snu.dolphin.ps.examples.add.parameters.NumUpdates;
 import edu.snu.dolphin.ps.examples.add.parameters.NumWorkers;
 import edu.snu.dolphin.ps.worker.api.ParameterWorker;
+import edu.snu.dolphin.ps.worker.partitioned.PartitionedParameterWorker;
 import org.apache.reef.annotations.audience.TaskSide;
 import org.apache.reef.tang.annotations.Parameter;
 import org.apache.reef.task.Task;
@@ -60,21 +61,51 @@ public final class ValidatorTask implements Task {
   public byte[] call(final byte[] bytes) throws Exception {
     LOG.log(Level.INFO, "Task.call() commencing...");
 
-    final int expectedResult = numWorkers * numUpdates / numKeys;
+    final long sleepMillis = 100;
+    int numRetries = 20;
 
+    final int expectedResult = numWorkers * numUpdates / numKeys;
+    while (numRetries > 0) {
+      numRetries--;
+
+      if (worker instanceof PartitionedParameterWorker) {
+        LOG.log(Level.INFO, "Invalidating cache before key validation.");
+        ((PartitionedParameterWorker) worker).invalidateAll();
+      }
+      try {
+        if (validate(expectedResult)) {
+          return null;
+        }
+      } catch (final IntegerValidationException e) {
+        if (numRetries > 0) {
+          LOG.log(Level.INFO, "Sleeping {0} ms to let PS catch up.", sleepMillis);
+          Thread.sleep(sleepMillis);
+        } else {
+          throw new RuntimeException(e);
+        }
+      }
+    }
+    return null;
+  }
+
+  private boolean validate(final int expectedResult) throws IntegerValidationException {
     for (int i = 0; i < numKeys; i++) {
       final int result = worker.pull(startKey + i);
 
       if (expectedResult != result) {
-        LOG.log(Level.SEVERE, "For key {0}, expected value {1} but received {2}",
+        LOG.log(Level.WARNING, "For key {0}, expected value {1} but received {2}",
             new Object[]{startKey + i, expectedResult, result});
-        throw new RuntimeException(String.format("For key %d, expected value %d but received %d",
-            startKey + i, expectedResult, result));
+        throw new IntegerValidationException(startKey + i, expectedResult, result);
       } else {
         LOG.log(Level.INFO, "For key {0}, received expected value {1}.", new Object[]{startKey + i, expectedResult});
       }
     }
+    return true;
+  }
 
-    return null;
+  private static class IntegerValidationException extends Exception {
+    public IntegerValidationException(final int key, final int expected, final int actual) {
+      super(String.format("For key %d, expected value %d but received %d", key, expected, actual));
+    }
   }
 }

--- a/dolphin-ps/src/main/java/edu/snu/dolphin/ps/server/partitioned/PartitionedServerSideMsgHandler.java
+++ b/dolphin-ps/src/main/java/edu/snu/dolphin/ps/server/partitioned/PartitionedServerSideMsgHandler.java
@@ -21,6 +21,7 @@ import edu.snu.dolphin.ps.avro.AvroParameterServerMsg;
 import edu.snu.dolphin.ps.avro.PullMsg;
 import edu.snu.dolphin.ps.avro.PushMsg;
 import edu.snu.dolphin.util.SingleMessageExtractor;
+import org.apache.hadoop.util.hash.MurmurHash;
 import org.apache.reef.annotations.audience.EvaluatorSide;
 import org.apache.reef.io.network.Message;
 import org.apache.reef.io.serialization.Codec;
@@ -33,6 +34,10 @@ import java.util.logging.Logger;
 /**
  * Server-side Parameter Server message handler.
  * Decode messages and call the appropriate {@link PartitionedParameterServer} method.
+ * We also compute a {@link MurmurHash} on the encoded key and pass it to {@link PartitionedParameterServer}.
+ *
+ * An alternative approach would be to compute the hash at the client and send it as part of the message.
+ * This would trade-off less computation on the server for more computation on the client and more communication cost.
  */
 @EvaluatorSide
 public final class PartitionedServerSideMsgHandler<K, P, V> implements EventHandler<Message<AvroParameterServerMsg>> {
@@ -90,12 +95,18 @@ public final class PartitionedServerSideMsgHandler<K, P, V> implements EventHand
   private void onPushMsg(final PushMsg pushMsg) {
     final K key = keyCodec.decode(pushMsg.getKey().array());
     final P preValue = preValueCodec.decode(pushMsg.getPreValue().array());
-    parameterServer.push(key, preValue);
+    final int keyHash = hash(pushMsg.getKey().array());
+    parameterServer.push(key, preValue, keyHash);
   }
 
   private void onPullMsg(final PullMsg pullMsg) {
     final String srcId = pullMsg.getSrcId().toString();
     final K key = keyCodec.decode(pullMsg.getKey().array());
-    parameterServer.pull(key, srcId);
+    final int keyHash = hash(pullMsg.getKey().array());
+    parameterServer.pull(key, srcId, keyHash);
+  }
+
+  private int hash(final byte[] encodedKey) {
+    return Math.abs(MurmurHash.getInstance().hash(encodedKey));
   }
 }

--- a/dolphin-ps/src/main/java/edu/snu/dolphin/ps/server/partitioned/parameters/ServerNumPartitions.java
+++ b/dolphin-ps/src/main/java/edu/snu/dolphin/ps/server/partitioned/parameters/ServerNumPartitions.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 2016 Seoul National University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.snu.dolphin.ps.server.partitioned.parameters;
+
+import org.apache.reef.tang.annotations.Name;
+import org.apache.reef.tang.annotations.NamedParameter;
+
+@NamedParameter(doc = "Number of partitions", default_value = "2", short_name = "serverNumPartitions")
+public final class ServerNumPartitions implements Name<Integer> {
+}

--- a/dolphin-ps/src/main/java/edu/snu/dolphin/ps/server/partitioned/parameters/ServerQueueSize.java
+++ b/dolphin-ps/src/main/java/edu/snu/dolphin/ps/server/partitioned/parameters/ServerQueueSize.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2016 Seoul National University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.snu.dolphin.ps.server.partitioned.parameters;
+
+import org.apache.reef.tang.annotations.Name;
+import org.apache.reef.tang.annotations.NamedParameter;
+
+@NamedParameter(doc = "Max number of items that can be queued for each partition", default_value = "1000",
+    short_name = "serverQueueSize")
+public final class ServerQueueSize implements Name<Integer> {
+}

--- a/dolphin-ps/src/main/java/edu/snu/dolphin/ps/worker/concurrent/ConcurrentParameterWorker.java
+++ b/dolphin-ps/src/main/java/edu/snu/dolphin/ps/worker/concurrent/ConcurrentParameterWorker.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package edu.snu.dolphin.ps.worker.impl;
+package edu.snu.dolphin.ps.worker.concurrent;
 
 import edu.snu.dolphin.ps.driver.impl.ServerId;
 import edu.snu.dolphin.ps.worker.api.ParameterWorker;
@@ -33,8 +33,8 @@ import java.util.logging.Logger;
  * the codec classes used in {@link WorkerSideMsgSender} are thread-safe.
  */
 @EvaluatorSide
-public final class SingleNodeParameterWorker<K, P, V> implements ParameterWorker<K, P, V> {
-  private static final Logger LOG = Logger.getLogger(SingleNodeParameterWorker.class.getName());
+public final class ConcurrentParameterWorker<K, P, V> implements ParameterWorker<K, P, V> {
+  private static final Logger LOG = Logger.getLogger(ConcurrentParameterWorker.class.getName());
   private static final long TIMEOUT = 40000; // milliseconds
 
   /**
@@ -55,7 +55,7 @@ public final class SingleNodeParameterWorker<K, P, V> implements ParameterWorker
   private final ConcurrentMap<K, ValueWrapper> keyToValueWrapper;
 
   @Inject
-  private SingleNodeParameterWorker(@Parameter(ServerId.class) final String serverId,
+  private ConcurrentParameterWorker(@Parameter(ServerId.class) final String serverId,
                                     final InjectionFuture<WorkerSideMsgSender<K, P>> sender) {
     this.serverId = serverId;
     this.sender = sender;

--- a/dolphin-ps/src/main/java/edu/snu/dolphin/ps/worker/concurrent/WorkerSideMsgSender.java
+++ b/dolphin-ps/src/main/java/edu/snu/dolphin/ps/worker/concurrent/WorkerSideMsgSender.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package edu.snu.dolphin.ps.worker.impl;
+package edu.snu.dolphin.ps.worker.concurrent;
 
 import org.apache.reef.annotations.audience.EvaluatorSide;
 import org.apache.reef.tang.annotations.DefaultImplementation;

--- a/dolphin-ps/src/main/java/edu/snu/dolphin/ps/worker/concurrent/WorkerSideMsgSenderImpl.java
+++ b/dolphin-ps/src/main/java/edu/snu/dolphin/ps/worker/concurrent/WorkerSideMsgSenderImpl.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (C) 2015 Seoul National University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.snu.dolphin.ps.worker.concurrent;
+
+import edu.snu.dolphin.ps.ParameterServerParameters.KeyCodecName;
+import edu.snu.dolphin.ps.ParameterServerParameters.PreValueCodecName;
+import edu.snu.dolphin.ps.avro.AvroParameterServerMsg;
+import edu.snu.dolphin.ps.avro.PushMsg;
+import edu.snu.dolphin.ps.avro.PullMsg;
+import edu.snu.dolphin.ps.avro.Type;
+import edu.snu.dolphin.ps.ns.PSNetworkSetup;
+import org.apache.reef.annotations.audience.EvaluatorSide;
+import org.apache.reef.exception.evaluator.NetworkException;
+import org.apache.reef.io.network.Connection;
+import org.apache.reef.io.serialization.Codec;
+import org.apache.reef.tang.annotations.Parameter;
+import org.apache.reef.wake.IdentifierFactory;
+
+import javax.inject.Inject;
+import java.nio.ByteBuffer;
+
+/**
+ * Default implementation of {@link WorkerSideMsgSender}.
+ */
+@EvaluatorSide
+public final class WorkerSideMsgSenderImpl<K, P> implements WorkerSideMsgSender<K, P> {
+
+  /**
+   * Network Connection Service related setup required for a Parameter Server application.
+   */
+  private final PSNetworkSetup psNetworkSetup;
+
+  /**
+   * Required for using Network Connection Service API.
+   */
+  private final IdentifierFactory identifierFactory;
+
+  /**
+   * Codec for encoding PS keys.
+   */
+  private final Codec<K> keyCodec;
+
+  /**
+   * Codec for encoding PS preValues.
+   */
+  private final Codec<P> preValueCodec;
+
+  @Inject
+  private WorkerSideMsgSenderImpl(final PSNetworkSetup psNetworkSetup,
+                                  final IdentifierFactory identifierFactory,
+                                  @Parameter(KeyCodecName.class) final Codec<K> keyCodec,
+                                  @Parameter(PreValueCodecName.class) final Codec<P> preValueCodec) {
+    this.psNetworkSetup = psNetworkSetup;
+    this.identifierFactory = identifierFactory;    
+    this.keyCodec = keyCodec;
+    this.preValueCodec = preValueCodec;
+  }
+
+  private void send(final String destId, final AvroParameterServerMsg msg) {
+    final Connection<AvroParameterServerMsg> conn = psNetworkSetup.getConnectionFactory()
+        .newConnection(identifierFactory.getNewInstance(destId));
+    try {
+      conn.open();
+      conn.write(msg);
+    } catch (final NetworkException ex) {
+      throw new RuntimeException("NetworkException during connection open/write", ex);
+    }
+  }
+
+  @Override
+  public void sendPushMsg(final String destId, final K key, final P preValue) {
+    final PushMsg pushMsg = PushMsg.newBuilder()
+        .setKey(ByteBuffer.wrap(keyCodec.encode(key)))
+        .setPreValue(ByteBuffer.wrap(preValueCodec.encode(preValue)))
+        .build();
+
+    send(destId,
+        AvroParameterServerMsg.newBuilder()
+            .setType(Type.PushMsg)
+            .setPushMsg(pushMsg)
+            .build());
+  }
+
+  @Override
+  public void sendPullMsg(final String destId, final K key) {
+    final PullMsg pullMsg = PullMsg.newBuilder()
+        .setKey(ByteBuffer.wrap(keyCodec.encode(key)))
+        .setSrcId(psNetworkSetup.getMyId().toString())
+        .build();
+
+    send(destId,
+        AvroParameterServerMsg.newBuilder()
+            .setType(Type.PullMsg)
+            .setPullMsg(pullMsg)
+            .build());
+  }
+}

--- a/dolphin-ps/src/main/java/edu/snu/dolphin/ps/worker/concurrent/package-info.java
+++ b/dolphin-ps/src/main/java/edu/snu/dolphin/ps/worker/concurrent/package-info.java
@@ -13,12 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package edu.snu.dolphin.ps.server.partitioned.parameters;
-
-import org.apache.reef.tang.annotations.Name;
-import org.apache.reef.tang.annotations.NamedParameter;
-
-@NamedParameter(doc = "Max number of items that can be queued for each partition", default_value = "1000",
-    short_name = "queueSize")
-public final class QueueSize implements Name<Integer> {
-}
+/**
+ * Concurrent implementation of Parameter Server worker (client).
+ * For use with server in {@link edu.snu.dolphin.ps.server.concurrent}.
+ */
+package edu.snu.dolphin.ps.worker.concurrent;

--- a/dolphin-ps/src/main/java/edu/snu/dolphin/ps/worker/partitioned/ContextStopHandler.java
+++ b/dolphin-ps/src/main/java/edu/snu/dolphin/ps/worker/partitioned/ContextStopHandler.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2016 Seoul National University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.snu.dolphin.ps.worker.partitioned;
+
+import org.apache.reef.evaluator.context.events.ContextStop;
+import org.apache.reef.wake.EventHandler;
+
+import javax.inject.Inject;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Closes the PartitionedParameterWorker.
+ * This waits for the queued messages to be sent through NCS,
+ * to avoid losing queued messages when closing a context (e.g., immediately after task completion).
+ *
+ * However, we are still observing some lost messages when
+ * contexts are immediately closed after the task completes.
+ * It appears messages buffered in NCS are not being flushed before context close,
+ * but this has to be investigated further.
+ * The current workaround is to not close contexts immediately, but this must be resolved before
+ * we move to elastically removing contexts.
+ */
+public final class ContextStopHandler implements EventHandler<ContextStop> {
+  private static final Logger LOG = Logger.getLogger(ContextStopHandler.class.getName());
+
+  private PartitionedParameterWorker partitionedParameterWorker;
+
+  @Inject
+  private ContextStopHandler(final PartitionedParameterWorker partitionedParameterWorker) {
+    this.partitionedParameterWorker = partitionedParameterWorker;
+  }
+
+  @Override
+  public void onNext(final ContextStop contextStop) {
+    LOG.log(Level.INFO, "Calling close. Will wait for close.");
+    partitionedParameterWorker.close();
+    LOG.log(Level.INFO, "Worker closed.");
+  }
+}

--- a/dolphin-ps/src/main/java/edu/snu/dolphin/ps/worker/partitioned/EncodedKey.java
+++ b/dolphin-ps/src/main/java/edu/snu/dolphin/ps/worker/partitioned/EncodedKey.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2016 Seoul National University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.snu.dolphin.ps.worker.partitioned;
+
+import org.apache.hadoop.util.hash.MurmurHash;
+import org.apache.reef.io.serialization.Codec;
+
+class EncodedKey<K> {
+  private final K key;
+  private final int hash;
+  private final byte[] encoded;
+
+  public EncodedKey(final K key, final Codec<K> keyCodec) {
+    this.key = key;
+    this.encoded = keyCodec.encode(key);
+    this.hash = computeHash();
+  }
+
+  public K getKey() {
+    return key;
+  }
+
+  public int getHash() {
+    return hash;
+  }
+
+  public byte[] getEncoded() {
+    return encoded;
+  }
+
+  private int computeHash() {
+    return Math.abs(MurmurHash.getInstance().hash(encoded));
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    final EncodedKey<?> that = (EncodedKey<?>) o;
+
+    return key.equals(that.key);
+  }
+
+  @Override
+  public int hashCode() {
+    return hash;
+  }
+}

--- a/dolphin-ps/src/main/java/edu/snu/dolphin/ps/worker/partitioned/PartitionedParameterWorker.java
+++ b/dolphin-ps/src/main/java/edu/snu/dolphin/ps/worker/partitioned/PartitionedParameterWorker.java
@@ -1,0 +1,468 @@
+/*
+ * Copyright (C) 2016 Seoul National University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.snu.dolphin.ps.worker.partitioned;
+
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import edu.snu.dolphin.ps.ParameterServerParameters.KeyCodecName;
+import edu.snu.dolphin.ps.driver.impl.ServerId;
+import edu.snu.dolphin.ps.server.api.ParameterUpdater;
+import edu.snu.dolphin.ps.worker.api.ParameterWorker;
+import edu.snu.dolphin.ps.worker.partitioned.parameters.WorkerExpireTimeout;
+import edu.snu.dolphin.ps.worker.partitioned.parameters.WorkerKeyCacheSize;
+import edu.snu.dolphin.ps.worker.partitioned.parameters.WorkerNumPartitions;
+import edu.snu.dolphin.ps.worker.partitioned.parameters.WorkerQueueSize;
+import org.apache.reef.annotations.audience.EvaluatorSide;
+import org.apache.reef.io.serialization.Codec;
+import org.apache.reef.tang.InjectionFuture;
+import org.apache.reef.tang.annotations.Parameter;
+
+import javax.inject.Inject;
+import java.util.ArrayList;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * A Partitioned Parameter Server worker that interacts with the Partitioned single-node server.
+ * A single instance of this class can be used by more than one thread safely, if and only if
+ * the Codec classes are thread-safe.
+ *
+ * There are a few client-side optimizations that can be configured.
+ * A serialized and hashed representation of a key is cached, avoiding these costs.
+ * See {@link WorkerKeyCacheSize}.
+ * The remaining configurations are related to the partitions.
+ * See {@link Partition}.
+ */
+@EvaluatorSide
+public final class PartitionedParameterWorker<K, P, V> implements ParameterWorker<K, P, V> {
+  private static final Logger LOG = Logger.getLogger(PartitionedParameterWorker.class.getName());
+
+  /**
+   * Network Connection Service identifier of the server.
+   */
+  private final String serverId;
+
+  /**
+   * Object for processing preValues and applying updates to existing values.
+   */
+  private final ParameterUpdater<K, P, V> parameterUpdater;
+
+  /**
+   * A map of pending pulls, used to reconcile the asynchronous messaging with the synchronous CacheLoader call.
+   */
+  private final ConcurrentMap<K, PullFuture<V>> pendingPulls;
+
+  /**
+   * Number of partitions.
+   */
+  private final int numPartitions;
+
+  /**
+   * Max size of each partition's queue.
+   */
+  private final int queueSize;
+
+  /**
+   * Duration in ms to keep local entries cached, after which the entries are expired.
+   */
+  private final long expireTimeout;
+
+  /**
+   * Thread pool, where each Partition is submitted.
+   */
+  private final ExecutorService threadPool;
+
+  /**
+   * Running partitions.
+   */
+  private final Partition<K, P, V>[] partitions;
+
+  /**
+   * A cache that stores encoded (serialized) keys and hashes.
+   */
+  private final LoadingCache<K, EncodedKey<K>> encodedKeyCache;
+
+  /**
+   * Send messages to the server using this field.
+   * Without {@link InjectionFuture}, this class creates an injection loop with
+   * classes related to Network Connection Service and makes the job crash (detected by Tang).
+   */
+  private final InjectionFuture<PartitionedWorkerMsgSender<K, P>> sender;
+
+  @Inject
+  private PartitionedParameterWorker(@Parameter(ServerId.class) final String serverId,
+                                     @Parameter(WorkerNumPartitions.class) final int numPartitions,
+                                     @Parameter(WorkerQueueSize.class) final int queueSize,
+                                     @Parameter(WorkerExpireTimeout.class) final long expireTimeout,
+                                     @Parameter(WorkerKeyCacheSize.class) final int keyCacheSize,
+                                     @Parameter(KeyCodecName.class) final Codec<K> keyCodec,
+                                     final ParameterUpdater<K, P, V> parameterUpdater,
+                                     final InjectionFuture<PartitionedWorkerMsgSender<K, P>> sender) {
+    this.serverId = serverId;
+    this.numPartitions = numPartitions;
+    this.queueSize = queueSize;
+    this.expireTimeout = expireTimeout;
+    this.parameterUpdater = parameterUpdater;
+    this.sender = sender;
+    this.pendingPulls = new ConcurrentHashMap<>();
+    this.threadPool = Executors.newFixedThreadPool(numPartitions);
+    this.partitions = initPartitions();
+    this.encodedKeyCache = CacheBuilder.newBuilder()
+        .maximumSize(keyCacheSize)
+        .build(new CacheLoader<K, EncodedKey<K>>() {
+          @Override
+          public EncodedKey<K> load(final K key) throws Exception {
+            return new EncodedKey<>(key, keyCodec);
+          }
+        });
+  }
+
+  /**
+   * Call after initializing numPartitions and threadPool.
+   */
+  @SuppressWarnings("unchecked")
+  private Partition<K, P, V>[] initPartitions() {
+    LOG.log(Level.INFO, "Initializing {0} partitions", numPartitions);
+    final Partition<K, P, V>[] initialized = new Partition[numPartitions];
+    for (int i = 0; i < numPartitions; i++) {
+      initialized[i] = new Partition<>(pendingPulls, sender, serverId, queueSize, expireTimeout);
+      threadPool.submit(initialized[i]);
+    }
+    return initialized;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public void push(final K key, final P preValue) {
+    try {
+      push(encodedKeyCache.get(key), preValue);
+    } catch (final ExecutionException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  public void push(final EncodedKey<K> encodedKey, final P preValue) {
+    partitions[getPartitionIndex(encodedKey.getHash())].enqueue(new PushOp(encodedKey, preValue));
+  }
+
+  @Override
+  public V pull(final K key) {
+    try {
+      return pull(encodedKeyCache.get(key));
+    } catch (final ExecutionException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  public V pull(final EncodedKey<K> encodedKey) {
+    final PullOp pullOp = new PullOp(encodedKey);
+    partitions[getPartitionIndex(encodedKey.getHash())].enqueue(pullOp);
+    return pullOp.get();
+  }
+
+  public void invalidateAll() {
+    for (int i = 0; i < numPartitions; i++) {
+      partitions[i].invalidateAll();
+    }
+  }
+
+  private int getPartitionIndex(final int keyHash) {
+    return keyHash % numPartitions;
+  }
+
+  /**
+   * Handles incoming pull replies, by setting the value of the future.
+   * This will notify the Partition's (synchronous) CacheLoader method to continue.
+   */
+  @Override
+  public void processReply(final K key, final V value) {
+    final PullFuture<V> future = pendingPulls.get(key);
+    if (future != null) {
+      future.setValue(value);
+    } else {
+      // Because we use partitions, there can be at most one active pendingPull for a key.
+      // Thus, a null value should never appear.
+      throw new RuntimeException(String.format("Pending pull was not found for key %s", key));
+    }
+  }
+
+  /**
+   * A simple Future that will wait on a get, until a value is set.
+   * We do not implement a true Future, because this is simpler.
+   */
+  private static final class PullFuture<V> {
+    private V value;
+
+    /**
+     * Block until a value is set.
+     * @return the value
+     */
+    public synchronized V getValue() {
+      while (value == null) {
+        try {
+          wait();
+        } catch (final InterruptedException e) {
+          LOG.log(Level.WARNING, "InterruptedException on wait", e);
+        }
+      }
+      return value;
+    }
+
+    /**
+     * Set the value and unblock all waiting gets.
+     * @param value the value
+     */
+    public synchronized void setValue(final V value) {
+      this.value = value;
+      notify();
+    }
+  }
+
+  /**
+   * A generic operation; operations are queued at each Partition.
+   */
+  private interface Op<K, V> {
+    /**
+     * Method to apply when dequeued by the Partition.
+     * @param kvCache the raw LoadingCache, provided by the Partition.
+     */
+    void apply(LoadingCache<EncodedKey<K>, Wrapped<V>> kvCache);
+  }
+
+  /**
+   * Wrapped values for use within each partition's cache.
+   * Wrapping allows the partition to replace the value on a local update,
+   * without updating the write time of the cache entry.
+   */
+  private static class Wrapped<V> {
+    private V value;
+
+    public Wrapped(final V value) {
+      this.value = value;
+    }
+
+    public V getValue() {
+      return value;
+    }
+
+    public void setValue(final V value) {
+      this.value = value;
+    }
+  }
+
+  /**
+   * A push operation.
+   */
+  private class PushOp implements Op<K, V> {
+    private final EncodedKey<K> encodedKey;
+    private final P preValue;
+
+    public PushOp(final EncodedKey<K> encodedKey, final P preValue) {
+      this.encodedKey = encodedKey;
+      this.preValue = preValue;
+    }
+
+    /**
+     * First, update the local value, only if it is already cached.
+     * Second, send the update to the remote PS.
+     * @param kvCache the raw LoadingCache, provided by the Partition.
+     */
+    @Override
+    public void apply(final LoadingCache<EncodedKey<K>, Wrapped<V>> kvCache) {
+      final Wrapped<V> wrapped = kvCache.getIfPresent(encodedKey);
+
+      // If it exists, update the local value, without updating the cache's write time
+      if (wrapped != null) {
+        final V oldValue = wrapped.getValue();
+        final V deltaValue = parameterUpdater.process(encodedKey.getKey(), preValue);
+        if (deltaValue == null) {
+          return;
+        }
+        final V updatedValue = parameterUpdater.update(oldValue, deltaValue);
+        wrapped.setValue(updatedValue);
+      }
+
+      // Send to remote PS
+      sender.get().sendPushMsg(serverId, encodedKey, preValue);
+    }
+  }
+
+  /**
+   * A pull operation.
+   * Also exposes a blocking {@link #get} method to retrieve the result of the pull.
+   */
+  private class PullOp implements Op<K, V> {
+    private final EncodedKey<K> encodedKey;
+    private V value;
+
+    public PullOp(final EncodedKey<K> encodedKey) {
+      this.encodedKey = encodedKey;
+    }
+
+    /**
+     * Delegate loading to the cache, then update the value and notify waiting gets.
+     * @param kvCache the raw LoadingCache, provided by the Partition.
+     */
+    @Override
+    public void apply(final LoadingCache<EncodedKey<K>, Wrapped<V>> kvCache) {
+      try {
+        final V loadedValue = kvCache.get(encodedKey).getValue();
+        synchronized (this) {
+          this.value = loadedValue;
+          notify();
+        }
+      } catch (final ExecutionException e) {
+        throw new RuntimeException(e);
+      }
+    }
+
+    /**
+     * A blocking get.
+     * @return the value
+     */
+    public V get() {
+      synchronized (this) {
+        while (value == null) {
+          try {
+            wait();
+          } catch (final InterruptedException e) {
+            LOG.log(Level.WARNING, "InterruptedException on wait", e);
+          }
+        }
+        return value;
+      }
+    }
+  }
+
+  /**
+   * A partition for the cache on the Worker.
+   * The basic structure is similar to the partition for the Server at
+   * {@link edu.snu.dolphin.ps.server.partitioned.PartitionedParameterServer}.
+   *
+   * A remotely read pull remains in the local cache for a duration of expireTimeout.
+   * Pushes are applied locally while the parameter is cached.
+   * The single queue-and-thread, combined with the server, provides a guarantee that
+   * all previous local pushes are applied to a pull, if it is locally cached.
+   *
+   * This means pull operations are queued behind push operations.
+   * We should further explore this trade-off with real ML workloads.
+   */
+  private static class Partition<K, P, V> implements Runnable {
+    private static final long QUEUE_TIMEOUT_MS = 3000;
+
+    private final LoadingCache<EncodedKey<K>, Wrapped<V>> kvCache;
+    private final BlockingQueue<Op<K, V>> queue;
+    private final ArrayList<Op<K, V>> localOps; // Operations drained from the queue, and processed locally.
+    private final int drainSize; // Max number of operations to drain per iteration.
+
+    private volatile boolean shutdown = false;
+
+    public Partition(final ConcurrentMap<K, PullFuture<V>> pendingPulls,
+                     final InjectionFuture<PartitionedWorkerMsgSender<K, P>> sender,
+                     final String serverId,
+                     final int queueSize,
+                     final long expireTimeout) {
+      kvCache = CacheBuilder.newBuilder()
+          .concurrencyLevel(1)
+          .expireAfterWrite(expireTimeout, TimeUnit.MILLISECONDS)
+          .build(new CacheLoader<EncodedKey<K>, Wrapped<V>>() {
+            @Override
+            public Wrapped<V> load(final EncodedKey<K> encodedKey) throws Exception {
+              final PullFuture<V> future = new PullFuture<>();
+              pendingPulls.put(encodedKey.getKey(), future);
+              sender.get().sendPullMsg(serverId, encodedKey);
+              final V value = future.getValue();
+              pendingPulls.remove(encodedKey.getKey());
+              return new Wrapped<>(value);
+            }
+          });
+      queue = new ArrayBlockingQueue<>(queueSize);
+      this.drainSize = queueSize / 10;
+      this.localOps = new ArrayList<>(drainSize);
+    }
+
+    /**
+     * Enqueue an operation onto the queue, blocking if the queue is full.
+     * When the queue is full, this method will block; thus, a full queue will block the thread calling
+     * enqueue, e.g., from the NCS message thread pool, until the queue is drained.
+     *
+     * @param op the operation to enqueue
+     */
+    public void enqueue(final Op<K, V> op) {
+      try {
+        queue.put(op);
+      } catch (final InterruptedException e) {
+        LOG.log(Level.SEVERE, "Enqueue failed with InterruptedException", e);
+        return;
+      }
+    }
+
+    /**
+     * Invalidate all cached pulls.
+     */
+    public void invalidateAll() {
+      kvCache.invalidateAll();
+    }
+
+    /**
+     * Loop that dequeues operations and applies them.
+     * Dequeues are only performed through this thread.
+     */
+    @Override
+    public void run() {
+      while (!shutdown) {
+        // First, poll and apply. The timeout allows the run thread to shutdown cleanly within timeout ms.
+        try {
+          final Op<K, V> op = queue.poll(QUEUE_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+          if (op == null) {
+            continue;
+          }
+          op.apply(kvCache);
+        } catch (final InterruptedException e) {
+          LOG.log(Level.SEVERE, "Poll failed with InterruptedException", e);
+          continue;
+        }
+
+        // Then, drain up to drainSize of the remaining queue and apply.
+        // Calling drainTo does not block if queue is empty, which is why we poll first.
+        // This should be faster than polling each op, because the blocking queue's lock is only acquired once.
+        queue.drainTo(localOps, drainSize);
+        for (final Op<K, V> op : localOps) {
+          op.apply(kvCache);
+        }
+        localOps.clear();
+      }
+    }
+
+    /**
+     * Cleanly shutdown the run thread.
+     */
+    public void shutdown() {
+      shutdown = true;
+    }
+  }
+}

--- a/dolphin-ps/src/main/java/edu/snu/dolphin/ps/worker/partitioned/package-info.java
+++ b/dolphin-ps/src/main/java/edu/snu/dolphin/ps/worker/partitioned/package-info.java
@@ -13,11 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package edu.snu.dolphin.ps.server.partitioned.parameters;
-
-import org.apache.reef.tang.annotations.Name;
-import org.apache.reef.tang.annotations.NamedParameter;
-
-@NamedParameter(doc = "Number of partitions", default_value = "2", short_name = "numPartitions")
-public final class NumPartitions implements Name<Integer> {
-}
+/**
+ * Partitioned implementation of Parameter Server worker (client).
+ * For use with server in {@link edu.snu.dolphin.ps.server.partitioned}.
+ */
+package edu.snu.dolphin.ps.worker.partitioned;

--- a/dolphin-ps/src/main/java/edu/snu/dolphin/ps/worker/partitioned/parameters/WorkerExpireTimeout.java
+++ b/dolphin-ps/src/main/java/edu/snu/dolphin/ps/worker/partitioned/parameters/WorkerExpireTimeout.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2016 Seoul National University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.snu.dolphin.ps.worker.partitioned.parameters;
+
+import org.apache.reef.tang.annotations.Name;
+import org.apache.reef.tang.annotations.NamedParameter;
+
+@NamedParameter(doc = "Time in ms to expire local cache", default_value = "1000",
+    short_name = "workerExpireTimeout")
+public final class WorkerExpireTimeout implements Name<Long> {
+}

--- a/dolphin-ps/src/main/java/edu/snu/dolphin/ps/worker/partitioned/parameters/WorkerKeyCacheSize.java
+++ b/dolphin-ps/src/main/java/edu/snu/dolphin/ps/worker/partitioned/parameters/WorkerKeyCacheSize.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2016 Seoul National University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.snu.dolphin.ps.worker.partitioned.parameters;
+
+import org.apache.reef.tang.annotations.Name;
+import org.apache.reef.tang.annotations.NamedParameter;
+
+@NamedParameter(doc = "Max number of encoded keys to cache", default_value = "100",
+    short_name = "workerKeyCacheSize")
+public final class WorkerKeyCacheSize implements Name<Integer> {
+}

--- a/dolphin-ps/src/main/java/edu/snu/dolphin/ps/worker/partitioned/parameters/WorkerNumPartitions.java
+++ b/dolphin-ps/src/main/java/edu/snu/dolphin/ps/worker/partitioned/parameters/WorkerNumPartitions.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 2016 Seoul National University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.snu.dolphin.ps.worker.partitioned.parameters;
+
+import org.apache.reef.tang.annotations.Name;
+import org.apache.reef.tang.annotations.NamedParameter;
+
+@NamedParameter(doc = "Number of partitions", default_value = "2", short_name = "workerNumPartitions")
+public final class WorkerNumPartitions implements Name<Integer> {
+}

--- a/dolphin-ps/src/main/java/edu/snu/dolphin/ps/worker/partitioned/parameters/WorkerQueueSize.java
+++ b/dolphin-ps/src/main/java/edu/snu/dolphin/ps/worker/partitioned/parameters/WorkerQueueSize.java
@@ -13,8 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/**
- * Concurrent implementation of Parameter Server worker (client).
- * For use with server in {@link edu.snu.dolphin.ps.server.concurrent}.
- */
-package edu.snu.dolphin.ps.worker.impl;
+package edu.snu.dolphin.ps.worker.partitioned.parameters;
+
+import org.apache.reef.tang.annotations.Name;
+import org.apache.reef.tang.annotations.NamedParameter;
+
+@NamedParameter(doc = "Max number of items that can be queued for each partition", default_value = "100",
+    short_name = "workerQueueSize")
+public final class WorkerQueueSize implements Name<Integer> {
+}

--- a/dolphin-ps/src/main/java/edu/snu/dolphin/ps/worker/partitioned/parameters/package-info.java
+++ b/dolphin-ps/src/main/java/edu/snu/dolphin/ps/worker/partitioned/parameters/package-info.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright (C) 2016 Seoul National University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Parameters related to Partitioned PS Worker.
+ */
+package edu.snu.dolphin.ps.worker.partitioned.parameters;

--- a/dolphin-ps/src/test/java/edu/snu/dolphin/ps/worker/ConcurrentParameterWorkerTest.java
+++ b/dolphin-ps/src/test/java/edu/snu/dolphin/ps/worker/ConcurrentParameterWorkerTest.java
@@ -17,8 +17,8 @@ package edu.snu.dolphin.ps.worker;
 
 import edu.snu.dolphin.ps.TestUtils;
 import edu.snu.dolphin.ps.driver.impl.ServerId;
-import edu.snu.dolphin.ps.worker.impl.SingleNodeParameterWorker;
-import edu.snu.dolphin.ps.worker.impl.WorkerSideMsgSender;
+import edu.snu.dolphin.ps.worker.concurrent.ConcurrentParameterWorker;
+import edu.snu.dolphin.ps.worker.concurrent.WorkerSideMsgSender;
 import org.apache.reef.tang.Configuration;
 import org.apache.reef.tang.Injector;
 import org.apache.reef.tang.Tang;
@@ -36,13 +36,13 @@ import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
 /**
- * Tests for {@link SingleNodeParameterWorker}.
+ * Tests for {@link ConcurrentParameterWorker}.
  */
-public final class SingleNodeParameterWorkerTest {
+public final class ConcurrentParameterWorkerTest {
   private static final Integer KEY = 0;
   private static final String MSG_THREADS_NOT_FINISHED = "threads not finished (possible deadlock or infinite loop)";
   private static final String MSG_RESULT_ASSERTION = "threads received null";
-  private SingleNodeParameterWorker<Integer, Integer, Integer> worker;
+  private ConcurrentParameterWorker<Integer, Integer, Integer> worker;
 
   @Before
   public void setup() throws InjectionException {
@@ -73,12 +73,12 @@ public final class SingleNodeParameterWorkerTest {
     }).when(mockSender).sendPullMsg(anyString(), anyInt());
 
     injector.bindVolatileInstance(WorkerSideMsgSender.class, mockSender);
-    worker = injector.getInstance(SingleNodeParameterWorker.class);
+    worker = injector.getInstance(ConcurrentParameterWorker.class);
   }
 
   /**
-   * Test the thread safety of {@link SingleNodeParameterWorker} by
-   * creating multiple threads that try to pull values from the server using {@link SingleNodeParameterWorker}.
+   * Test the thread safety of {@link ConcurrentParameterWorker} by
+   * creating multiple threads that try to pull values from the server using {@link ConcurrentParameterWorker}.
    */
   @Test
   public void testMultiThreadPull() throws InterruptedException {


### PR DESCRIPTION
Closes #154.

This creates a Partitioned PS Worker.
   * A remotely read pull remains in the local cache for a duration of expireTimeout.
   * Pushes are applied locally while the parameter is cached.
   * The per partition single queue-and-thread, combined with the server, provides a guarantee that all previous local pushes are applied to a pull, if it is locally cached.

On local tests, the performance is comparable to ConcurrentParameterWorker.

There is a bug and workaround in this code:

We are observing some lost messages when contexts are immediately closed after the task completes in the example. It appears messages buffered in NCS are not being flushed before context close, but this has to be investigated further. The current workaround in the example is to not close contexts immediately, but this must be resolved before we move to elastically removing contexts.

(This should not be a Worker problem. The `ContextStopHandler` waits for messages to be flushed from the Worker queue.)