### PR TITLE
Use Apache REEF 0.14.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <reef.version>0.14.0-SNAPSHOT</reef.version>
+    <reef.version>0.14.0</reef.version>
     <hadoop.version>2.4.0</hadoop.version>
     <mahout.version>0.9</mahout.version>
     <rat.version>0.11</rat.version>


### PR DESCRIPTION
Apache REEF 0.14 is released at the maven central.
We had better use 0.14 instead of 0.14-SNAPSHOT.