### PR TITLE
Update Apache REEF and Checkstyle.

### DIFF
--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/data/NeuralNetworkDataParser.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/data/NeuralNetworkDataParser.java
@@ -140,7 +140,7 @@ public final class NeuralNetworkDataParser implements DataParser<List<Pair<Pair<
     private final List<Integer> labelList;
 
     BatchGenerator(final List<Pair<Pair<Matrix, int[]>, Boolean>> dataList,
-                          final boolean isValidation) {
+                   final boolean isValidation) {
       this.dataList = dataList;
       this.isValidation = isValidation;
       this.matrixList = new ArrayList<>(batchSize);

--- a/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/data/NeuralNetworkDataParser.java
+++ b/dolphin-dnn/src/main/java/edu/snu/dolphin/dnn/data/NeuralNetworkDataParser.java
@@ -139,7 +139,7 @@ public final class NeuralNetworkDataParser implements DataParser<List<Pair<Pair<
     private final List<Matrix> matrixList;
     private final List<Integer> labelList;
 
-    public BatchGenerator(final List<Pair<Pair<Matrix, int[]>, Boolean>> dataList,
+    BatchGenerator(final List<Pair<Pair<Matrix, int[]>, Boolean>> dataList,
                           final boolean isValidation) {
       this.dataList = dataList;
       this.isValidation = isValidation;

--- a/dolphin-ps/src/main/java/edu/snu/dolphin/ps/examples/add/ValidatorTask.java
+++ b/dolphin-ps/src/main/java/edu/snu/dolphin/ps/examples/add/ValidatorTask.java
@@ -104,7 +104,7 @@ public final class ValidatorTask implements Task {
   }
 
   private static class IntegerValidationException extends Exception {
-    public IntegerValidationException(final int key, final int expected, final int actual) {
+    IntegerValidationException(final int key, final int expected, final int actual) {
       super(String.format("For key %d, expected value %d but received %d", key, expected, actual));
     }
   }

--- a/dolphin-ps/src/main/java/edu/snu/dolphin/ps/server/partitioned/PartitionedParameterServer.java
+++ b/dolphin-ps/src/main/java/edu/snu/dolphin/ps/server/partitioned/PartitionedParameterServer.java
@@ -171,7 +171,7 @@ public final class PartitionedParameterServer<K, P, V> {
     private final K key;
     private final P preValue;
 
-    public PushOp(final K key, final P preValue) {
+    PushOp(final K key, final P preValue) {
       this.key = key;
       this.preValue = preValue;
     }
@@ -202,7 +202,7 @@ public final class PartitionedParameterServer<K, P, V> {
     private final K key;
     private final String srcId;
 
-    public PullOp(final K key, final String srcId) {
+    PullOp(final K key, final String srcId) {
       this.key = key;
       this.srcId = srcId;
     }
@@ -246,7 +246,7 @@ public final class PartitionedParameterServer<K, P, V> {
 
     private volatile boolean shutdown = false;
 
-    public Partition(final int queueSize) {
+    Partition(final int queueSize) {
       this.kvStore = new HashMap<>();
       this.queue = new ArrayBlockingQueue<>(queueSize);
       this.drainSize = queueSize / 10;

--- a/dolphin-ps/src/main/java/edu/snu/dolphin/ps/worker/partitioned/EncodedKey.java
+++ b/dolphin-ps/src/main/java/edu/snu/dolphin/ps/worker/partitioned/EncodedKey.java
@@ -23,7 +23,7 @@ class EncodedKey<K> {
   private final int hash;
   private final byte[] encoded;
 
-  public EncodedKey(final K key, final Codec<K> keyCodec) {
+  EncodedKey(final K key, final Codec<K> keyCodec) {
     this.key = key;
     this.encoded = keyCodec.encode(key);
     this.hash = computeHash();

--- a/dolphin-ps/src/main/java/edu/snu/dolphin/ps/worker/partitioned/PartitionedParameterWorker.java
+++ b/dolphin-ps/src/main/java/edu/snu/dolphin/ps/worker/partitioned/PartitionedParameterWorker.java
@@ -275,7 +275,7 @@ public final class PartitionedParameterWorker<K, P, V> implements ParameterWorke
   private static class Wrapped<V> {
     private V value;
 
-    public Wrapped(final V value) {
+    Wrapped(final V value) {
       this.value = value;
     }
 
@@ -295,7 +295,7 @@ public final class PartitionedParameterWorker<K, P, V> implements ParameterWorke
     private final EncodedKey<K> encodedKey;
     private final P preValue;
 
-    public PushOp(final EncodedKey<K> encodedKey, final P preValue) {
+    PushOp(final EncodedKey<K> encodedKey, final P preValue) {
       this.encodedKey = encodedKey;
       this.preValue = preValue;
     }
@@ -333,7 +333,7 @@ public final class PartitionedParameterWorker<K, P, V> implements ParameterWorke
     private final EncodedKey<K> encodedKey;
     private V value;
 
-    public PullOp(final EncodedKey<K> encodedKey) {
+    PullOp(final EncodedKey<K> encodedKey) {
       this.encodedKey = encodedKey;
     }
 
@@ -399,7 +399,7 @@ public final class PartitionedParameterWorker<K, P, V> implements ParameterWorke
     private volatile boolean close = false;
     private volatile boolean shutdown = false;
 
-    public Partition(final ConcurrentMap<K, PullFuture<V>> pendingPulls,
+    Partition(final ConcurrentMap<K, PullFuture<V>> pendingPulls,
                      final ServerResolver serverResolver,
                      final InjectionFuture<PartitionedWorkerMsgSender<K, P>> sender,
                      final int queueSize,

--- a/dolphin-ps/src/main/java/edu/snu/dolphin/ps/worker/partitioned/PartitionedParameterWorker.java
+++ b/dolphin-ps/src/main/java/edu/snu/dolphin/ps/worker/partitioned/PartitionedParameterWorker.java
@@ -400,10 +400,10 @@ public final class PartitionedParameterWorker<K, P, V> implements ParameterWorke
     private volatile boolean shutdown = false;
 
     Partition(final ConcurrentMap<K, PullFuture<V>> pendingPulls,
-                     final ServerResolver serverResolver,
-                     final InjectionFuture<PartitionedWorkerMsgSender<K, P>> sender,
-                     final int queueSize,
-                     final long expireTimeout) {
+              final ServerResolver serverResolver,
+              final InjectionFuture<PartitionedWorkerMsgSender<K, P>> sender,
+              final int queueSize,
+              final long expireTimeout) {
       kvCache = CacheBuilder.newBuilder()
           .concurrencyLevel(1)
           .expireAfterWrite(expireTimeout, TimeUnit.MILLISECONDS)

--- a/dolphin-ps/src/test/java/edu/snu/dolphin/ps/server/PartitionedParameterServerTest.java
+++ b/dolphin-ps/src/test/java/edu/snu/dolphin/ps/server/PartitionedParameterServerTest.java
@@ -158,7 +158,7 @@ public final class PartitionedParameterServerTest {
     private volatile int latest = -1;
 
     @Inject
-    public MockPartitionedServerSideReplySender() {
+    MockPartitionedServerSideReplySender() {
     }
 
     @Override

--- a/pom.xml
+++ b/pom.xml
@@ -33,12 +33,12 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <reef.version>0.14.0</reef.version>
+    <reef.version>0.15.0</reef.version>
     <hadoop.version>2.4.0</hadoop.version>
     <mahout.version>0.9</mahout.version>
     <rat.version>0.11</rat.version>
     <maven-checkstyle-plugin.version>2.15</maven-checkstyle-plugin.version>
-    <checkstyle.version>6.6</checkstyle.version>
+    <checkstyle.version>6.17</checkstyle.version>
     <protobuf.version>2.5.0</protobuf.version>
     <avro.version>1.7.7</avro.version>
     <mockito.version>1.10.19</mockito.version>


### PR DESCRIPTION
Apache REEF 0.15 is released at the maven central. We had better use 0.15.
This PR also updates Checkstyle with the same version of REEF,
and fixes some RedundantModifier errors accordingly.

This PR was tested by the following commands.
```bash
rm -rf ~/.m2/
mvn clean install
```