### PR TITLE
[MINOR] Update checkstyle plugin version to avoid security vulnerability

### DIFF
--- a/dolphin-ps/src/main/java/edu/snu/dolphin/ps/server/concurrent/api/ServerSideMsgSender.java
+++ b/dolphin-ps/src/main/java/edu/snu/dolphin/ps/server/concurrent/api/ServerSideMsgSender.java
@@ -34,5 +34,5 @@ public interface ServerSideMsgSender<K, V> {
    * @param key key object associated with the expected value
    * @param valueEntry {@link ValueEntry} object containing the requested value
    */
-  void sendReplyMsg(final String destId, final K key, final ValueEntry<V> valueEntry);
+  void sendReplyMsg(String destId, K key, ValueEntry<V> valueEntry);
 }

--- a/dolphin-ps/src/main/java/edu/snu/dolphin/ps/worker/concurrent/WorkerSideMsgSender.java
+++ b/dolphin-ps/src/main/java/edu/snu/dolphin/ps/worker/concurrent/WorkerSideMsgSender.java
@@ -31,7 +31,7 @@ public interface WorkerSideMsgSender<K, P> {
    * @param key key object representing what is being sent
    * @param preValue value to be sent to the destination
    */
-  void sendPushMsg(final String destId, final K key, final P preValue);
+  void sendPushMsg(String destId, K key, P preValue);
 
   /**
    * Send a request to another evaluator for fetching a certain value.
@@ -40,5 +40,5 @@ public interface WorkerSideMsgSender<K, P> {
    * @param destId Network Connection Service identifier of the destination evaluator
    * @param key key object representing the expected value
    */
-  void sendPullMsg(final String destId, final K key);
+  void sendPullMsg(String destId, K key);
 }

--- a/dolphin-ps/src/main/java/edu/snu/dolphin/util/AvroUtils.java
+++ b/dolphin-ps/src/main/java/edu/snu/dolphin/util/AvroUtils.java
@@ -40,7 +40,7 @@ public final class AvroUtils {
   public static <T> byte[] toBytes(final T avroObject, final Class<T> theClass) {
     final DatumWriter<T> datumWriter = new SpecificDatumWriter<>(theClass);
     final byte[] theBytes;
-    try (final ByteArrayOutputStream out = new ByteArrayOutputStream()) {
+    try (ByteArrayOutputStream out = new ByteArrayOutputStream()) {
       final BinaryEncoder encoder = EncoderFactory.get().binaryEncoder(out, null);
       datumWriter.write(avroObject, encoder);
       encoder.flush();

--- a/pom.xml
+++ b/pom.xml
@@ -37,8 +37,8 @@
     <hadoop.version>2.4.0</hadoop.version>
     <mahout.version>0.9</mahout.version>
     <rat.version>0.11</rat.version>
-    <maven-checkstyle-plugin.version>2.15</maven-checkstyle-plugin.version>
-    <checkstyle.version>6.17</checkstyle.version>
+    <maven-checkstyle-plugin.version>3.0.0</maven-checkstyle-plugin.version>
+    <checkstyle.version>8.18</checkstyle.version>
     <protobuf.version>2.5.0</protobuf.version>
     <avro.version>1.7.7</avro.version>
     <mockito.version>1.10.19</mockito.version>


### PR DESCRIPTION
Github recently warned the potential security vulnerability, caused by Checkstyle plugin. 
```
Known moderate severity security vulnerability detected in com.puppycrawl.tools:checkstyle < 8.18 defined in pom.xml.
pom.xml update suggested: com.puppycrawl.tools:checkstyle ~> 8.18.
```

This PR updates its version, to which is known to have fixed the issue. 