### PR TITLE
[DOLPHIN-131] Add static multi-node parameter server

### DIFF
--- a/dolphin-ps/src/main/java/edu/snu/dolphin/ps/common/Constants.java
+++ b/dolphin-ps/src/main/java/edu/snu/dolphin/ps/common/Constants.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2016 Seoul National University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.snu.dolphin.ps.common;
+
+/**
+ * Constants used across Driver/Server/Worker boundaries.
+ */
+public final class Constants {
+  /**
+   * Empty private constructor to prohibit instantiation of utility class.
+   */
+  private Constants() {
+  }
+
+  public static final String SERVER_ID_PREFIX = "SERVER_ID_";
+  public static final String WORKER_ID_PREFIX = "WORKER_ID_";
+}

--- a/dolphin-ps/src/main/java/edu/snu/dolphin/ps/common/package-info.java
+++ b/dolphin-ps/src/main/java/edu/snu/dolphin/ps/common/package-info.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright (C) 2016 Seoul National University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Common Parameter Server classes used across Driver, Server, and Worker.
+ */
+package edu.snu.dolphin.ps.common;

--- a/dolphin-ps/src/main/java/edu/snu/dolphin/ps/common/partitioned/parameters/NumPartitions.java
+++ b/dolphin-ps/src/main/java/edu/snu/dolphin/ps/common/partitioned/parameters/NumPartitions.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 2016 Seoul National University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.snu.dolphin.ps.common.partitioned.parameters;
+
+import org.apache.reef.tang.annotations.Name;
+import org.apache.reef.tang.annotations.NamedParameter;
+
+@NamedParameter(doc = "Number of partitions across all servers", default_value = "2", short_name = "numPartitions")
+public final class NumPartitions implements Name<Integer> {
+}

--- a/dolphin-ps/src/main/java/edu/snu/dolphin/ps/common/partitioned/parameters/NumServers.java
+++ b/dolphin-ps/src/main/java/edu/snu/dolphin/ps/common/partitioned/parameters/NumServers.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 2016 Seoul National University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.snu.dolphin.ps.common.partitioned.parameters;
+
+import org.apache.reef.tang.annotations.Name;
+import org.apache.reef.tang.annotations.NamedParameter;
+
+@NamedParameter(doc = "Number of servers", default_value = "1", short_name = "numServers")
+public final class NumServers implements Name<Integer> {
+}

--- a/dolphin-ps/src/main/java/edu/snu/dolphin/ps/common/partitioned/parameters/package-info.java
+++ b/dolphin-ps/src/main/java/edu/snu/dolphin/ps/common/partitioned/parameters/package-info.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright (C) 2016 Seoul National University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Common parameters related to Partitioned PS.
+ */
+package edu.snu.dolphin.ps.common.partitioned.parameters;

--- a/dolphin-ps/src/main/java/edu/snu/dolphin/ps/common/partitioned/resolver/ServerResolver.java
+++ b/dolphin-ps/src/main/java/edu/snu/dolphin/ps/common/partitioned/resolver/ServerResolver.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2016 Seoul National University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.snu.dolphin.ps.common.partitioned.resolver;
+
+import java.util.List;
+
+/**
+ * A ServerResolver that is queried for the mapping between hashed keys,
+ * partitions and servers.
+ *
+ * Used at both the worker and server:
+ * A worker resolves a hashed key to its server,
+ * then the server resolves this hashed key to a partition.
+ */
+public interface ServerResolver {
+
+  /**
+   * @param hash unsigned int hash to resolve server from.
+   * @return Network Connection Service identifier of the server.
+   */
+  String resolveServer(int hash);
+
+  /**
+   * @param hash unsigned int hash to resolve partition index from.
+   * @return Global partition index that this hash resolves to.
+   */
+  int resolvePartition(int hash);
+
+  /**
+   * @param server Network Connections Service identifier of the server.
+   * @return List of global partition indices that are mapped to the server.
+   */
+  List<Integer> getPartitions(String server);
+}

--- a/dolphin-ps/src/main/java/edu/snu/dolphin/ps/common/partitioned/resolver/SingleNodeServerResolver.java
+++ b/dolphin-ps/src/main/java/edu/snu/dolphin/ps/common/partitioned/resolver/SingleNodeServerResolver.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2016 Seoul National University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.snu.dolphin.ps.common.partitioned.resolver;
+
+import edu.snu.dolphin.ps.common.partitioned.parameters.NumPartitions;
+import edu.snu.dolphin.ps.driver.impl.ServerId;
+import org.apache.reef.tang.annotations.Parameter;
+
+import javax.inject.Inject;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Resolves to the single server node defined by {@link ServerId}.
+ */
+public final class SingleNodeServerResolver implements ServerResolver {
+
+  /**
+   * Network Connection Service identifier of the server.
+   */
+  private final String serverId;
+
+  /**
+   * Number of partitions.
+   */
+  private final int numPartitions;
+
+  /**
+   * List of all partitions mapped to the single node.
+   */
+  private final List<Integer> partitions;
+
+  @Inject
+  private SingleNodeServerResolver(@Parameter(ServerId.class) final String serverId,
+                                   @Parameter(NumPartitions.class) final int numPartitions) {
+    this.serverId = serverId;
+    this.numPartitions = numPartitions;
+    this.partitions = new ArrayList<>(numPartitions);
+    for (int i = 0; i < numPartitions; i++) {
+      partitions.add(i);
+    }
+  }
+
+  @Override
+  public String resolveServer(final int hash) {
+    return serverId;
+  }
+
+  @Override
+  public int resolvePartition(final int hash) {
+    return hash % numPartitions;
+  }
+
+  @Override
+  public List<Integer> getPartitions(final String server) {
+    return partitions;
+  }
+}

--- a/dolphin-ps/src/main/java/edu/snu/dolphin/ps/common/partitioned/resolver/StaticServerResolver.java
+++ b/dolphin-ps/src/main/java/edu/snu/dolphin/ps/common/partitioned/resolver/StaticServerResolver.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (C) 2016 Seoul National University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.snu.dolphin.ps.common.partitioned.resolver;
+
+import edu.snu.dolphin.ps.common.partitioned.parameters.NumPartitions;
+import edu.snu.dolphin.ps.common.partitioned.parameters.NumServers;
+import org.apache.reef.tang.annotations.Parameter;
+
+import javax.inject.Inject;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static edu.snu.dolphin.ps.common.Constants.SERVER_ID_PREFIX;
+
+/**
+ * A hashed key to partition to server mapping that is configured on Job startup,
+ * based on a simple round-robin assignment of partitions to physical servers.
+ * For example, with 3 servers and 7 partitions, the server-to-partition mapping will produce:
+ *   server0 -> 0, 3, 6
+ *   server1 -> 1, 4
+ *   server2 -> 2, 5
+ *
+ * This mapping cannot be changed dynamically (i.e., after Job configuration).
+ */
+public final class StaticServerResolver implements ServerResolver {
+
+  /**
+   * Number of partitions, globally held by all servers.
+   */
+  private final int numPartitions;
+
+  /**
+   * Mapping from partition to server.
+   * The array is indexed by partition index, and contains the server's NCS name.
+   */
+  private final String[] partitionToServer;
+
+  /**
+   * Mapping from server to partitions.
+   * The key is the server's NCS name, and the value is a list of partition indices held by the server.
+   * Contains the same information as partitionToServer, but indexed by server.
+   */
+  private final Map<String, List<Integer>> serverToPartitions;
+
+  @Inject
+  private StaticServerResolver(@Parameter(NumServers.class) final int numServers,
+                               @Parameter(NumPartitions.class) final int numPartitions) {
+    this.numPartitions = numPartitions;
+
+    this.serverToPartitions = new HashMap<>(numServers);
+    for (int i = 0; i < numServers; i++) {
+      serverToPartitions.put(SERVER_ID_PREFIX + i, new ArrayList<Integer>());
+    }
+
+    this.partitionToServer = new String[numPartitions];
+    for (int partitionIndex = 0; partitionIndex < partitionToServer.length; partitionIndex++) {
+      final int serverIndex = partitionIndex % numServers;
+      partitionToServer[partitionIndex] = (SERVER_ID_PREFIX + serverIndex);
+      serverToPartitions.get(SERVER_ID_PREFIX + serverIndex).add(partitionIndex);
+    }
+  }
+
+  @Override
+  public String resolveServer(final int hash) {
+    return partitionToServer[resolvePartition(hash)];
+  }
+
+  @Override
+  public int resolvePartition(final int hash) {
+    return hash % numPartitions;
+  }
+
+  @Override
+  public List<Integer> getPartitions(final String server) {
+    return serverToPartitions.get(server);
+  }
+}

--- a/dolphin-ps/src/main/java/edu/snu/dolphin/ps/common/partitioned/resolver/package-info.java
+++ b/dolphin-ps/src/main/java/edu/snu/dolphin/ps/common/partitioned/resolver/package-info.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright (C) 2016 Seoul National University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Resolve Server name based on a hashed key.
+ */
+package edu.snu.dolphin.ps.common.partitioned.resolver;

--- a/dolphin-ps/src/main/java/edu/snu/dolphin/ps/driver/impl/ConcurrentParameterServerManager.java
+++ b/dolphin-ps/src/main/java/edu/snu/dolphin/ps/driver/impl/ConcurrentParameterServerManager.java
@@ -33,14 +33,15 @@ import org.apache.reef.tang.Tang;
 import javax.inject.Inject;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import static edu.snu.dolphin.ps.common.Constants.SERVER_ID_PREFIX;
+import static edu.snu.dolphin.ps.common.Constants.WORKER_ID_PREFIX;
+
 /**
  * Manager class for a Parameter Server that uses only one node for a server.
  * This manager does NOT handle server or worker faults.
  */
 @DriverSide
 public final class ConcurrentParameterServerManager implements ParameterServerManager {
-  private static final String SERVER_ID = "SINGLE_NODE_SERVER_ID";
-  private static final String WORKER_ID_PREFIX = "SINGLE_NODE_WORKER_ID_";
   private final AtomicInteger numWorkers;
 
   @Inject
@@ -62,7 +63,7 @@ public final class ConcurrentParameterServerManager implements ParameterServerMa
             .build())
         .bindImplementation(ParameterWorker.class, ConcurrentParameterWorker.class)
         .bindImplementation(AsyncWorkerHandler.class, ConcurrentWorkerHandler.class)
-        .bindNamedParameter(ServerId.class, SERVER_ID)
+        .bindNamedParameter(ServerId.class, SERVER_ID_PREFIX + 0)
         .bindNamedParameter(EndpointId.class, WORKER_ID_PREFIX + workerIndex)
         .build();
   }
@@ -79,7 +80,7 @@ public final class ConcurrentParameterServerManager implements ParameterServerMa
             .build())
         .bindNamedParameter(PSMessageHandler.class, ServerSideMsgHandler.class)
         .bindImplementation(ParameterServer.class, ConcurrentParameterServer.class)
-        .bindNamedParameter(EndpointId.class, SERVER_ID)
+        .bindNamedParameter(EndpointId.class, SERVER_ID_PREFIX + 0)
         .build();
   }
 

--- a/dolphin-ps/src/main/java/edu/snu/dolphin/ps/driver/impl/PartitionedParameterServerManager.java
+++ b/dolphin-ps/src/main/java/edu/snu/dolphin/ps/driver/impl/PartitionedParameterServerManager.java
@@ -22,13 +22,16 @@ import edu.snu.dolphin.ps.server.partitioned.PartitionedParameterServer;
 import edu.snu.dolphin.ps.server.partitioned.PartitionedServerSideMsgHandler;
 import edu.snu.dolphin.ps.server.partitioned.PartitionedServerSideReplySender;
 import edu.snu.dolphin.ps.server.partitioned.PartitionedServerSideReplySenderImpl;
-import edu.snu.dolphin.ps.server.partitioned.parameters.ServerNumPartitions;
+import edu.snu.dolphin.ps.common.partitioned.parameters.NumServers;
+import edu.snu.dolphin.ps.common.partitioned.parameters.NumPartitions;
 import edu.snu.dolphin.ps.server.partitioned.parameters.ServerQueueSize;
 import edu.snu.dolphin.ps.worker.AsyncWorkerHandler;
 import edu.snu.dolphin.ps.worker.api.ParameterWorker;
 import edu.snu.dolphin.ps.worker.partitioned.ContextStopHandler;
 import edu.snu.dolphin.ps.worker.partitioned.PartitionedParameterWorker;
 import edu.snu.dolphin.ps.worker.partitioned.PartitionedWorkerHandler;
+import edu.snu.dolphin.ps.common.partitioned.resolver.ServerResolver;
+import edu.snu.dolphin.ps.common.partitioned.resolver.StaticServerResolver;
 import org.apache.reef.annotations.audience.DriverSide;
 import org.apache.reef.driver.context.ServiceConfiguration;
 import org.apache.reef.tang.Configuration;
@@ -37,6 +40,9 @@ import org.apache.reef.tang.annotations.Parameter;
 
 import javax.inject.Inject;
 import java.util.concurrent.atomic.AtomicInteger;
+
+import static edu.snu.dolphin.ps.common.Constants.SERVER_ID_PREFIX;
+import static edu.snu.dolphin.ps.common.Constants.WORKER_ID_PREFIX;
 
 /**
  * Manager class for a Partitioned Parameter Server, that supports atomic,
@@ -48,19 +54,21 @@ import java.util.concurrent.atomic.AtomicInteger;
  */
 @DriverSide
 public final class PartitionedParameterServerManager implements ParameterServerManager {
-  private static final String SERVER_ID = "PARTITIONED_SERVER_ID";
-  private static final String WORKER_ID_PREFIX = "PARTITIONED_WORKER_ID_";
-
+  private final int numServers;
   private final int numPartitions;
   private final int queueSize;
-  private final AtomicInteger numWorkers;
+  private final AtomicInteger workerCount;
+  private final AtomicInteger serverCount;
 
   @Inject
-  private PartitionedParameterServerManager(@Parameter(ServerNumPartitions.class) final int numPartitions,
+  private PartitionedParameterServerManager(@Parameter(NumServers.class) final int numServers,
+                                            @Parameter(NumPartitions.class) final int numPartitions,
                                             @Parameter(ServerQueueSize.class) final int queueSize) {
+    this.numServers = numServers;
     this.numPartitions = numPartitions;
     this.queueSize = queueSize;
-    this.numWorkers = new AtomicInteger(0);
+    this.workerCount = new AtomicInteger(0);
+    this.serverCount = new AtomicInteger(0);
   }
 
   /**
@@ -69,7 +77,7 @@ public final class PartitionedParameterServerManager implements ParameterServerM
    */
   @Override
   public Configuration getWorkerServiceConfiguration() {
-    final int workerIndex = numWorkers.getAndIncrement();
+    final int workerIndex = workerCount.getAndIncrement();
 
     return Tang.Factory.getTang()
         .newConfigurationBuilder(ServiceConfiguration.CONF
@@ -78,7 +86,9 @@ public final class PartitionedParameterServerManager implements ParameterServerM
             .build())
         .bindImplementation(ParameterWorker.class, PartitionedParameterWorker.class)
         .bindImplementation(AsyncWorkerHandler.class, PartitionedWorkerHandler.class)
-        .bindNamedParameter(ServerId.class, SERVER_ID)
+        .bindImplementation(ServerResolver.class, StaticServerResolver.class)
+        .bindNamedParameter(NumServers.class, Integer.toString(numServers))
+        .bindNamedParameter(NumPartitions.class, Integer.toString(numPartitions))
         .bindNamedParameter(EndpointId.class, WORKER_ID_PREFIX + workerIndex)
         .build();
   }
@@ -88,15 +98,19 @@ public final class PartitionedParameterServerManager implements ParameterServerM
    */
   @Override
   public Configuration getServerServiceConfiguration() {
+    final int serverIndex = serverCount.getAndIncrement();
+
     return Tang.Factory.getTang()
         .newConfigurationBuilder(ServiceConfiguration.CONF
             .set(ServiceConfiguration.SERVICES, PartitionedParameterServer.class)
             .build())
-        .bindNamedParameter(EndpointId.class, SERVER_ID)
-        .bindNamedParameter(PSMessageHandler.class, PartitionedServerSideMsgHandler.class)
-        .bindNamedParameter(ServerNumPartitions.class, Integer.toString(numPartitions))
-        .bindNamedParameter(ServerQueueSize.class, Integer.toString(queueSize))
         .bindImplementation(PartitionedServerSideReplySender.class, PartitionedServerSideReplySenderImpl.class)
+        .bindNamedParameter(EndpointId.class, SERVER_ID_PREFIX + serverIndex)
+        .bindNamedParameter(PSMessageHandler.class, PartitionedServerSideMsgHandler.class)
+        .bindImplementation(ServerResolver.class, StaticServerResolver.class)
+        .bindNamedParameter(NumServers.class, Integer.toString(numServers))
+        .bindNamedParameter(NumPartitions.class, Integer.toString(numPartitions))
+        .bindNamedParameter(ServerQueueSize.class, Integer.toString(queueSize))
         .build();
   }
 }

--- a/dolphin-ps/src/main/java/edu/snu/dolphin/ps/examples/add/PSExampleDriver.java
+++ b/dolphin-ps/src/main/java/edu/snu/dolphin/ps/examples/add/PSExampleDriver.java
@@ -20,6 +20,7 @@ import edu.snu.dolphin.ps.examples.add.parameters.NumKeys;
 import edu.snu.dolphin.ps.examples.add.parameters.NumUpdates;
 import edu.snu.dolphin.ps.examples.add.parameters.NumWorkers;
 import edu.snu.dolphin.ps.examples.add.parameters.StartKey;
+import edu.snu.dolphin.ps.common.partitioned.parameters.NumServers;
 import org.apache.reef.annotations.audience.DriverSide;
 import org.apache.reef.driver.context.ActiveContext;
 import org.apache.reef.driver.context.ContextConfiguration;
@@ -56,7 +57,7 @@ import java.util.logging.Logger;
 public final class PSExampleDriver {
   private static final Logger LOG = Logger.getLogger(PSExampleDriver.class.getName());
 
-  private static final String PS_ID = "PS";
+  private static final String PS_CONTEXT_PREFIX = "PS-Context-";
   private static final String WORKER_CONTEXT_PREFIX = "Worker-Context-";
   private static final String UPDATER_TASK_PREFIX = "Updater-Task-";
   private static final String VALIDATOR_TASK_ID = "Validator-Task";
@@ -64,6 +65,7 @@ public final class PSExampleDriver {
   private final ParameterServerDriver psDriver;
   private final EvaluatorRequestor evalRequestor;
 
+  private final int numServers;
   private final int numWorkers;
   private final int numUpdatesPerWorker;
   private final int startKey;
@@ -72,8 +74,8 @@ public final class PSExampleDriver {
   private final AtomicInteger evalCounter = new AtomicInteger(0);
   private final AtomicInteger taskCompletedCounter = new AtomicInteger(0);
 
-  private ActiveContext psActiveContext = null;
-  private ConcurrentLinkedQueue<ActiveContext> contextsToClose = new ConcurrentLinkedQueue<>();
+  private ConcurrentLinkedQueue<ActiveContext> psContexts = new ConcurrentLinkedQueue<>();
+  private ConcurrentLinkedQueue<ActiveContext> workerContextsToClose = new ConcurrentLinkedQueue<>();
 
   /**
    * numUpdates is the _total_ number of updates to push.
@@ -86,6 +88,7 @@ public final class PSExampleDriver {
   @Inject
   private PSExampleDriver(final ParameterServerDriver psDriver,
                           final EvaluatorRequestor evalRequestor,
+                          @Parameter(NumServers.class) final int numServers,
                           @Parameter(NumWorkers.class) final int numWorkers,
                           @Parameter(NumUpdates.class) final int numUpdates,
                           @Parameter(StartKey.class) final int startKey,
@@ -102,6 +105,7 @@ public final class PSExampleDriver {
 
     this.psDriver = psDriver;
     this.evalRequestor = evalRequestor;
+    this.numServers = numServers;
     this.numWorkers = numWorkers;
     this.numUpdatesPerWorker = numUpdates / numWorkers;
     this.startKey = startKey;
@@ -115,7 +119,7 @@ public final class PSExampleDriver {
     @Override
     public void onNext(final StartTime startTime) {
       evalRequestor.submit(EvaluatorRequest.newBuilder()
-          .setNumber(numWorkers + 1)
+          .setNumber(numWorkers + numServers)
           .setMemory(512)
           .setNumberOfCores(1)
           .build());
@@ -130,11 +134,12 @@ public final class PSExampleDriver {
     public void onNext(final AllocatedEvaluator allocatedEvaluator) {
       final int evalCount = evalCounter.incrementAndGet();
 
-      if (evalCount == 1) { // Submit the ParameterServer
+      if (evalCount <= numServers) { // Submit the ParameterServers
 
         final Configuration contextConf = Configurations.merge(
             ContextConfiguration.CONF
-                .set(ContextConfiguration.IDENTIFIER, PS_ID)
+                .set(ContextConfiguration.IDENTIFIER,
+                    PS_CONTEXT_PREFIX + (evalCount - 1))
                 .build(),
             psDriver.getContextConfiguration());
 
@@ -178,8 +183,8 @@ public final class PSExampleDriver {
     @Override
     public void onNext(final ActiveContext activeContext) {
       LOG.log(Level.INFO, "Context active: {0}", activeContext.getId());
-      if (activeContext.getId().equals(PS_ID)) {
-        psActiveContext = activeContext;
+      if (activeContext.getId().startsWith(PS_CONTEXT_PREFIX)) {
+        psContexts.add(activeContext);
       }
     }
   }
@@ -206,7 +211,7 @@ public final class PSExampleDriver {
 
       final int taskCompletedCount = taskCompletedCounter.incrementAndGet();
       if (taskCompletedCount < numWorkers) { // Close Contexts when their task is completed, up to the last Worker.
-        contextsToClose.add(completedTask.getActiveContext());
+        workerContextsToClose.add(completedTask.getActiveContext());
         // completedTask.getActiveContext().close();
 
       } else if (taskCompletedCount == numWorkers) { // For the last Worker, run the Validator Task.
@@ -227,14 +232,16 @@ public final class PSExampleDriver {
         completedTask.getActiveContext().submitTask(Configurations.merge(taskConf, parameterConf));
 
       } else if (taskCompletedCount == numWorkers + 1) { // When the Validator Task is complete, close all contexts.
-        contextsToClose.add(completedTask.getActiveContext());
+        workerContextsToClose.add(completedTask.getActiveContext());
         // completedTask.getActiveContext().close();
 
         LOG.log(Level.INFO, "Correct result validated, shutting down parameter server.");
-        for (final ActiveContext context : contextsToClose) {
+        for (final ActiveContext context : workerContextsToClose) {
           context.close();
         }
-        psActiveContext.close();
+        for (final ActiveContext context : psContexts) {
+          context.close();
+        }
       }
     }
   }

--- a/dolphin-ps/src/main/java/edu/snu/dolphin/ps/examples/add/PartitionedPSExampleREEF.java
+++ b/dolphin-ps/src/main/java/edu/snu/dolphin/ps/examples/add/PartitionedPSExampleREEF.java
@@ -18,7 +18,8 @@ package edu.snu.dolphin.ps.examples.add;
 import edu.snu.dolphin.ps.ParameterServerConfigurationBuilder;
 import edu.snu.dolphin.ps.driver.impl.PartitionedParameterServerManager;
 import edu.snu.dolphin.ps.examples.add.parameters.*;
-import edu.snu.dolphin.ps.server.partitioned.parameters.ServerNumPartitions;
+import edu.snu.dolphin.ps.common.partitioned.parameters.NumServers;
+import edu.snu.dolphin.ps.common.partitioned.parameters.NumPartitions;
 import edu.snu.dolphin.ps.server.partitioned.parameters.ServerQueueSize;
 import edu.snu.dolphin.ps.worker.partitioned.parameters.WorkerExpireTimeout;
 import edu.snu.dolphin.ps.worker.partitioned.parameters.WorkerKeyCacheSize;
@@ -53,6 +54,7 @@ public final class PartitionedPSExampleREEF {
   private final int numUpdates;
   private final int numKeys;
   private final int startKey;
+  private final int numServers;
   private final int serverNumPartitions;
   private final int serverQueueSize;
   private final int workerNumPartitions;
@@ -66,7 +68,8 @@ public final class PartitionedPSExampleREEF {
                                    @Parameter(NumUpdates.class) final int numUpdates,
                                    @Parameter(NumKeys.class) final int numKeys,
                                    @Parameter(StartKey.class) final int startKey,
-                                   @Parameter(ServerNumPartitions.class) final int serverNumPartitions,
+                                   @Parameter(NumServers.class) final int numServers,
+                                   @Parameter(NumPartitions.class) final int serverNumPartitions,
                                    @Parameter(ServerQueueSize.class) final int serverQueueSize,
                                    @Parameter(WorkerNumPartitions.class) final int workerNumPartitions,
                                    @Parameter(WorkerQueueSize.class) final int workerQueueSize,
@@ -77,6 +80,7 @@ public final class PartitionedPSExampleREEF {
     this.numUpdates = numUpdates;
     this.numKeys = numKeys;
     this.startKey = startKey;
+    this.numServers = numServers;
     this.serverNumPartitions = serverNumPartitions;
     this.serverQueueSize = serverQueueSize;
     this.workerNumPartitions = workerNumPartitions;
@@ -107,7 +111,8 @@ public final class PartitionedPSExampleREEF {
         .bindNamedParameter(NumUpdates.class, Integer.toString(numUpdates))
         .bindNamedParameter(NumKeys.class, Integer.toString(numKeys))
         .bindNamedParameter(StartKey.class, Integer.toString(startKey))
-        .bindNamedParameter(ServerNumPartitions.class, Integer.toString(serverNumPartitions))
+        .bindNamedParameter(NumServers.class, Integer.toString(numServers))
+        .bindNamedParameter(NumPartitions.class, Integer.toString(serverNumPartitions))
         .bindNamedParameter(ServerQueueSize.class, Integer.toString(serverQueueSize))
         .bindNamedParameter(WorkerNumPartitions.class, Integer.toString(workerNumPartitions))
         .bindNamedParameter(WorkerQueueSize.class, Integer.toString(workerQueueSize))
@@ -132,7 +137,7 @@ public final class PartitionedPSExampleREEF {
 
   private Configuration getLocalRuntimeConfiguration() {
     return LocalRuntimeConfiguration.CONF
-        .set(LocalRuntimeConfiguration.MAX_NUMBER_OF_EVALUATORS, numWorkers + 1)
+        .set(LocalRuntimeConfiguration.MAX_NUMBER_OF_EVALUATORS, numWorkers + numServers)
         .build();
   }
 
@@ -148,7 +153,8 @@ public final class PartitionedPSExampleREEF {
     cl.registerShortNameOfClass(NumUpdates.class);
     cl.registerShortNameOfClass(NumKeys.class);
     cl.registerShortNameOfClass(StartKey.class);
-    cl.registerShortNameOfClass(ServerNumPartitions.class);
+    cl.registerShortNameOfClass(NumServers.class);
+    cl.registerShortNameOfClass(NumPartitions.class);
     cl.registerShortNameOfClass(ServerQueueSize.class);
     cl.registerShortNameOfClass(WorkerNumPartitions.class);
     cl.registerShortNameOfClass(WorkerQueueSize.class);

--- a/dolphin-ps/src/main/java/edu/snu/dolphin/ps/server/partitioned/PartitionedParameterServer.java
+++ b/dolphin-ps/src/main/java/edu/snu/dolphin/ps/server/partitioned/PartitionedParameterServer.java
@@ -15,15 +15,17 @@
  */
 package edu.snu.dolphin.ps.server.partitioned;
 
+import edu.snu.dolphin.ps.ns.EndpointId;
 import edu.snu.dolphin.ps.server.api.ParameterUpdater;
-import edu.snu.dolphin.ps.server.partitioned.parameters.ServerNumPartitions;
 import edu.snu.dolphin.ps.server.partitioned.parameters.ServerQueueSize;
+import edu.snu.dolphin.ps.common.partitioned.resolver.ServerResolver;
 import org.apache.reef.annotations.audience.EvaluatorSide;
 import org.apache.reef.tang.annotations.Parameter;
 
 import javax.inject.Inject;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
@@ -47,9 +49,14 @@ public final class PartitionedParameterServer<K, P, V> {
   private static final Logger LOG = Logger.getLogger(PartitionedParameterServer.class.getName());
 
   /**
-   * Number of partitions.
+   * Network Connection Service endpoint of this ParameterServer.
    */
-  private final int numPartitions;
+  private final String endpointId;
+
+  /**
+   * ServerResolver that maps hashed keys to partitions.
+   */
+  private final ServerResolver serverResolver;
 
   /**
    * Max size of each partition's queue.
@@ -64,7 +71,7 @@ public final class PartitionedParameterServer<K, P, V> {
   /**
    * Running partitions.
    */
-  private final Partition<K, V>[] partitions;
+  private final Map<Integer, Partition<K, V>> partitions;
 
   /**
    * Object for processing preValues and applying updates to existing values.
@@ -74,16 +81,18 @@ public final class PartitionedParameterServer<K, P, V> {
   /**
    * Sender that sends pull responses.
    */
-  private final PartitionedServerSideReplySender sender;
+  private final PartitionedServerSideReplySender<K, V> sender;
 
   @Inject
-  private PartitionedParameterServer(@Parameter(ServerNumPartitions.class) final int numPartitions,
+  private PartitionedParameterServer(@Parameter(EndpointId.class) final String endpointId,
                                      @Parameter(ServerQueueSize.class) final int queueSize,
+                                     final ServerResolver serverResolver,
                                      final ParameterUpdater<K, P, V> parameterUpdater,
-                                     final PartitionedServerSideReplySender sender) {
-    this.numPartitions = numPartitions;
+                                     final PartitionedServerSideReplySender<K, V> sender) {
+    this.endpointId = endpointId;
+    this.serverResolver = serverResolver;
     this.queueSize = queueSize;
-    this.threadPool = Executors.newFixedThreadPool(numPartitions);
+    this.threadPool = Executors.newFixedThreadPool(serverResolver.getPartitions(endpointId).size());
     this.partitions = initPartitions();
     this.parameterUpdater = parameterUpdater;
     this.sender = sender;
@@ -92,13 +101,14 @@ public final class PartitionedParameterServer<K, P, V> {
   /**
    * Call after initializing numPartitions and threadPool.
    */
-  @SuppressWarnings("unchecked")
-  private Partition<K, V>[] initPartitions() {
-    LOG.log(Level.INFO, "Initializing {0} partitions", numPartitions);
-    final Partition<K, V>[] initialized = new Partition[numPartitions];
-    for (int i = 0; i < numPartitions; i++) {
-      initialized[i] = new Partition<>(queueSize);
-      threadPool.submit(initialized[i]);
+  private Map<Integer, Partition<K, V>> initPartitions() {
+    final Map<Integer, Partition<K, V>> initialized = new HashMap<>();
+    final List<Integer> localPartitions = serverResolver.getPartitions(endpointId);
+    LOG.log(Level.INFO, "Initializing {0} partitions", localPartitions.size());
+    for (final int partitionIndex : localPartitions) {
+      final Partition<K, V> partition = new Partition<>(queueSize);
+      initialized.put(partitionIndex, partition);
+      threadPool.submit(partition);
     }
     return initialized;
   }
@@ -115,7 +125,7 @@ public final class PartitionedParameterServer<K, P, V> {
    * @param keyHash hash of the key, a positive integer used to map to the correct partition
    */
   public void push(final K key, final P preValue, final int keyHash) {
-    partitions[getPartitionIndex(keyHash)].enqueue(new PushOp(key, preValue));
+    partitions.get(serverResolver.resolvePartition(keyHash)).enqueue(new PushOp(key, preValue));
   }
 
   /**
@@ -129,11 +139,7 @@ public final class PartitionedParameterServer<K, P, V> {
    * @param keyHash hash of the key, a positive integer used to map to the correct partition
    */
   public void pull(final K key, final String srcId, final int keyHash) {
-    partitions[getPartitionIndex(keyHash)].enqueue(new PullOp(key, srcId));
-  }
-
-  private int getPartitionIndex(final int keyHash) {
-    return keyHash % numPartitions;
+    partitions.get(serverResolver.resolvePartition(keyHash)).enqueue(new PullOp(key, srcId));
   }
 
   /**
@@ -141,8 +147,8 @@ public final class PartitionedParameterServer<K, P, V> {
    */
   public int opsPending() {
     int sum = 0;
-    for (int i = 0; i < numPartitions; i++) {
-      sum += partitions[i].opsPending();
+    for (final Partition<K, V> partition : partitions.values()) {
+      sum += partition.opsPending();
     }
     return sum;
   }
@@ -263,7 +269,6 @@ public final class PartitionedParameterServer<K, P, V> {
         queue.put(op);
       } catch (final InterruptedException e) {
         LOG.log(Level.SEVERE, "Enqueue failed with InterruptedException", e);
-        return;
       }
     }
 

--- a/dolphin-ps/src/main/java/edu/snu/dolphin/ps/worker/partitioned/PartitionedParameterWorker.java
+++ b/dolphin-ps/src/main/java/edu/snu/dolphin/ps/worker/partitioned/PartitionedParameterWorker.java
@@ -19,13 +19,13 @@ import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 import edu.snu.dolphin.ps.ParameterServerParameters.KeyCodecName;
-import edu.snu.dolphin.ps.driver.impl.ServerId;
 import edu.snu.dolphin.ps.server.api.ParameterUpdater;
 import edu.snu.dolphin.ps.worker.api.ParameterWorker;
 import edu.snu.dolphin.ps.worker.partitioned.parameters.WorkerExpireTimeout;
 import edu.snu.dolphin.ps.worker.partitioned.parameters.WorkerKeyCacheSize;
 import edu.snu.dolphin.ps.worker.partitioned.parameters.WorkerNumPartitions;
 import edu.snu.dolphin.ps.worker.partitioned.parameters.WorkerQueueSize;
+import edu.snu.dolphin.ps.common.partitioned.resolver.ServerResolver;
 import org.apache.reef.annotations.audience.EvaluatorSide;
 import org.apache.reef.io.serialization.Codec;
 import org.apache.reef.tang.InjectionFuture;
@@ -60,14 +60,14 @@ public final class PartitionedParameterWorker<K, P, V> implements ParameterWorke
   private static final Logger LOG = Logger.getLogger(PartitionedParameterWorker.class.getName());
 
   /**
-   * Network Connection Service identifier of the server.
-   */
-  private final String serverId;
-
-  /**
    * Object for processing preValues and applying updates to existing values.
    */
   private final ParameterUpdater<K, P, V> parameterUpdater;
+
+  /**
+   * Resolve to a server's Network Connection Service identifier based on hashed key.
+   */
+  private final ServerResolver serverResolver;
 
   /**
    * A map of pending pulls, used to reconcile the asynchronous messaging with the synchronous CacheLoader call.
@@ -112,19 +112,19 @@ public final class PartitionedParameterWorker<K, P, V> implements ParameterWorke
   private final InjectionFuture<PartitionedWorkerMsgSender<K, P>> sender;
 
   @Inject
-  private PartitionedParameterWorker(@Parameter(ServerId.class) final String serverId,
-                                     @Parameter(WorkerNumPartitions.class) final int numPartitions,
+  private PartitionedParameterWorker(@Parameter(WorkerNumPartitions.class) final int numPartitions,
                                      @Parameter(WorkerQueueSize.class) final int queueSize,
                                      @Parameter(WorkerExpireTimeout.class) final long expireTimeout,
                                      @Parameter(WorkerKeyCacheSize.class) final int keyCacheSize,
                                      @Parameter(KeyCodecName.class) final Codec<K> keyCodec,
                                      final ParameterUpdater<K, P, V> parameterUpdater,
+                                     final ServerResolver serverResolver,
                                      final InjectionFuture<PartitionedWorkerMsgSender<K, P>> sender) {
-    this.serverId = serverId;
     this.numPartitions = numPartitions;
     this.queueSize = queueSize;
     this.expireTimeout = expireTimeout;
     this.parameterUpdater = parameterUpdater;
+    this.serverResolver = serverResolver;
     this.sender = sender;
     this.pendingPulls = new ConcurrentHashMap<>();
     this.threadPool = Executors.newFixedThreadPool(numPartitions);
@@ -147,7 +147,7 @@ public final class PartitionedParameterWorker<K, P, V> implements ParameterWorke
     LOG.log(Level.INFO, "Initializing {0} partitions", numPartitions);
     final Partition<K, P, V>[] initialized = new Partition[numPartitions];
     for (int i = 0; i < numPartitions; i++) {
-      initialized[i] = new Partition<>(pendingPulls, sender, serverId, queueSize, expireTimeout);
+      initialized[i] = new Partition<>(pendingPulls, serverResolver, sender, queueSize, expireTimeout);
       threadPool.submit(initialized[i]);
     }
     return initialized;
@@ -321,7 +321,7 @@ public final class PartitionedParameterWorker<K, P, V> implements ParameterWorke
       }
 
       // Send to remote PS
-      sender.get().sendPushMsg(serverId, encodedKey, preValue);
+      sender.get().sendPushMsg(serverResolver.resolveServer(encodedKey.getHash()), encodedKey, preValue);
     }
   }
 
@@ -400,8 +400,8 @@ public final class PartitionedParameterWorker<K, P, V> implements ParameterWorke
     private volatile boolean shutdown = false;
 
     public Partition(final ConcurrentMap<K, PullFuture<V>> pendingPulls,
+                     final ServerResolver serverResolver,
                      final InjectionFuture<PartitionedWorkerMsgSender<K, P>> sender,
-                     final String serverId,
                      final int queueSize,
                      final long expireTimeout) {
       kvCache = CacheBuilder.newBuilder()
@@ -412,7 +412,7 @@ public final class PartitionedParameterWorker<K, P, V> implements ParameterWorke
             public Wrapped<V> load(final EncodedKey<K> encodedKey) throws Exception {
               final PullFuture<V> future = new PullFuture<>();
               pendingPulls.put(encodedKey.getKey(), future);
-              sender.get().sendPullMsg(serverId, encodedKey);
+              sender.get().sendPullMsg(serverResolver.resolveServer(encodedKey.getHash()), encodedKey);
               final V value = future.getValue();
               pendingPulls.remove(encodedKey.getKey());
               return new Wrapped<>(value);

--- a/dolphin-ps/src/test/java/edu/snu/dolphin/ps/common/partitioned/resolver/StaticServerResolverTest.java
+++ b/dolphin-ps/src/test/java/edu/snu/dolphin/ps/common/partitioned/resolver/StaticServerResolverTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (C) 2016 Seoul National University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.snu.dolphin.ps.common.partitioned.resolver;
+
+import edu.snu.dolphin.ps.common.partitioned.parameters.NumPartitions;
+import edu.snu.dolphin.ps.common.partitioned.parameters.NumServers;
+import org.apache.reef.tang.Configuration;
+import org.apache.reef.tang.Injector;
+import org.apache.reef.tang.Tang;
+import org.apache.reef.tang.exceptions.InjectionException;
+import org.junit.Test;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static edu.snu.dolphin.ps.common.Constants.SERVER_ID_PREFIX;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Test that StaticServerResolver creates a balanced assignment of partitions to physical servers.
+ */
+public final class StaticServerResolverTest {
+  private StaticServerResolver newStaticServerResolver(final int numServers,
+                                                       final int numPartitions) throws InjectionException {
+    final Configuration configuration = Tang.Factory.getTang().newConfigurationBuilder()
+        .bindNamedParameter(NumServers.class, Integer.toString(numServers))
+        .bindNamedParameter(NumPartitions.class, Integer.toString(numPartitions))
+        .build();
+    final Injector injector = Tang.Factory.getTang().newInjector(configuration);
+
+    return injector.getInstance(StaticServerResolver.class);
+  }
+
+  /**
+   * Test the mapping with a single server and ten partitions.
+   */
+  @Test
+  public void testSingleServer() throws InjectionException {
+    final int numServers = 1;
+    final int numPartitions = 10;
+    final ServerResolver resolver = newStaticServerResolver(numServers, numPartitions);
+
+    final List<Integer> partitions = resolver.getPartitions(SERVER_ID_PREFIX + 0);
+    assertEquals(numPartitions, partitions.size());
+    for (int i = 0; i < numPartitions; i++) {
+      assertTrue(partitions.contains(i));
+    }
+
+    // Check resolution for first 100 hashes
+    for (int i = 0; i < 100; i++) {
+      assertEquals(SERVER_ID_PREFIX + 0, resolver.resolveServer(i));
+    }
+  }
+
+  /**
+   * Test the mapping with three servers and twenty partitions.
+   */
+  @Test
+  public void testThreeServers() throws InjectionException {
+    final int numServers = 3;
+    final int numPartitions = 20;
+    final ServerResolver resolver = newStaticServerResolver(numServers, numPartitions);
+
+    final Set<Integer> allPartitions = new HashSet<>(numPartitions);
+
+    for (int i = 0; i < numServers; i++) {
+      final List<Integer> partitions = resolver.getPartitions(SERVER_ID_PREFIX + i);
+      assertTrue(partitions.size() == numPartitions / numServers ||
+          partitions.size() == numPartitions / numServers + 1);
+      allPartitions.addAll(partitions);
+    }
+    assertEquals(numPartitions, allPartitions.size());
+    for (int i = 0; i < numPartitions; i++) {
+      assertTrue(allPartitions.contains(i));
+    }
+
+    // Check resolution for first 100 hashes maps to a server
+    for (int i = 0; i < 100; i++) {
+      assertTrue(resolver.resolveServer(i).startsWith(SERVER_ID_PREFIX));
+    }
+  }
+}

--- a/dolphin-ps/src/test/java/edu/snu/dolphin/ps/common/partitioned/resolver/package-info.java
+++ b/dolphin-ps/src/test/java/edu/snu/dolphin/ps/common/partitioned/resolver/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016 Seoul National University
+ * Copyright (C) 2015 Seoul National University
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,11 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package edu.snu.dolphin.ps.server.partitioned.parameters;
-
-import org.apache.reef.tang.annotations.Name;
-import org.apache.reef.tang.annotations.NamedParameter;
-
-@NamedParameter(doc = "Number of partitions", default_value = "2", short_name = "serverNumPartitions")
-public final class ServerNumPartitions implements Name<Integer> {
-}
+/**
+ * Classes for common parameter server tests.
+ */
+package edu.snu.dolphin.ps.common.partitioned.resolver;

--- a/dolphin-ps/src/test/java/edu/snu/dolphin/ps/server/PartitionedParameterServerTest.java
+++ b/dolphin-ps/src/test/java/edu/snu/dolphin/ps/server/PartitionedParameterServerTest.java
@@ -17,11 +17,15 @@ package edu.snu.dolphin.ps.server;
 
 import edu.snu.dolphin.ps.ParameterServerParameters;
 import edu.snu.dolphin.ps.TestUtils;
+import edu.snu.dolphin.ps.common.partitioned.resolver.ServerResolver;
+import edu.snu.dolphin.ps.common.partitioned.resolver.SingleNodeServerResolver;
+import edu.snu.dolphin.ps.driver.impl.ServerId;
 import edu.snu.dolphin.ps.examples.add.IntegerCodec;
+import edu.snu.dolphin.ps.ns.EndpointId;
 import edu.snu.dolphin.ps.server.api.ParameterUpdater;
 import edu.snu.dolphin.ps.server.partitioned.PartitionedParameterServer;
 import edu.snu.dolphin.ps.server.partitioned.PartitionedServerSideReplySender;
-import edu.snu.dolphin.ps.server.partitioned.parameters.ServerNumPartitions;
+import edu.snu.dolphin.ps.common.partitioned.parameters.NumPartitions;
 import org.apache.reef.tang.Configuration;
 import org.apache.reef.tang.Injector;
 import org.apache.reef.tang.Tang;
@@ -35,6 +39,7 @@ import java.util.concurrent.TimeUnit;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static edu.snu.dolphin.ps.common.Constants.SERVER_ID_PREFIX;
 
 
 /**
@@ -51,10 +56,13 @@ public final class PartitionedParameterServerTest {
   public void setup() throws InjectionException {
     final Configuration conf = Tang.Factory.getTang().newConfigurationBuilder()
         .bind(PartitionedServerSideReplySender.class, MockPartitionedServerSideReplySender.class)
+        .bindImplementation(ServerResolver.class, SingleNodeServerResolver.class)
+        .bindNamedParameter(ServerId.class, SERVER_ID_PREFIX + 0)
+        .bindNamedParameter(EndpointId.class, SERVER_ID_PREFIX + 0)
         .bindNamedParameter(ParameterServerParameters.KeyCodecName.class, IntegerCodec.class)
         .bindNamedParameter(ParameterServerParameters.ValueCodecName.class, IntegerCodec.class)
         .bindNamedParameter(ParameterServerParameters.PreValueCodecName.class, IntegerCodec.class)
-        .bindNamedParameter(ServerNumPartitions.class, "4")
+        .bindNamedParameter(NumPartitions.class, "4")
         .build();
     final Injector injector = Tang.Factory.getTang().newInjector(conf);
     injector.bindVolatileInstance(ParameterUpdater.class, new ParameterUpdater<Integer, Integer, Integer>() {


### PR DESCRIPTION
Closes #131 

Adds a multi-node parameter server that is statically configured based on the number of servers. I have tested this on my laptop with the ps example.