### PR TITLE
[DOLPHIN-158] Remove processReply from PartitionWorker

### DIFF
--- a/dolphin-ps/src/main/java/edu/snu/dolphin/ps/driver/impl/ConcurrentParameterServerManager.java
+++ b/dolphin-ps/src/main/java/edu/snu/dolphin/ps/driver/impl/ConcurrentParameterServerManager.java
@@ -21,8 +21,10 @@ import edu.snu.dolphin.ps.ns.PSMessageHandler;
 import edu.snu.dolphin.ps.server.concurrent.api.ParameterServer;
 import edu.snu.dolphin.ps.server.concurrent.impl.ServerSideMsgHandler;
 import edu.snu.dolphin.ps.server.concurrent.impl.ConcurrentParameterServer;
+import edu.snu.dolphin.ps.worker.AsyncWorkerHandler;
 import edu.snu.dolphin.ps.worker.api.ParameterWorker;
 import edu.snu.dolphin.ps.worker.concurrent.ConcurrentParameterWorker;
+import edu.snu.dolphin.ps.worker.concurrent.ConcurrentWorkerHandler;
 import org.apache.reef.annotations.audience.DriverSide;
 import org.apache.reef.driver.context.ServiceConfiguration;
 import org.apache.reef.tang.Configuration;
@@ -59,6 +61,7 @@ public final class ConcurrentParameterServerManager implements ParameterServerMa
             .set(ServiceConfiguration.SERVICES, ConcurrentParameterWorker.class)
             .build())
         .bindImplementation(ParameterWorker.class, ConcurrentParameterWorker.class)
+        .bindImplementation(AsyncWorkerHandler.class, ConcurrentWorkerHandler.class)
         .bindNamedParameter(ServerId.class, SERVER_ID)
         .bindNamedParameter(EndpointId.class, WORKER_ID_PREFIX + workerIndex)
         .build();

--- a/dolphin-ps/src/main/java/edu/snu/dolphin/ps/driver/impl/PartitionedParameterServerManager.java
+++ b/dolphin-ps/src/main/java/edu/snu/dolphin/ps/driver/impl/PartitionedParameterServerManager.java
@@ -24,9 +24,11 @@ import edu.snu.dolphin.ps.server.partitioned.PartitionedServerSideReplySender;
 import edu.snu.dolphin.ps.server.partitioned.PartitionedServerSideReplySenderImpl;
 import edu.snu.dolphin.ps.server.partitioned.parameters.ServerNumPartitions;
 import edu.snu.dolphin.ps.server.partitioned.parameters.ServerQueueSize;
+import edu.snu.dolphin.ps.worker.AsyncWorkerHandler;
 import edu.snu.dolphin.ps.worker.api.ParameterWorker;
 import edu.snu.dolphin.ps.worker.partitioned.ContextStopHandler;
 import edu.snu.dolphin.ps.worker.partitioned.PartitionedParameterWorker;
+import edu.snu.dolphin.ps.worker.partitioned.PartitionedWorkerHandler;
 import org.apache.reef.annotations.audience.DriverSide;
 import org.apache.reef.driver.context.ServiceConfiguration;
 import org.apache.reef.tang.Configuration;
@@ -75,6 +77,7 @@ public final class PartitionedParameterServerManager implements ParameterServerM
             .set(ServiceConfiguration.ON_CONTEXT_STOP, ContextStopHandler.class)
             .build())
         .bindImplementation(ParameterWorker.class, PartitionedParameterWorker.class)
+        .bindImplementation(AsyncWorkerHandler.class, PartitionedWorkerHandler.class)
         .bindNamedParameter(ServerId.class, SERVER_ID)
         .bindNamedParameter(EndpointId.class, WORKER_ID_PREFIX + workerIndex)
         .build();

--- a/dolphin-ps/src/main/java/edu/snu/dolphin/ps/worker/AsyncWorkerHandler.java
+++ b/dolphin-ps/src/main/java/edu/snu/dolphin/ps/worker/AsyncWorkerHandler.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2016 Seoul National University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.snu.dolphin.ps.worker;
+
+/**
+ * Process a pull reply message received from the server.
+ * This is an internal interface, to be used to connect the {@link WorkerSideMsgHandler}
+ * to a {@link edu.snu.dolphin.ps.worker.api.ParameterWorker}.
+ */
+public interface AsyncWorkerHandler<K, V> {
+  /**
+   * Reply to the worker with a {@code value} that was previously requested by {@code pull}.
+   * @param key key object representing what was sent
+   * @param value value sent from the server
+   */
+  void processReply(K key, V value);
+}

--- a/dolphin-ps/src/main/java/edu/snu/dolphin/ps/worker/api/ParameterWorker.java
+++ b/dolphin-ps/src/main/java/edu/snu/dolphin/ps/worker/api/ParameterWorker.java
@@ -40,12 +40,5 @@ public interface ParameterWorker<K, P, V> {
    * @return value specified by the {@code key}, or {@code null} if something unexpected happens (see implementation)
    */
   V pull(K key);
-
-  /**
-   * Reply to the worker with a {@code value} that was previously requested by {@code pull}.
-   * @param key key object representing what was sent
-   * @param value value sent from the server
-   */
-  void processReply(K key, V value);
 }
 

--- a/dolphin-ps/src/main/java/edu/snu/dolphin/ps/worker/concurrent/ConcurrentParameterWorker.java
+++ b/dolphin-ps/src/main/java/edu/snu/dolphin/ps/worker/concurrent/ConcurrentParameterWorker.java
@@ -35,7 +35,7 @@ import java.util.logging.Logger;
 @EvaluatorSide
 public final class ConcurrentParameterWorker<K, P, V> implements ParameterWorker<K, P, V> {
   private static final Logger LOG = Logger.getLogger(ConcurrentParameterWorker.class.getName());
-  private static final long TIMEOUT = 40000; // milliseconds
+  private static final long TIMEOUT = 400000; // milliseconds
 
   /**
    * Network Connection Service identifier of the server.
@@ -84,17 +84,17 @@ public final class ConcurrentParameterWorker<K, P, V> implements ParameterWorker
 
       final ValueWrapper valueWrapper = keyToValueWrapper.get(key);
       synchronized (valueWrapper) {
-        // the reply arrived right before I acquired the lock
-        // try again from start
         if (!keyToValueWrapper.containsKey(key)) {
+          // the reply arrived right before I acquired the lock
+          // try again from start
           continue;
         }
 
         valueWrapper.startWaiting();
 
-        // the first one to wait will send the fetch message
-        // others don't have to send the same message again
         if (isFirstToWait) {
+          // the first one to wait will send the fetch message
+          // others don't have to send the same message again
           sender.get().sendPullMsg(serverId, key);
         }
 
@@ -118,9 +118,9 @@ public final class ConcurrentParameterWorker<K, P, V> implements ParameterWorker
   }
 
   /**
-   * {@inheritDoc}
+   * Process a pull reply message received from the server.
+   * Called by {@link ConcurrentWorkerHandler#processReply}.
    */
-  @Override
   public void processReply(final K key, final V value) {
     final ValueWrapper valueWrapper = keyToValueWrapper.remove(key);
     if (valueWrapper != null) {

--- a/dolphin-ps/src/main/java/edu/snu/dolphin/ps/worker/concurrent/ConcurrentWorkerHandler.java
+++ b/dolphin-ps/src/main/java/edu/snu/dolphin/ps/worker/concurrent/ConcurrentWorkerHandler.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2016 Seoul National University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.snu.dolphin.ps.worker.concurrent;
+
+import edu.snu.dolphin.ps.worker.AsyncWorkerHandler;
+
+import javax.inject.Inject;
+
+public final class ConcurrentWorkerHandler<K, V> implements AsyncWorkerHandler<K, V> {
+  private final ConcurrentParameterWorker<K, ?, V> concurrentParameterWorker;
+
+  @Inject
+  private ConcurrentWorkerHandler(final ConcurrentParameterWorker<K, ?, V> concurrentParameterWorker) {
+    this.concurrentParameterWorker = concurrentParameterWorker;
+  }
+
+  @Override
+  public void processReply(final K key, final V value) {
+    concurrentParameterWorker.processReply(key, value);
+  }
+}

--- a/dolphin-ps/src/main/java/edu/snu/dolphin/ps/worker/partitioned/PartitionedParameterWorker.java
+++ b/dolphin-ps/src/main/java/edu/snu/dolphin/ps/worker/partitioned/PartitionedParameterWorker.java
@@ -52,7 +52,7 @@ import java.util.logging.Logger;
  * There are a few client-side optimizations that can be configured.
  * A serialized and hashed representation of a key is cached, avoiding these costs.
  * See {@link WorkerKeyCacheSize}.
- * The remaining configurations are related to the partitions.
+ * The remaining configurations are related to the worker-side partitions.
  * See {@link Partition}.
  */
 @EvaluatorSide
@@ -211,8 +211,8 @@ public final class PartitionedParameterWorker<K, P, V> implements ParameterWorke
   /**
    * Handles incoming pull replies, by setting the value of the future.
    * This will notify the Partition's (synchronous) CacheLoader method to continue.
+   * Called by {@link PartitionedWorkerHandler#processReply}.
    */
-  @Override
   public void processReply(final K key, final V value) {
     final PullFuture<V> future = pendingPulls.get(key);
     if (future != null) {
@@ -376,6 +376,9 @@ public final class PartitionedParameterWorker<K, P, V> implements ParameterWorke
    * A partition for the cache on the Worker.
    * The basic structure is similar to the partition for the Server at
    * {@link edu.snu.dolphin.ps.server.partitioned.PartitionedParameterServer}.
+   *
+   * The partitions at the Worker can be independent of the partitions at the Server. In other words,
+   * the number of worker-side partitions does not have to be equal to the number of server-side partitions.
    *
    * A remotely read pull remains in the local cache for a duration of expireTimeout.
    * Pushes are applied locally while the parameter is cached.

--- a/dolphin-ps/src/main/java/edu/snu/dolphin/ps/worker/partitioned/PartitionedWorkerHandler.java
+++ b/dolphin-ps/src/main/java/edu/snu/dolphin/ps/worker/partitioned/PartitionedWorkerHandler.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2016 Seoul National University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.snu.dolphin.ps.worker.partitioned;
+
+import edu.snu.dolphin.ps.worker.AsyncWorkerHandler;
+
+import javax.inject.Inject;
+
+public final class PartitionedWorkerHandler<K, V> implements AsyncWorkerHandler<K, V> {
+  private final PartitionedParameterWorker<K, ?, V> partitionedParameterWorker;
+
+  @Inject
+  private PartitionedWorkerHandler(final PartitionedParameterWorker<K, ?, V> partitionedParameterWorker) {
+    this.partitionedParameterWorker = partitionedParameterWorker;
+  }
+
+  @Override
+  public void processReply(final K key, final V value) {
+    partitionedParameterWorker.processReply(key, value);
+  }
+}

--- a/dolphin-ps/src/test/java/edu/snu/dolphin/ps/worker/ConcurrentParameterWorkerTest.java
+++ b/dolphin-ps/src/test/java/edu/snu/dolphin/ps/worker/ConcurrentParameterWorkerTest.java
@@ -17,8 +17,9 @@ package edu.snu.dolphin.ps.worker;
 
 import edu.snu.dolphin.ps.TestUtils;
 import edu.snu.dolphin.ps.driver.impl.ServerId;
-import edu.snu.dolphin.ps.worker.concurrent.ConcurrentParameterWorker;
+import edu.snu.dolphin.ps.worker.concurrent.ConcurrentWorkerHandler;
 import edu.snu.dolphin.ps.worker.concurrent.WorkerSideMsgSender;
+import edu.snu.dolphin.ps.worker.concurrent.ConcurrentParameterWorker;
 import org.apache.reef.tang.Configuration;
 import org.apache.reef.tang.Injector;
 import org.apache.reef.tang.Tang;
@@ -32,7 +33,8 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.*;
 
 /**
@@ -43,6 +45,7 @@ public final class ConcurrentParameterWorkerTest {
   private static final String MSG_THREADS_NOT_FINISHED = "threads not finished (possible deadlock or infinite loop)";
   private static final String MSG_RESULT_ASSERTION = "threads received null";
   private ConcurrentParameterWorker<Integer, Integer, Integer> worker;
+  private ConcurrentWorkerHandler<Integer, Integer> handler;
 
   @Before
   public void setup() throws InjectionException {
@@ -60,7 +63,7 @@ public final class ConcurrentParameterWorkerTest {
             try {
               // simulate slow network by purposely sleeping for 5 seconds
               Thread.sleep(5000);
-              worker.processReply(KEY, 1);
+              handler.processReply(KEY, 1);
             } catch (final InterruptedException e) {
               throw new RuntimeException(e);
             }
@@ -74,6 +77,7 @@ public final class ConcurrentParameterWorkerTest {
 
     injector.bindVolatileInstance(WorkerSideMsgSender.class, mockSender);
     worker = injector.getInstance(ConcurrentParameterWorker.class);
+    handler = injector.getInstance(ConcurrentWorkerHandler.class);
   }
 
   /**


### PR DESCRIPTION
Remove processReply from user-facing PartitionWorker by introducing AsyncWorkerHandler. AsyncWorkerHandler is implemented by Concurrent and Partitioned Workers; it is only meant to be used internally.

This closes #158.